### PR TITLE
Support passing external_id in the secret_access_key for cross-accoun…

### DIFF
--- a/anchore_engine/auth/aws_ecr.py
+++ b/anchore_engine/auth/aws_ecr.py
@@ -54,7 +54,11 @@ def refresh_ecr_credentials(registry, access_key_id, secret_access_key):
         elif access_key_id == '_iam_role':
             try:
                 sts = boto3.client('sts')
-                session = sts.assume_role(RoleArn=secret_access_key, RoleSessionName=str(int(time.time())))
+                role_arn, external_id = secret_access_key.split(";") # pass = "role_arn;external_id"
+                if external_id:
+                    session = sts.assume_role(RoleArn=role_arn, RoleSessionName=str(int(time.time())), ExternalId=external_id)
+                else:
+                    session = sts.assume_role(RoleArn=role_arn, RoleSessionName=str(int(time.time())))
                 access_key_id = session['Credentials']['AccessKeyId']
                 secret_access_key = session['Credentials']['SecretAccessKey']
                 session_token = session['Credentials']['SessionToken']

--- a/anchore_engine/auth/aws_ecr.py
+++ b/anchore_engine/auth/aws_ecr.py
@@ -54,7 +54,10 @@ def refresh_ecr_credentials(registry, access_key_id, secret_access_key):
         elif access_key_id == '_iam_role':
             try:
                 sts = boto3.client('sts')
-                role_arn, external_id = secret_access_key.split(";") # pass = "role_arn;external_id"
+                components = secret_access_key.split(';') # pass = "role_arn;external_id"
+                role_arn = components[0]
+                if len(components) > 1:
+                    external_id = components[1]
                 if external_id:
                     session = sts.assume_role(RoleArn=role_arn, RoleSessionName=str(int(time.time())), ExternalId=external_id)
                 else:


### PR DESCRIPTION
Support passing external_id in the secret_access_key for cross-account ECR access

<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**:
The PR allows passing the external_id which allows a cross-account role to be assumed in case the corresponding role's account requires an external_id to be sent as a request parameter (in order to allow the role to be assumed). This is achieved by passing the secret_access_key / registry_pass variable in this format (separated by a semi-colon) "role_arn;external_id".

**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #:

**Special notes**:


