### PR TITLE
Add Maven metadata to Java analyzer

### DIFF
--- a/anchore_engine/services/apiext/api/controllers/images.py
+++ b/anchore_engine/services/apiext/api/controllers/images.py
@@ -96,6 +96,7 @@ def make_response_content(content_type, content_data):
                 el['location'] = content_data[package]['location']
                 el['specification-version'] = content_data[package]['specification-version']
                 el['implementation-version'] = content_data[package]['implementation-version']
+                el['maven-version'] = content_data[package]['maven-version']
                 el['origin'] = content_data[package]['origin'] or 'Unknown'
             except:
                 el = {}

--- a/anchore_engine/services/policy_engine/engine/loaders.py
+++ b/anchore_engine/services/policy_engine/engine/loaders.py
@@ -604,6 +604,10 @@ class ImageLoader(object):
             if sversion not in ret_versions:
                 ret_versions.append(sversion)
 
+        mversion = input_el.get('maven-version', "N/A")
+        if mversion != 'N/A' and mversion not in ret_versions:
+            ret_versions.append(mversion)
+
         # do some heuristic tokenizing
         try:
             toks = re.findall("[^-]+", input_el['name'])


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds the metadata found from an embedded pom.properties file
contained in many Java libraries. This file is not subject to name
collisions like the MANIFEST.MF is, so this technique works on shaded
jars as well.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(,
fixes #<issue_number, ...)` format, will close the issue when PR is
merged*: fixes #48

**Special notes**:
This may need an update to the cli to add another column for the maven
version of a java package.

Also requesting @reviewbybees