### PR TITLE
Improve version comparison for dpkg and rpm

### DIFF
--- a/anchore_engine/db/entities/policy_engine.py
+++ b/anchore_engine/db/entities/policy_engine.py
@@ -389,19 +389,18 @@ class FixedArtifact(Base):
             return True
 
         # Is the package older than the fix?
-        if flavor == 'RHEL':
-            if rpm_compare_versions(package_obj.name, package_obj.fullversion, fix_obj.name, fix_obj.epochless_version) < 0:
-                log.spew('rpm Compared: {} < {}: True'.format(package_obj.fullversion, fix_obj.epochless_version))
+        if flavor == 'RHEL':  # compare full package version with full fixed-in version, epoch handled in compare fn. fixes issue-265
+            if rpm_compare_versions(package_obj.fullversion, fix_obj.version) < 0:
+                log.spew('rpm Compared: {} < {}: True'.format(package_obj.fullversion, fix_obj.version))
                 return True
-        elif flavor == 'DEB':
-            if dpkg_compare_versions(package_obj.fullversion, 'lt', fix_obj.epochless_version):
-                log.spew('dpkg Compared: {} < {}: True'.format(package_obj.fullversion, fix_obj.epochless_version))
+        elif flavor == 'DEB':  # compare full package version with full fixed-in version, epoch handled in compare fn. fixes issue-265
+            if dpkg_compare_versions(package_obj.fullversion, 'lt', fix_obj.version):
+                log.spew('dpkg Compared: {} < {}: True'.format(package_obj.fullversion, fix_obj.version))
                 return True
-        elif flavor == 'ALPINE':
+        elif flavor == 'ALPINE':  # compare full package version with epochless fixed-in version
             if apkg_compare_versions(package_obj.fullversion, 'lt', fix_obj.epochless_version):
                 log.spew('apkg Compared: {} < {}: True'.format(package_obj.fullversion, fix_obj.epochless_version))
                 return True
-
 
         if package_obj.pkg_type in ['java', 'maven', 'npm', 'gem', 'python', 'js']:
             if package_obj.pkg_type in ['java', 'maven']:

--- a/anchore_engine/util/deb.py
+++ b/anchore_engine/util/deb.py
@@ -13,11 +13,12 @@ compare_operators = {
     'gt': lambda x: x > 0,
 }
 
-# See dpkg lib/dpkg/version.h for the dpkg_version struct, which this mirrors
-# epoch will be null if not present
-# version is the upstream part of the version
-# revision is the debian revision part of the version
+
 class DpkgVersion(object):
+    """
+    See dpkg lib/dpkg/version.h for the dpkg_version struct, which this mirrors
+    """
+
     @classmethod
     def blank(cls):
         return DpkgVersion(0, None, None)
@@ -25,10 +26,31 @@ class DpkgVersion(object):
     @classmethod
     def from_string(cls, version_str):
         """
-        Parse a pkg version from a string
+        Parse a pkg version from a string as per dpkg spec.
+        Essentially a wrapper around non-compliant result to reset epoch to 0 if its null
+
+        Returns a tuple containing epoch, version and release:
+        epoch will be zero if not present
+        version is the upstream part of the version
+        revision is the debian revision part of the version
 
         :param version_str:
-        :return:
+        :return: tuple (epoch, version, release)
+        """
+        nc_version = DpkgVersion.non_compliant_parser(version_str)
+        if nc_version and nc_version.epoch is None:
+            nc_version.epoch = 0
+
+        return nc_version
+
+    @classmethod
+    def non_compliant_parser(cls, version_str):
+        """
+        Parse a pkg version as per anchore engine rules, which may not be compliant with dpkg spec.
+        Use the wrapper fn from_string() for dpkg compliant version parser
+
+        :param version_str:
+        :return: tuple (epoch, version, release). epoch is null if the inbound version does not contain epoc
         """
         version_str = version_str.strip()
 
@@ -167,7 +189,7 @@ class DpkgVersion(object):
             return 0
 
 
-def compare_versions(v1, op, v2):
+def strict_compare_versions(v1, op, v2):
     """
     Pure python impl of the dpkg version comparison code from: dpkg/lib/vercmp.c
 
@@ -199,6 +221,48 @@ def compare_versions(v1, op, v2):
 
     pkg1 = DpkgVersion.from_string(v1)
     pkg2 = DpkgVersion.from_string(v2)
+
+    try:
+        return eval_fn(pkg1.__cmp__(pkg2))
+    except Exception as e:
+        raise
+
+
+def compare_versions(v1, op, v2):
+    """
+    Anchore engine variation of dpkg comparison code.
+    Special handling for epoch - comparison of epochs is carried out only if both versions contain an epoch, otherwise
+    epoch is ignored
+
+    Returns standard boolean truth of op applied to v1 and v2, so if op == 'lt' and v1 < v2, return True.
+
+    Splits the version string into number and non-number components and does a component-wise comparison.
+
+    For a dpkg spec compliant comparison use strict_compare_versions()
+
+    E.g.
+
+    1.2.10 -> 1,2,10
+    1.15.1 -> 1,15,1
+
+    Thus 1.2.10 < 1.15.1.
+
+    values for op:
+    le, lt, eq, ne, ge, gt
+
+    :param v1: version string
+    :param op: string operator
+    :param v2: version string
+    :return:
+    """
+
+    if op not in compare_operators:
+        raise ValueError('Invalid op, {}, requested. Valid values are: {}'.format(op, list(compare_operators.keys())))
+    else:
+        eval_fn = compare_operators[op]
+
+    pkg1 = DpkgVersion.non_compliant_parser(v1)
+    pkg2 = DpkgVersion.non_compliant_parser(v2)
 
     try:
         return eval_fn(pkg1.__cmp__(pkg2))

--- a/anchore_engine/util/deb.py
+++ b/anchore_engine/util/deb.py
@@ -14,7 +14,7 @@ compare_operators = {
 }
 
 # See dpkg lib/dpkg/version.h for the dpkg_version struct, which this mirrors
-# epoch will be zero if not present
+# epoch will be null if not present
 # version is the upstream part of the version
 # revision is the debian revision part of the version
 class DpkgVersion(object):
@@ -58,8 +58,9 @@ class DpkgVersion(object):
             version = version_comps[0]
             revision = version_comps[1]
 
-        if not epoch:
-            epoch = 0
+        # commenting this out to leave the epoch with a null value. helps distinguish between an absent and a real 0 epoch
+        # if not epoch:
+        #     epoch = 0
 
         return DpkgVersion(epoch=epoch, version=version, revision=revision)
 
@@ -72,17 +73,17 @@ class DpkgVersion(object):
         if not isinstance(other, DpkgVersion):
             raise TypeError('Can only compare other DpkVersion objects. Found: {}'.format(type(other)))
 
-        if self.epoch > other.epoch:
-            return 1
-        if self.epoch < other.epoch:
-            return 0
+        if self.epoch is not None and other.epoch is not None:  # compare only when both epochs are available. ignore otherwise
+            if self.epoch > other.epoch:
+                return 1
+            if self.epoch < other.epoch:
+                return 0
 
         ver_cmp = DpkgVersion._compare_version_str(self.version, other.version)
         if ver_cmp:
             return ver_cmp
 
         return DpkgVersion._compare_version_str(self.revision, other.revision)
-
 
     @staticmethod
     def _compare_version_str(ver_a, ver_b):

--- a/anchore_engine/util/packages.py
+++ b/anchore_engine/util/packages.py
@@ -1,6 +1,6 @@
 from .apk import compare_versions as apk_compare_versions
 from .deb import compare_versions as deb_compare_versions
-from .rpm import split_rpm_filename, compare_labels
+from .rpm import compare_versions as rpm_compare_versions
 
 
 def compare_package_versions(distro_flavor, pkg_a, ver_a, pkg_b, ver_b):
@@ -10,9 +10,9 @@ def compare_package_versions(distro_flavor, pkg_a, ver_a, pkg_b, ver_b):
 
     :param distro_flavor: (str) the package type/distro type for the comparison ("RHEL", "DEB", "ALPINE")
     :param pkg_a: (str) package A's name
-    :param: ver_a: (str) package A's version
-    :param: pkg_b: (str) package B's name
-    :param: ver_b: (str) package B's version
+    :param ver_a: (str) package A's version
+    :param pkg_b: (str) package B's name
+    :param ver_b: (str) package B's version
     :return: int comparison output -1, 0, or 1
     """
 
@@ -26,12 +26,7 @@ def compare_package_versions(distro_flavor, pkg_a, ver_a, pkg_b, ver_b):
         return (0)
 
     if distro_flavor == "RHEL":
-        fixfile = pkg_b + "-" + ver_b + ".arch.rpm"
-        imagefile = pkg_a + "-" + ver_a + ".arch.rpm"
-        (n1, v1, r1, e1, a1) = split_rpm_filename(imagefile)
-        (n2, v2, r2, e2, a2) = split_rpm_filename(fixfile)
-
-        if compare_labels(('1', v1, r1), ('1', v2, r2)) < 0:
+        if rpm_compare_versions(ver_a, ver_b) < 0:
             return -1
         else:
             return 1

--- a/anchore_engine/util/rpm.py
+++ b/anchore_engine/util/rpm.py
@@ -49,16 +49,18 @@ def split_rpm_filename(rpm_filename):
     return name, version, release, epoch, arch
 
 
-def split_version(version):
+def split_fullversion(version):
     """
-    Splits version string into a tuple (epoch, version, release). Returns a null for epoch if the version string does not contain epoch.
+    Splits version string into a tuple (epoch, version, release). Inbound version string is specific to anchore engine's
+    implementation of versions and may not compliant with the rpm spec.
+
     Use this function for splitting versions already processed by anchore engine. For parsing info from rpm file name, use split_rpm_filename()
 
     '2.27-34.base.el7' -> (null, '2.27', '34.base.el7')
     '1:2.27-34.base.el7' -> ('1', '2.27', '34.base.el7')
 
     :param version: Version string with or without an epoch prefix
-    :return: tuple (epoch, version, release)
+    :return: tuple (epoch, version, release). epoch is null if the inbound version does not contain epoch
     """
     ver_comp = version.rsplit('-', 1)
 
@@ -84,7 +86,7 @@ def split_version(version):
 
 def compare_versions(ver_a, ver_b):
     """
-    Compare pkg and versions using rpm file name rules. Follows standard __cmp__ semantics of -1 iff a < b, 0 iff a == b, 1 iff a > b
+    Compare pkg and versions using anchore engine rules. Follows standard __cmp__ semantics of -1 iff a < b, 0 iff a == b, 1 iff a > b
     
     :param ver_a:
     :param ver_b:
@@ -93,8 +95,8 @@ def compare_versions(ver_a, ver_b):
     if ver_a == ver_b:
         return 0
 
-    (e1, v1, r1) = split_version(ver_a)
-    (e2, v2, r2) = split_version(ver_b)
+    (e1, v1, r1) = split_fullversion(ver_a)
+    (e2, v2, r2) = split_fullversion(ver_b)
 
     return compare_labels((e1, v1, r1), (e2, v2, r2))
 

--- a/test/unit/anchore_engine/util/test_deb.py
+++ b/test/unit/anchore_engine/util/test_deb.py
@@ -10,30 +10,24 @@ class TestDpkgVersionHandling(unittest.TestCase):
 
     def test_version_comparision(self):
         test_epoch = [
-            ('1','1', 0),
-            ('1:0', '0:10', 1),
-            (),
-            (),
-            (),
+            ('1:0', '0:10', 'gt', True),
+            ('1:0', '1', 'ge', False),
+            ('1:2', '1', 'gt', True),
+            ('1:5.14-2ubuntu3', '1:5.14-2ubuntu3.1', 'lt', True),
+            ('1:5.14-2ubuntu3', '5.14-2ubuntu3.1', 'eq', False),
+            ('5.14-2ubuntu3', '1:5.14-2ubuntu3.1', 'le', True)
         ]
 
         test_no_epoch = [
-            ('1.01.1', '1.1.1', 'eq', False),
-            ('1.01.1', '1.1.1', 'lt', True),
+            ('1', '1', 'eq', True),
+            ('1.01.1', '1.1.1', 'eq', True),
+            ('1.01.1', '1.1.1', 'lt', False),
             ('1.01.1', '1.1.1', 'le', True),
             ('1.101.1', '1.100.1', 'eq', False),
             ('1.100a.1', '1.9a9.100', 'eq', False),
-            ('1.100.1', '1.99.100', 'eq', False),
-            ('1.100.1', '1.99.100', 'eq', False),
             ('1.100.1', '1.99.100', 'eq', False)
         ]
 
-
-        for i in test_no_epoch:
-            print(('Testing: {}'.format(i)))
-            if not i[3] == compare_versions(i[0], i[2], i[1]):
-                print('Mismatch!')
-            else:
-                print('Match!')
-
-        print((compare_versions('1.900.1-debian1-2.4+deb8u3', 'lt', '1.900.1-5.1')))
+        for i in test_epoch + test_no_epoch:
+            self.assertEqual(i[3], compare_versions(i[0], i[2], i[1]), '{} {} {}'.format(i[0], i[2], i[1]))
+            print('Tested: {}'.format(i))

--- a/test/unit/anchore_engine/util/test_deb.py
+++ b/test/unit/anchore_engine/util/test_deb.py
@@ -1,5 +1,5 @@
 import unittest
-from anchore_engine.util.deb import compare_versions
+from anchore_engine.util.deb import compare_versions, strict_compare_versions
 
 
 class TestDpkgVersionHandling(unittest.TestCase):
@@ -8,13 +8,39 @@ class TestDpkgVersionHandling(unittest.TestCase):
 
     """
 
+    def test_strict_version_comparison(self):
+        print('Testing strict version comparison')
+        test_epoch = [
+            ('1:0', '0:10', 'gt', True),
+            ('1:0', '1', 'le', False),
+            ('1:2', '1', 'gt', True),
+            ('1:5.14-2ubuntu3', '1:5.14-2ubuntu3.1', 'lt', True),
+            ('1:5.14-2ubuntu3', '5.14-2ubuntu3.1', 'gt', True),
+            ('5.14-2ubuntu3', '1:5.14-2ubuntu3.1', 'le', True)
+        ]
+
+        test_no_epoch = [
+            ('1', '1', 'eq', True),
+            ('1.01.1', '1.1.1', 'eq', True),
+            ('1.01.1', '1.1.1', 'lt', False),
+            ('1.01.1', '1.1.1', 'le', True),
+            ('1.101.1', '1.100.1', 'eq', False),
+            ('1.100a.1', '1.9a9.100', 'eq', False),
+            ('1.100.1', '1.99.100', 'eq', False)
+        ]
+
+        for i in test_epoch + test_no_epoch:
+            self.assertEqual(i[3], strict_compare_versions(i[0], i[2], i[1]), '{} {} {}'.format(i[0], i[2], i[1]))
+            print('Tested: {}'.format(i))
+
     def test_version_comparision(self):
+        print('Testing anchore engine specific version comparison')
         test_epoch = [
             ('1:0', '0:10', 'gt', True),
             ('1:0', '1', 'ge', False),
             ('1:2', '1', 'gt', True),
             ('1:5.14-2ubuntu3', '1:5.14-2ubuntu3.1', 'lt', True),
-            ('1:5.14-2ubuntu3', '5.14-2ubuntu3.1', 'eq', False),
+            ('1:5.14-2ubuntu3', '5.14-2ubuntu3', 'eq', True),
             ('5.14-2ubuntu3', '1:5.14-2ubuntu3.1', 'le', True)
         ]
 

--- a/test/unit/anchore_engine/util/test_rpm.py
+++ b/test/unit/anchore_engine/util/test_rpm.py
@@ -1,0 +1,38 @@
+import unittest
+
+from anchore_engine.util.rpm import compare_versions
+
+
+class TestRpmVersionHandling(unittest.TestCase):
+    """
+    Tests for version comparisons of the rpm version parser and compare code.
+
+    """
+
+    def test_version_comparision(self):
+        test_epoch = [
+            ('1:0', '0:1', 1),
+            ('1:0', '1', -1),
+            ('1:2', '1', 1),
+            ('2:4.19.01-1.el7_5', '4.19.1-1.el7_5', 0),
+            ('4.19.01-1.el7_5', '2:4.19.1-1.el7_5', 0),
+            ('0:4.19.1-1.el7_5', '2:4.19.1-1.el7_5', -1),
+            ('4.19.0-1.el7_5', '12:4.19.0-1.el7', 1),
+            ('3:4.19.0-1.el7_5', '4.21.0-1.el7', -1)
+        ]
+
+        test_no_epoch = [
+            ('1', '1', 0),
+            ('4.19.0a-1.el7_5', '4.19.0c-1.el7', -1),
+            ('4.19.0-1.el7_5', '4.21.0-1.el7', -1),
+            ('4.19.01-1.el7_5', '4.19.10-1.el7_5', -1),
+            ('4.19.0-1.el7_5', '4.19.0-1.el7', 1),
+            ('4.19.0-1.el7_5', '4.17.0-1.el7', 1),
+            ('4.19.01-1.el7_5', '4.19.1-1.el7_5', 0),
+            ('4.19.1-1.el7_5', '4.19.1-01.el7_5', 0),
+            ('4.19.1', '4.19.1', 0),
+        ]
+
+        for i in test_epoch + test_no_epoch:
+            self.assertEqual(i[2], compare_versions(i[0], i[1]), 'comparison between {} and {}'.format(i[0], i[1]))
+            print('Tested: {}'.format(i))

--- a/test/unit/anchore_engine/util/test_rpm.py
+++ b/test/unit/anchore_engine/util/test_rpm.py
@@ -5,11 +5,12 @@ from anchore_engine.util.rpm import compare_versions
 
 class TestRpmVersionHandling(unittest.TestCase):
     """
-    Tests for version comparisons of the rpm version parser and compare code.
+    Tests for version comparisons of rpm package versions maintained in anchore engine.
+    Note that this does not exactly confirm the official rpm spec
 
     """
 
-    def test_version_comparision(self):
+    def test_version_comparison(self):
         test_epoch = [
             ('1:0', '0:1', 1),
             ('1:0', '1', -1),
@@ -18,7 +19,8 @@ class TestRpmVersionHandling(unittest.TestCase):
             ('4.19.01-1.el7_5', '2:4.19.1-1.el7_5', 0),
             ('0:4.19.1-1.el7_5', '2:4.19.1-1.el7_5', -1),
             ('4.19.0-1.el7_5', '12:4.19.0-1.el7', 1),
-            ('3:4.19.0-1.el7_5', '4.21.0-1.el7', -1)
+            ('3:4.19.0-1.el7_5', '4.21.0-1.el7', -1),
+            ('4:1.2.3-3-el7_5', '1.2.3-el7_5~snapshot1', 1)
         ]
 
         test_no_epoch = [
@@ -31,6 +33,7 @@ class TestRpmVersionHandling(unittest.TestCase):
             ('4.19.01-1.el7_5', '4.19.1-1.el7_5', 0),
             ('4.19.1-1.el7_5', '4.19.1-01.el7_5', 0),
             ('4.19.1', '4.19.1', 0),
+            ('1.2.3-el7_5~snapshot1', '1.2.3-3-el7_5', -1)
         ]
 
         for i in test_epoch + test_no_epoch:


### PR DESCRIPTION
For dpkg and rpm
    - compare package version with the epoch included fixed-in version
    - compare epochs only if all versions being compared contain an epoch, otherwise ignore it

Fixes #265

Signed-off-by: Swathi Gangisetty <swathi@anchore.com>

