### PR TITLE
Fix simplequeue swagger file

### DIFF
--- a/anchore_engine/services/simplequeue/swagger/swagger.yaml
+++ b/anchore_engine/services/simplequeue/swagger/swagger.yaml
@@ -208,7 +208,6 @@ paths:
         required: true
       responses:
         200:
-          description: "success"
           description: "Queue element"
           schema:
             type: object


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a error that I get when checking the YAML file against https://editor.swagger.io/

Having 2 `description` fields is not valid (I think).

How to reproduce: 

1. copy paste https://raw.githubusercontent.com/anchore/anchore-engine/master/anchore_engine/services/simplequeue/swagger/swagger.yaml into https://editor.swagger.io/
2. The website return this error message: 
     ```
     Parser error duplicated mapping key
     Jump to line 212
     ```
3. Remove one of the 2 `description` field.
4. The swagger file is now valid.



