### PR TITLE
Target multiple digests in vuln_update/policy_eval subscriptions

### DIFF
--- a/anchore_engine/services/catalog/__init__.py
+++ b/anchore_engine/services/catalog/__init__.py
@@ -161,7 +161,7 @@ def handle_vulnerability_scan(*args, **kwargs):
             # vulnerability scans
 
             doperform = False
-            vuln_sub_tags = []
+            vuln_subs = []
             for subscription_type in ['vuln_update']:
                 dbfilter = {'subscription_type': subscription_type}
                 with db.session_scope() as dbsession:
@@ -172,16 +172,28 @@ def handle_vulnerability_scan(*args, **kwargs):
                             'subscription_key'], registry_lookup=False, registry_creds=(None, None))
                         dbfilter = {'registry': image_info['registry'], 'repo': image_info['repo'],
                                     'tag': image_info['tag']}
-                        if dbfilter not in vuln_sub_tags:
-                            vuln_sub_tags.append(dbfilter)
+                        if (dbfilter, subscription_record['subscription_value']) not in vuln_subs:
+                            vuln_subs.append((dbfilter, subscription_record['subscription_value']))
 
-            for dbfilter in vuln_sub_tags:
+            for (dbfilter, value) in vuln_subs:
                 with db.session_scope() as dbsession:
                     image_records = db_catalog_image.get_byimagefilter(userId, 'docker', dbfilter=dbfilter,
-                                                                       onlylatest=True, session=dbsession)
+                                                                       onlylatest=False, session=dbsession)
+                try:
+                    subscription_value = json.loads(value)
+                    digests = set(subscription_value['digests'])
+                except Exception as err:
+                    digests = set()
+                # always add latest version of the image
+                if len(image_records) > 0:
+                    digests.add(image_records[0]['imageDigest'])
                 for image_record in image_records:
                     if image_record['analysis_status'] == taskstate.complete_state('analyze'):
                         imageDigest = image_record['imageDigest']
+
+                        if imageDigest not in digests:
+                            continue
+
                         fulltag = dbfilter['registry'] + "/" + dbfilter['repo'] + ":" + dbfilter['tag']
 
                         doperform = True
@@ -793,7 +805,7 @@ def handle_policyeval(*args, **kwargs):
             # policy evaluations
 
             doperform = False
-            policy_sub_tags = []
+            policy_subs = []
             for subscription_type in ['policy_eval']:
                 dbfilter = {'subscription_type': subscription_type}
                 with db.session_scope() as dbsession:
@@ -804,16 +816,28 @@ def handle_policyeval(*args, **kwargs):
                             'subscription_key'], registry_lookup=False, registry_creds=(None, None))
                         dbfilter = {'registry': image_info['registry'], 'repo': image_info['repo'],
                                     'tag': image_info['tag']}
-                        if dbfilter not in policy_sub_tags:
-                            policy_sub_tags.append(dbfilter)
+                        if (dbfilter, subscription_record['subscription_value']) not in policy_subs:
+                            policy_subs.append((dbfilter, subscription_record['subscription_value']))
 
-            for dbfilter in policy_sub_tags:
+            for (dbfilter, value) in policy_subs:
                 with db.session_scope() as dbsession:
                     image_records = db_catalog_image.get_byimagefilter(userId, 'docker', dbfilter=dbfilter,
-                                                                       onlylatest=True, session=dbsession)
+                                                                       onlylatest=False, session=dbsession)
+                try:
+                    subscription_value = json.loads(value)
+                    digests = set(subscription_value['digests'])
+                except Exception as err:
+                    digests = set()
+                # always add latest version of the image
+                if len(image_records) > 0:
+                    digests.add(image_records[0]['imageDigest'])
                 for image_record in image_records:
                     if image_record['analysis_status'] == taskstate.complete_state('analyze'):
                         imageDigest = image_record['imageDigest']
+
+                        if imageDigest not in digests:
+                            continue
+
                         fulltag = dbfilter['registry'] + "/" + dbfilter['repo'] + ":" + dbfilter['tag']
 
                         # TODO - checks to avoid performing eval if nothing has changed

--- a/anchore_engine/services/catalog/catalog_impl.py
+++ b/anchore_engine/services/catalog/catalog_impl.py
@@ -1100,6 +1100,7 @@ def perform_vulnerability_scan(userId, imageDigest, dbsession, scantag=None, for
         if imageId and imageId not in imageIds:
             imageIds.append(imageId)
 
+    archiveId = scantag + image_record["imageDigest"]
 
     for imageId in imageIds:
         # do the image load, just in case it was missed in analyze...
@@ -1112,7 +1113,7 @@ def perform_vulnerability_scan(userId, imageDigest, dbsession, scantag=None, for
 
         last_vuln_result = {}
         try:
-            last_vuln_result = obj_store.get_document(userId, 'vulnerability_scan', scantag)
+            last_vuln_result = obj_store.get_document(userId, 'vulnerability_scan', archiveId)
         except:
             pass
 
@@ -1123,7 +1124,7 @@ def perform_vulnerability_scan(userId, imageDigest, dbsession, scantag=None, for
         if last_vuln_result and curr_vuln_result:
             vdiff = anchore_utils.process_cve_status(old_cves_result=last_vuln_result['legacy_report'], new_cves_result=curr_vuln_result['legacy_report'])
 
-        obj_store.put_document(userId, 'vulnerability_scan', scantag, curr_vuln_result)
+        obj_store.put_document(userId, 'vulnerability_scan', archiveId, curr_vuln_result)
 
         try:
             if vdiff and (vdiff['updated'] or vdiff['added'] or vdiff['removed']):


### PR DESCRIPTION
Add the ability to target specific image digests while handling vuln_update/policy_eval subscriptions.
In an approach similar to the repo_update handling, the `subscription_value` field of the sub record is 
used to store a set of digests that will be checked on top of the latest version of the image.

NB: this is to be considered a feature proposal more than a fully-featured PR.