### PR TITLE
Add optional policy parameter for vulnerabilities older than N days

### DIFF
--- a/anchore_engine/services/policy_engine/engine/policy/gates/vulnerabilities.py
+++ b/anchore_engine/services/policy_engine/engine/policy/gates/vulnerabilities.py
@@ -39,7 +39,7 @@ class VulnerabilityMatchTrigger(BaseTrigger):
     severity = EnumStringParameter(name='severity', example_str='high', description='Severity to compare against.', enum_values=SEVERITY_ORDERING, is_required=True, sort_order=3)
     fix_available = BooleanStringParameter(name='fix_available', example_str='true', description='If present, the fix availability for the vulnerability record must match the value of this parameter.', is_required=False, sort_order=4)
     vendor_only = BooleanStringParameter(name='vendor_only', example_str='true', description='If True, an available fix for this CVE must not be explicitly marked as wont be addressed by the vendor', is_required=False, sort_order=5)
-    max_days_since_sync = IntegerStringParameter(name='max_days_since_sync', example_str='7', description='If provided, this CVE must be older than the days provided to trigger.', is_required=False, sort_order=6)
+    max_days_since_creation = IntegerStringParameter(name='max_days_since_creation', example_str='7', description='If provided, this CVE must be older than the days provided to trigger.', is_required=False, sort_order=6)
 
     def evaluate(self, image_obj, context):
         is_fix_available = self.fix_available.value()
@@ -47,8 +47,8 @@ class VulnerabilityMatchTrigger(BaseTrigger):
         comparison_idx = SEVERITY_ORDERING.index(self.severity.value().lower())
         comparison_fn = self.SEVERITY_COMPARISONS.get(self.severity_comparison.value())
         timeallowed = time.time()
-        if self.max_days_since_sync.value() is not None:
-            timeallowed -= int(int(self.max_days_since_sync.value()) * 86400)
+        if self.max_days_since_creation.value() is not None:
+            timeallowed -= int(int(self.max_days_since_creation.value()) * 86400)
         if not comparison_fn:
             raise KeyError(self.severity_comparison)
 

--- a/anchore_engine/services/policy_engine/engine/policy/gates/vulnerabilities.py
+++ b/anchore_engine/services/policy_engine/engine/policy/gates/vulnerabilities.py
@@ -39,12 +39,16 @@ class VulnerabilityMatchTrigger(BaseTrigger):
     severity = EnumStringParameter(name='severity', example_str='high', description='Severity to compare against.', enum_values=SEVERITY_ORDERING, is_required=True, sort_order=3)
     fix_available = BooleanStringParameter(name='fix_available', example_str='true', description='If present, the fix availability for the vulnerability record must match the value of this parameter.', is_required=False, sort_order=4)
     vendor_only = BooleanStringParameter(name='vendor_only', example_str='true', description='If True, an available fix for this CVE must not be explicitly marked as wont be addressed by the vendor', is_required=False, sort_order=5)
+    days_past_creation = IntegerStringParameter(name='days_past_creation', example_str='7', description='If provided, this CVE must be older than the days provided to trigger.', is_required=False, sort_order=6)
 
     def evaluate(self, image_obj, context):
         is_fix_available = self.fix_available.value()
         is_vendor_only = self.vendor_only.value(default_if_none=True)
         comparison_idx = SEVERITY_ORDERING.index(self.severity.value().lower())
         comparison_fn = self.SEVERITY_COMPARISONS.get(self.severity_comparison.value())
+        timeallowed = time.time()
+        if self.days_past_creation.value() is not None:
+            timeallowed -= int(int(self.days_past_creation.value()) * 86400)
         if not comparison_fn:
             raise KeyError(self.severity_comparison)
 
@@ -56,6 +60,9 @@ class VulnerabilityMatchTrigger(BaseTrigger):
                         found_severity_idx = SEVERITY_ORDERING.index(sev.lower()) if sev else 0
                         if comparison_fn(found_severity_idx, comparison_idx):
                             for image_cpe, vulnerability_cpe in cpevulns[sev]:
+                                # Check if the vulnerability is to recent for this policy
+                                if calendar.timegm(vulnerability_cpe.created_at.timetuple()) > timeallowed:
+                                    continue
                                 trigger_fname = None
                                 if image_cpe.pkg_type in ['java', 'gem']:
                                     try:
@@ -97,6 +104,10 @@ class VulnerabilityMatchTrigger(BaseTrigger):
                         # Check vendor_only flag specified by the user in policy
                         if is_vendor_only and pkg_vuln.fix_has_no_advisory():
                             # skip this vulnerability
+                            continue
+
+                        # Check if the vulnerability is to recent for this policy
+                        if calendar.timegm(pkg_vuln.vulnerability.created_at.timetuple()) > timeallowed:
                             continue
 
                         # Check fix_available status if specified by user in policy

--- a/anchore_engine/services/policy_engine/engine/policy/gates/vulnerabilities.py
+++ b/anchore_engine/services/policy_engine/engine/policy/gates/vulnerabilities.py
@@ -39,7 +39,7 @@ class VulnerabilityMatchTrigger(BaseTrigger):
     severity = EnumStringParameter(name='severity', example_str='high', description='Severity to compare against.', enum_values=SEVERITY_ORDERING, is_required=True, sort_order=3)
     fix_available = BooleanStringParameter(name='fix_available', example_str='true', description='If present, the fix availability for the vulnerability record must match the value of this parameter.', is_required=False, sort_order=4)
     vendor_only = BooleanStringParameter(name='vendor_only', example_str='true', description='If True, an available fix for this CVE must not be explicitly marked as wont be addressed by the vendor', is_required=False, sort_order=5)
-    days_past_creation = IntegerStringParameter(name='days_past_creation', example_str='7', description='If provided, this CVE must be older than the days provided to trigger.', is_required=False, sort_order=6)
+    max_days_since_sync = IntegerStringParameter(name='max_days_since_sync', example_str='7', description='If provided, this CVE must be older than the days provided to trigger.', is_required=False, sort_order=6)
 
     def evaluate(self, image_obj, context):
         is_fix_available = self.fix_available.value()
@@ -47,8 +47,8 @@ class VulnerabilityMatchTrigger(BaseTrigger):
         comparison_idx = SEVERITY_ORDERING.index(self.severity.value().lower())
         comparison_fn = self.SEVERITY_COMPARISONS.get(self.severity_comparison.value())
         timeallowed = time.time()
-        if self.days_past_creation.value() is not None:
-            timeallowed -= int(int(self.days_past_creation.value()) * 86400)
+        if self.max_days_since_sync.value() is not None:
+            timeallowed -= int(int(self.max_days_since_sync.value()) * 86400)
         if not comparison_fn:
             raise KeyError(self.severity_comparison)
 


### PR DESCRIPTION
fixes #149
cc @nurmi 

Let me know how this looks, and what other changes would need to be made for it to be included. How are tests handled for policy filters like this? Does the cli need to be updated to include the creation date in vulnerability output?