### PR TITLE
get the latest evaluation result from database if the newest_only is …

### DIFF
--- a/anchore_engine/services/catalog/api/controllers/policy_evaluations.py
+++ b/anchore_engine/services/catalog/api/controllers/policy_evaluations.py
@@ -27,11 +27,8 @@ def get_evals(policyId=None, imageDigest=None, tag=None, evalId=None, newest_onl
         user_id = request_inputs['userId']
 
         with db.session_scope() as session:
-            if newest_only:
-                evals = list_evals_impl(session, userId=user_id, policyId=policyId, imageDigest=imageDigest, tag=tag,
-                                        evalId=evalId)
-            else:
-                evals = list_evals_impl(session, userId=user_id, policyId=policyId, imageDigest=imageDigest, tag=tag, evalId=evalId)
+            evals = list_evals_impl(session, userId=user_id, policyId=policyId, imageDigest=imageDigest, tag=tag,
+                                    evalId=evalId, newest_only=newest_only)
 
             if not evals:
                 httpcode = 404
@@ -141,6 +138,10 @@ def list_evals_impl(dbsession, userId, policyId=None, imageDigest=None, tag=None
     if evalId is not None:
         dbfilter['evalId'] = evalId
 
+    if newest_only:
+        records = db_policyeval.tsget_byfilter(userId, session=dbsession, **dbfilter)
+        if len(records) > 0:
+            return records
 
     # perform an interactive eval to get/install the latest
     try:


### PR DESCRIPTION
…true

<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**:
Fix one issue on kubernetes webhook

**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #:

* https://github.com/anchore/anchore-engine/issues/81

**Special notes**:

The logic change part is to check the existing evaluation result first, then do evaluation if there're no evaluation records in the database.

