### PR TITLE
fix the issue that the lays of images doesn't have full image info.

### DIFF
--- a/anchore_engine/clients/localanchore_standalone.py
+++ b/anchore_engine/clients/localanchore_standalone.py
@@ -416,13 +416,16 @@ def get_image_metadata_v1(staging_dirs, imageDigest, imageId, manifest_data, doc
                 lsize = hel['Size']
             except:
                 lsize = 0
-            
-            if hel['container_config']['Cmd']:
+
+            try:
                 lcreatedby = ' '.join(hel['container_config']['Cmd'])
-            else:
+            except:
                 lcreatedby = ""
-            
-            lcreated = hel['created']
+
+            try:
+                lcreated = hel['created']
+            except:
+                lcreated = ""
             lid = layers[count]
             count = count + 1
             hfinal.append(


### PR DESCRIPTION
some of the history has body like:
```json
    {
      "v1Compatibility":
        "{\"id\":\"38c5916c333...\",\"parent\":\"bac7f0439852...\"}"
    }
```

The analyze function break directly.
