### PR TITLE
allow multiple arguments in bootstrap log functions

### DIFF
--- a/anchore_engine/subsys/logger.py
+++ b/anchore_engine/subsys/logger.py
@@ -10,6 +10,9 @@ import logging
 bootstrap_logger = None
 bootstrap_logger_enabled = False
 
+DEFAULT_FORMAT = "[{}] %(asctime)s [-] [%(name)s] [%(levelname)s] %(message)s"
+DEFAULT_DATE_FORMAT = '%Y-%m-%d %H:%M:%S+0000'
+
 log_level_map = {
     'FATAL': 0,
     'ERROR': 1,
@@ -18,14 +21,16 @@ log_level_map = {
     'DEBUG': 4,
     'SPEW': 99
 }
-log_level = None # int level for logging
+log_level = None  # int level for logging
 _log_to_db = None
 _log_to_stdout = False
 
 
 def enable_test_logging(level='WARN', outfile=None):
     """
-    Use the bootstrap logger for logging in test code (as root logger), for intercept by pytest etc. This code should *only* ever be called in code from test/
+    Use the bootstrap logger for logging in test code (as root logger), for
+    intercept by pytest etc. This code should *only* ever be called in code
+    from test/
 
     :return:
     """
@@ -43,9 +48,15 @@ def enable_test_logging(level='WARN', outfile=None):
 
     prefix = 'test'
     if outfile:
-        logging.basicConfig(level=level, filename=outfile, format="[{}] %(asctime)s [-] [%(name)s] [%(levelname)s] %(message)s".format(prefix), datefmt='%Y-%m-%d %H:%M:%S+0000')
+        logging.basicConfig(
+            level=level, filename=outfile,
+            format=DEFAULT_FORMAT.format(prefix), datefmt=DEFAULT_DATE_FORMAT
+        )
     else:
-        logging.basicConfig(level=level, stream=sys.stdout, format="[{}] %(asctime)s [-] [%(name)s] [%(levelname)s] %(message)s".format(prefix), datefmt='%Y-%m-%d %H:%M:%S+0000')
+        logging.basicConfig(
+            level=level, stream=sys.stdout,
+            format=DEFAULT_FORMAT.format(prefix), datefmt=DEFAULT_DATE_FORMAT
+        )
 
     bootstrap_logger = logging.getLogger()
     bootstrap_logger_enabled = True
@@ -53,7 +64,8 @@ def enable_test_logging(level='WARN', outfile=None):
 
 def enable_bootstrap_logging(service_name=None):
     """
-    Turn on the bootstrap logger, which provides basic stdout logs until the main twisted logger is online and ready.
+    Turn on the bootstrap logger, which provides basic stdout logs until the
+    main twisted logger is online and ready.
 
     :param name_prefix:
     :return:
@@ -71,7 +83,11 @@ def enable_bootstrap_logging(service_name=None):
         level = 'INFO'
 
     prefix = 'service:{}'.format(service_name if service_name else ' ')
-    logging.basicConfig(level=level, stream=sys.stdout, format="[{}] %(asctime)s [-] [%(name)s] [%(levelname)s] %(message)s".format(prefix), datefmt='%Y-%m-%d %H:%M:%S+0000')
+    logging.basicConfig(
+        level=level,
+        stream=sys.stdout,
+        format=DEFAULT_FORMAT.format(prefix), datefmt=DEFAULT_DATE_FORMAT
+    )
 
     bootstrap_logger = logging.getLogger('bootstrap')
     bootstrap_logger_enabled = True
@@ -103,7 +119,7 @@ def bootstrap_logger_intercept(level):
 def _msg(msg_string, msg_log_level='INFO'):
     global log_level, log_level_map, _log_to_stdout, _log_to_db
 
-    if log_level == None:
+    if log_level is None:
         log_level = log_level_map['INFO']
 
     if log_level_map[msg_log_level] <= log_level:
@@ -117,7 +133,7 @@ def _msg(msg_string, msg_log_level='INFO'):
             module = inspect.getmodule(frame[0])
             caller_file = module.__name__
             caller_name = outer_frame[3][3]
-        except Exception as err:
+        except Exception:
             pass
 
         themsg = "[" + caller_file + "/" + caller_name + "()] [" + msg_log_level + "] " + msg_string

--- a/anchore_engine/subsys/logger.py
+++ b/anchore_engine/subsys/logger.py
@@ -133,28 +133,50 @@ def _msg(msg_string, msg_log_level='INFO'):
                 # removing old event log stuff since there are no fatal messages in the system
                 pass
 
-#@bootstrap_logger_intercept(logging.DEBUG)
+
+def safe_formatter(message, args):
+    """
+    Try to safely format a log message, so that exceptions are logged and do
+    not break an application.
+
+    Used as a helper by the log functions so that they can accept the
+    following:
+
+        logger.debug("a debug message: %s", "extra argument")
+    """
+    if args:
+        try:
+            return message % args
+        except TypeError:
+            exception('unable to produce log record: %s' % message)
+    return message
+
+
 def spew(msg_string):
     return (_msg(msg_string, msg_log_level='SPEW'))
 
 
 @bootstrap_logger_intercept(logging.DEBUG)
-def debug(msg_string):
+def debug(msg_string, *args):
+    msg_string = safe_formatter(msg_string, args)
     return (_msg(msg_string, msg_log_level='DEBUG'))
 
 
 @bootstrap_logger_intercept(logging.INFO)
-def info(msg_string):
+def info(msg_string, *args):
+    msg_string = safe_formatter(msg_string, args)
     return (_msg(msg_string, msg_log_level='INFO'))
 
 
 @bootstrap_logger_intercept(logging.WARN)
-def warn(msg_string):
+def warn(msg_string, *args):
+    msg_string = safe_formatter(msg_string, args)
     return (_msg(msg_string, msg_log_level='WARN'))
 
 
 @bootstrap_logger_intercept(logging.ERROR)
-def error(msg_string):
+def error(msg_string, *args):
+    msg_string = safe_formatter(msg_string, args)
     return (_msg(msg_string, msg_log_level='ERROR'))
 
 
@@ -203,4 +225,3 @@ def set_log_level(new_log_level, log_to_stdout=False, log_to_db=False):
 
     _log_to_stdout = log_to_stdout
     _log_to_db = log_to_db
-

--- a/test/unit/anchore_engine/subsys/test_logger.py
+++ b/test/unit/anchore_engine/subsys/test_logger.py
@@ -1,0 +1,70 @@
+import pytest
+from anchore_engine.subsys import logger
+
+
+class TestSafeFormatter:
+
+    def test_no_args(self):
+        result = logger.safe_formatter('message', ())
+        assert result == 'message'
+
+    def test_multiple_empty_args(self):
+        result = logger.safe_formatter('message %s %s', ('', ''))
+        assert result == 'message  '
+
+    def test_args_to_format_mismatch(self, capsys):
+        result = logger.safe_formatter('message %s', ('', ''))
+        # exception logger will spit out the traceback, eating up the exception
+        out, err = capsys.readouterr()
+        assert 'not all arguments converted during string formatting' in err
+        assert result == 'message %s'
+
+    def test_actual_formatting(self):
+        result = logger.safe_formatter('message %s, %s', ('first arg', 'second arg'))
+        assert result == 'message first arg, second arg'
+
+
+@pytest.fixture(scope="class")
+def monkeyclass(request):
+    """
+    This is an unfortunate kludge needed to force the monkeypatch fixture to
+    allow a specific scope. In this case we want to monkeypatch always for
+    a all the test methods in a class. Without this, Pytest would raise an
+    error explaining this is not possible.
+
+    See: https://github.com/pytest-dev/pytest/issues/363
+
+    If this ever stops working, then the `monkeypatch` needs to be done on
+    every test method.
+    """
+    from _pytest.monkeypatch import MonkeyPatch
+    mpatch = MonkeyPatch()
+    yield mpatch
+    mpatch.undo()
+
+
+@pytest.fixture(scope='class')
+def log_to_stdout(monkeyclass):
+    monkeyclass.setattr(logger, '_log_to_stdout', True)
+    monkeyclass.setattr(logger, 'log_level', 99)
+
+
+@pytest.mark.usefixtures('log_to_stdout')
+class TestLoggerFunctions:
+
+    @pytest.mark.parametrize('log', [logger.info, logger.warn, logger.error, logger.debug])
+    def test_info_formats_string(self, capsys, log):
+        log('log message %s', 'argument')
+        out, err = capsys.readouterr()
+        assert '[MainThread]' in err
+        assert err.endswith('log message argument\n')
+
+    @pytest.mark.parametrize('log', [logger.info, logger.warn, logger.error, logger.debug])
+    def test_info_cant_format_correctly(self, capsys, log):
+        log('log message %s %s', 'argument')
+        out, err = capsys.readouterr()
+        assert out == ''
+        assert 'Traceback (most recent call last)' in err
+        assert 'TypeError: not enough arguments for format string' in err
+        assert '[ERROR] unable to produce log record: log message %s %s' in err
+        assert err.endswith('] log message %s %s\n')


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes issue #339 by creating a helper to safely format log entries. This prevents breakage when formatting does not work and is how the logging module proceeds to prevent issues.

Additionally, it fixes a problem with the swagger API test which was using no longer valid keyword arguments (see https://github.com/zalando/connexion/issues/1161) . This problem would cause the test to fail but it would not get caught by tox/pytest, I think because of the `fork()`.  It fixes that by using the test facilities that Flask offers and is used by the `connexion` team.

There is room for more exhaustive testing, but these changes gets us to the same validation and more clarity when it fails.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #339

**Special notes**:


