### PR TITLE
use query args instead of JSON body when doing an HTTP DELETE

### DIFF
--- a/anchore_engine/plugins/authorization/client.py
+++ b/anchore_engine/plugins/authorization/client.py
@@ -227,8 +227,7 @@ class AuthzPluginHttpClient(BasicApiClient):
             resp.raise_for_status()
 
     def delete_domain(self, domain: str):
-        req = Domain(domain)
-        resp = self.call_api(requests.delete, 'domains', body=json.dumps(req.to_json()))
+        resp = self.call_api(requests.delete, 'domains', query_params={'domain': domain})
 
         if resp.status_code in [200, 204]:
             return True
@@ -236,7 +235,7 @@ class AuthzPluginHttpClient(BasicApiClient):
             resp.raise_for_status()
 
     def list_domains(self):
-        resp = self.call_api(requests.get, 'domains')        
+        resp = self.call_api(requests.get, 'domains')
         if resp.status_code == 200:
             return [Domain(x) for x in resp.json()]
         else:
@@ -251,8 +250,7 @@ class AuthzPluginHttpClient(BasicApiClient):
             resp.raise_for_status()
 
     def delete_principal(self, principal: str):
-        req = Principal(principal)
-        resp = self.call_api(requests.delete, 'principals', body=json.dumps(req.to_json()))
+        resp = self.call_api(requests.delete, 'principals', query_params={'principal': principal})
 
         if resp.status_code in [200, 204]:
             return True
@@ -260,7 +258,7 @@ class AuthzPluginHttpClient(BasicApiClient):
             resp.raise_for_status()
 
     def list_principals(self):
-        resp = self.call_api(requests.get, 'principals')        
+        resp = self.call_api(requests.get, 'principals')
         if resp.status_code == 200:
             return [Principal(x) for x in resp.json()]
         else:

--- a/anchore_engine/plugins/authorization/swagger/swagger.yaml
+++ b/anchore_engine/plugins/authorization/swagger/swagger.yaml
@@ -63,10 +63,11 @@ paths:
       description: Delete information about a domain, if applicable
       parameters:
         - name: domain
-          in: body
+          in: query
           required: true
           schema:
-            $ref: "#/definitions/Domain"
+            type: string
+            description: The name of a domain
       responses:
         200:
           description: Deletion successful
@@ -93,10 +94,11 @@ paths:
       description: Delete information about a principal, if applicable
       parameters:
         - name: principal
-          in: body
+          in: query
           required: true
           schema:
-            $ref: "#/definitions/Principal"
+            type: string
+            description: The name of a principal
       responses:
         200:
           description: Deletion successful


### PR DESCRIPTION
**What this PR does / why we need it**:  While not forbidden, body on a DELETE is not common practice and thus tooling (e.g. connexion) no longer handles it properly. All Anchore API routes with this behavior must be updated. This is a breaking change that will require a new api version.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes issue #366 


