### PR TITLE
Rename `advisories` to `github`

### DIFF
--- a/anchore_engine/services/policy_engine/engine/feeds/feeds.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/feeds.py
@@ -652,7 +652,7 @@ class GithubFeed(VulnerabilityFeed):
     Feed for the Github Advisories data
     """
 
-    __feed_name__ = 'advisories'
+    __feed_name__ = 'github'
     _cve_key = 'id'
     __group_data_mappers__ = SingleTypeMapperFactory(
         __feed_name__, GithubFeedDataMapper, _cve_key

--- a/conf/default_config.yaml
+++ b/conf/default_config.yaml
@@ -71,7 +71,7 @@ feeds:
     # If enabled only sync specific feeds instead of all.
     enabled: ${ANCHORE_FEEDS_SELECTIVE_ENABLED}
     feeds:
-      advisories: true
+      github: true
       vulnerabilities: true
       # Warning: enabling the packages and nvd sync causes the service to require much
       #   more memory to do process the significant data volume. We recommend at least 4GB available for the container


### PR DESCRIPTION

**What this PR does / why we need it**: Renames `advisories` to `github` to be more specific about the feed type.


**Which issue this PR fixes**  Fixes issue #365 

**Special notes**:


