### PR TITLE
Don't return an iterator from list_accounts()

### DIFF
--- a/anchore_engine/subsys/identities.py
+++ b/anchore_engine/subsys/identities.py
@@ -188,8 +188,8 @@ class IdentityManager(object):
         return account
 
     def list_accounts(self, with_state=None, include_service=False):
-        accounts = filter(lambda x: (include_service or (x['type'] != AccountTypes.service)),
-                          db_accounts.get_all(with_state=with_state, session=self.session))
+        accounts = list(filter(lambda x: (include_service or (x['type'] != AccountTypes.service)),
+                          db_accounts.get_all(with_state=with_state, session=self.session)))
         return accounts
 
     def get_account(self, accountname):


### PR DESCRIPTION
Since we may want to loop over the result multiple times, don't return an iterator in `list_accounts()` but wrap the result in a list.

Fixes https://github.com/anchore/anchore-engine/issues/190.