### PR TITLE
Removes duplicate vulnerabilities from the /images vulnerability responses

### DIFF
--- a/anchore_engine/services/apiext/api/controllers/images.py
+++ b/anchore_engine/services/apiext/api/controllers/images.py
@@ -235,6 +235,10 @@ def make_cvss_scores(metrics):
 
     return score_list
 
+def _get_unique_vulnerabilities(vulnerabilities):
+    seen = set()
+    # Remove duplicate vulnerabilities
+    return [seen.add(vuln['vuln']) or vuln for vuln in vulnerabilities if vuln['vuln'] not in seen]
 
 def make_response_vulnerability(vulnerability_type, vulnerability_data):
     ret = []
@@ -385,7 +389,7 @@ def make_response_vulnerability(vulnerability_type, vulnerability_data):
     else:
         ret = vulnerability_data
 
-    return (ret)
+    return (_get_unique_vulnerabilities(ret))
 
 
 def make_response_policyeval(eval_record, params, catalog_client):


### PR DESCRIPTION
**What this PR does / why we need it**:

It simply removes duplicate CVEs from the /images/<image>/vuln/<os|non-os|all> responses

**Which issue this PR fixes**
#220 

**Special notes**
I haven't added any tests for this, mostly because it's pretty trivial so a regression doesn't matter much but also because I wasn't sure where they'd fit well. If anyone thinks there is somewhere a test would fit nicely, feel free to point me to the file and I'll happily add one :)