### PR TITLE
add tolerance on archive doc migration

### DIFF
--- a/anchore_engine/subsys/archive/migration.py
+++ b/anchore_engine/subsys/archive/migration.py
@@ -132,10 +132,9 @@ def initiate_migration(from_config, to_config, remove_on_source=False, do_lock=T
                             logger.info('Skipping removal of documents on source because source and dest drivers are the same')
                     else:
                         logger.info('Skipping removal of document on source driver because configured to leave source data.')
-
+                    counter = counter + 1
                 except Exception as e:
                     logger.exception('Error migrating content url: {} to {}'.format(content_url, context.from_archive.primary_client.__config_name__, context.to_archive.primary_client.__config_name__,))
-                    break
             else:
                 result_state = 'complete'
 
@@ -146,6 +145,7 @@ def initiate_migration(from_config, to_config, remove_on_source=False, do_lock=T
                 task_record.last_state = task_record.state
                 task_record.state = result_state
                 task_record.ended_at = datetime.datetime.utcnow()
+                task_record.archive_documents_migrated = counter
                 logger.info('Migration result summary: {}'.format(json.dumps(task_record.to_json())))
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**:

1. This PR adds the toleration on migration failures
2. add warning message on migration failure images
3. add migrated counter into finally block

**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #:
1. The default migration process breaks directly once there's some exception on one of the item's migration. 

**Special notes**:


