### PR TITLE
Add support for scanning Jenkins plugins

### DIFF
--- a/anchore_engine/analyzers/modules/32_java_packages.py
+++ b/anchore_engine/analyzers/modules/32_java_packages.py
@@ -22,6 +22,8 @@ import anchore_engine.analyzers.utils
 
 analyzer_name = "package_list"
 
+java_library_file = ".*\.([jwe]ar|[jh]pi)"
+
 try:
     config = anchore_engine.analyzers.utils.init_analyzer_cmdline(sys.argv, analyzer_name)
 except Exception as err:
@@ -40,7 +42,7 @@ def process_java_archive(prefix, filename, inZFH):
     fullpath = '/'.join([prefix, filename])
 
     jtype = None
-    patt = re.match(".*\.(jar|war|ear)", fullpath)
+    patt = re.match(java_library_file, fullpath)
     if patt:
         jtype = patt.group(1)
     else:
@@ -119,7 +121,7 @@ def process_java_archive(prefix, filename, inZFH):
 
         for zfname in ZFH.namelist():
             sub_jtype = None
-            patt = re.match(".*\.(jar|war|ear)", zfname)
+            patt = re.match(java_library_file, zfname)
             if patt:
                 sub_jtype = patt.group(1)
 


### PR DESCRIPTION
This adds the file extensions ".hpi" and ".jpi" to the list of recognized Java
library filenames.

**What this PR does / why we need it**:

This adds Jenkins plugin file extensions to the list of Java file extensions to scan.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #:

**Special notes**:

Related to #48 somewhat.