### PR TITLE
Feed enabled/disabled toggles and data flush capabilities

### DIFF
--- a/anchore_engine/apis/exceptions.py
+++ b/anchore_engine/apis/exceptions.py
@@ -24,6 +24,10 @@ class BadRequest(AnchoreApiError):
     __response_code__ = 400
 
 
+class ConflictingRequest(AnchoreApiError):
+    __response_code__ = 409
+
+
 class AccessDeniedError(AnchoreApiError):
     __response_code__ = 403
 

--- a/anchore_engine/clients/services/policy_engine.py
+++ b/anchore_engine/clients/services/policy_engine.py
@@ -1,6 +1,6 @@
 import json
 from anchore_engine.clients.services.internal import InternalServiceClient
-from anchore_engine.clients.services.http import anchy_get, anchy_post, anchy_delete
+from anchore_engine.clients.services.http import anchy_get, anchy_post, anchy_delete, anchy_put
 
 
 class PolicyEngineClient(InternalServiceClient):
@@ -82,4 +82,18 @@ class PolicyEngineClient(InternalServiceClient):
 
     def sync_feeds(self, force_flush=False):
         return self.call_api(anchy_post, 'feeds', query_params={'force_flush': force_flush})
+
+    def toggle_feed_enabled(self, feed, enabled):
+        return self.call_api(anchy_put, 'feeds/{feed}', path_params={'feed': feed}, query_params={'enabled': enabled})
+
+    def toggle_feed_group_enabled(self, feed, group, enabled):
+        return self.call_api(anchy_put, 'feeds/{feed}/{group}', path_params={'feed': feed, 'group': group}, query_params={'enabled': enabled})
+
+    def delete_feed(self, feed):
+        return self.call_api(anchy_delete, 'feeds/{feed}', path_params={'feed': feed})
+
+    def delete_feed_group(self, feed, group):
+        return self.call_api(anchy_delete, 'feeds/{feed}/{group}', path_params={'feed': feed, 'group': group})
+
+
 

--- a/anchore_engine/db/entities/upgrade.py
+++ b/anchore_engine/db/entities/upgrade.py
@@ -16,6 +16,7 @@ try:
     from twisted.python import log
 except:
     import logging
+
     logger = logging.getLogger(__name__)
     log = logger
 
@@ -24,19 +25,21 @@ upgrade_enabled = True
 # Set at module level for any db module that needs db upgrade ability
 my_module_upgrade_id = 1
 
+
 def do_db_compatibility_check():
-    required_pg_version = (9,6)
+    required_pg_version = (9, 6)
 
     try:
         engine = anchore_engine.db.entities.common.get_engine()
         if engine.dialect.server_version_info >= required_pg_version:
-            return(True)
+            return (True)
         else:
             raise Exception("discovered db version {} is not >= required db version {}".format(engine.dialect.server_version_info, required_pg_version))
     except Exception as err:
         raise err
 
     raise Exception("database compatibility could not be performed")
+
 
 def do_db_post_actions(localconfig=None):
     return
@@ -45,7 +48,7 @@ def do_db_post_actions(localconfig=None):
 def get_versions():
     code_versions = {}
     db_versions = {}
-    
+
     from anchore_engine import version
 
     code_versions['service_version'] = version.version
@@ -58,11 +61,12 @@ def get_versions():
     except Exception as err:
         if is_table_not_found(err):
             logger.info("anchore table not found")
-            #raise TableNotFoundError('anchore table not found')
+            # raise TableNotFoundError('anchore table not found')
         else:
             raise Exception("Cannot find existing/populated anchore DB tables in connected database - has anchore-engine initialized this DB?\n\nDB - exception: " + str(err))
 
-    return(code_versions, db_versions)
+    return (code_versions, db_versions)
+
 
 def do_version_update(db_versions, code_versions):
     from anchore_engine.db import db_anchore, session_scope
@@ -70,7 +74,7 @@ def do_version_update(db_versions, code_versions):
     with session_scope() as dbsession:
         db_anchore.add(code_versions['service_version'], code_versions['db_version'], code_versions, session=dbsession)
 
-    return(True)
+    return (True)
 
 
 @contextmanager
@@ -90,8 +94,9 @@ def upgrade_context(lock_id):
         versions = get_versions()
         yield versions
 
+
 def do_create_tables(specific_tables=None):
-    print ("Creating DB Tables")
+    print("Creating DB Tables")
     from anchore_engine.db.entities.common import Base, do_create
 
     try:
@@ -99,8 +104,9 @@ def do_create_tables(specific_tables=None):
             do_create(specific_tables=specific_tables, base=Base)
     except Exception as err:
         raise err
-    print ("DB Tables created")
-    return(True)
+    print("DB Tables created")
+    return (True)
+
 
 def do_db_bootstrap(localconfig=None, db_versions=None, code_versions=None):
     from anchore_engine.db import session_scope
@@ -115,6 +121,7 @@ def do_db_bootstrap(localconfig=None, db_versions=None, code_versions=None):
                 raise Exception("Initialization failed: could not initialize system credentials - exception: " + str(err))
 
         do_version_update(db_versions, code_versions)
+
 
 def run_upgrade():
     """
@@ -159,6 +166,7 @@ def run_upgrade():
             except Exception as err:
                 raise err
 
+
 def do_upgrade(inplace, incode):
     global upgrade_enabled, upgrade_functions
 
@@ -200,6 +208,7 @@ def do_upgrade(inplace, incode):
 
     ret = True
     return (ret)
+
 
 ### Individual upgrade routines - be sure to add to the function map at the end of this module if adding a new routine here
 
@@ -273,6 +282,7 @@ def db_upgrade_002_003():
 
     return True
 
+
 def db_upgrade_003_004():
     engine = anchore_engine.db.entities.common.get_engine()
 
@@ -313,7 +323,7 @@ def db_upgrade_003_004():
                 result = db_archivedocument.get(userId, 'analysis_data', imageDigest, session=dbsession)
             if result and 'jsondata' in result:
                 image_data = json.loads(result['jsondata'])['document']
-                
+
             if image_data:
                 # update the record and store
                 anchore_engine.common.helpers.update_image_record_with_analysis_data(image_record, image_data)
@@ -325,6 +335,7 @@ def db_upgrade_003_004():
             log.err("upgrade: failed to populate new columns with existing data for image (" + str(imageDigest) + "), record may be incomplete: " + str(err))
 
     return True
+
 
 def db_upgrade_004_005():
     engine = anchore_engine.db.entities.common.get_engine()
@@ -342,6 +353,7 @@ def db_upgrade_004_005():
         except Exception as e:
             log.err('failed to perform DB upgrade on catalog_image adding column - exception: {}'.format(str(e)))
             raise Exception('failed to perform DB upgrade on catalog_image adding column - exception: {}'.format(str(e)))
+
 
 def queue_data_upgrades_005_006():
     engine = anchore_engine.db.entities.common.get_engine()
@@ -394,7 +406,8 @@ def archive_data_upgrade_005_006():
     max_pending_session_size = 10000
 
     with session_scope() as db_session:
-        for doc in db_session.query(LegacyArchiveDocument.userId, LegacyArchiveDocument.bucket, LegacyArchiveDocument.archiveId, LegacyArchiveDocument.documentName, LegacyArchiveDocument.created_at, LegacyArchiveDocument.last_updated, LegacyArchiveDocument.record_state_key, LegacyArchiveDocument.record_state_val):
+        for doc in db_session.query(LegacyArchiveDocument.userId, LegacyArchiveDocument.bucket, LegacyArchiveDocument.archiveId, LegacyArchiveDocument.documentName, LegacyArchiveDocument.created_at, LegacyArchiveDocument.last_updated,
+                                    LegacyArchiveDocument.record_state_key, LegacyArchiveDocument.record_state_val):
             meta = ObjectStorageMetadata(userId=doc[0],
                                          bucket=doc[1],
                                          archiveId=doc[2],
@@ -452,6 +465,7 @@ def db_upgrade_005_006():
     queue_data_upgrades_005_006()
     archive_data_upgrade_005_006()
     fixed_artifact_upgrade_005_006()
+
 
 def catalog_image_upgrades_006_007():
     engine = anchore_engine.db.entities.common.get_engine()
@@ -527,10 +541,12 @@ def user_account_upgrades_007_008():
 def db_upgrade_006_007():
     catalog_image_upgrades_006_007()
 
+
 def db_upgrade_007_008():
     catalog_upgrade_007_008()
     policy_engine_packages_upgrade_007_008()
     user_account_upgrades_007_008()
+
 
 def catalog_upgrade_007_008():
     from anchore_engine.db import session_scope
@@ -557,7 +573,8 @@ def catalog_upgrade_007_008():
             except Exception as e:
                 log.err('failed to perform DB upgrade on {} adding column - exception: {}'.format(table, str(e)))
                 raise Exception('failed to perform DB upgrade on {} adding column - exception: {}'.format(table, str(e)))
-        
+
+
 def policy_engine_packages_upgrade_007_008():
     from anchore_engine.db import session_scope, ImagePackage, ImageNpm, ImageGem, Image
     if True:
@@ -601,7 +618,6 @@ def policy_engine_packages_upgrade_007_008():
                     log.err('failed to perform DB upgrade on {} adding column - exception: {}'.format(table, str(e)))
                     raise Exception('failed to perform DB upgrade on {} adding column - exception: {}'.format(table, str(e)))
 
-
         # populate the new columns
         log.err("updating new column (pkg_path) - this may take a while")
         for table in ['image_packages', 'image_package_vulnerabilities']:
@@ -611,8 +627,7 @@ def policy_engine_packages_upgrade_007_008():
                 startts = time.time()
                 rc = engine.execute("UPDATE {} set pkg_path='pkgdb' where pkg_path is null".format(table))
                 log.err("updated {} records in {} (time={}), performing next range".format(rc.rowcount, table, time.time() - startts))
-                done=True
-
+                done = True
 
         with session_scope() as dbsession:
             db_image_ids = dbsession.query(Image.id).distinct().all()
@@ -667,7 +682,6 @@ def policy_engine_packages_upgrade_007_008():
             engine.execute(command)
             cmdcount = cmdcount + 1
 
-
         log.err("converting ImageNpm and ImageGem records into ImagePackage records - this may take a while")
         # migrate ImageNpm and ImageGem records into ImagePackage records
         with session_scope() as dbsession:
@@ -675,7 +689,6 @@ def policy_engine_packages_upgrade_007_008():
             total_gems = dbsession.query(ImageGem).count()
 
         log.err("will migrate {} image npm records".format(total_npms))
-
 
         npms = []
         chunk_size = 8192
@@ -824,7 +837,6 @@ def db_upgrade_008_009():
             "ALTER TABLE image_gems add column IF NOT EXISTS seq_id int DEFAULT nextval('image_gems_seq_id_seq')",
             "CREATE INDEX IF NOT EXISTS idx_gem_seq ON image_gems using btree (seq_id)",
 
-
             # This is a duplicate action from the updated 0.0.8 upgrade, effectively a no-op if that upgrade was already run
             "ALTER TABLE image_packages ALTER COLUMN origin TYPE varchar",
 
@@ -925,6 +937,7 @@ def registry_name_upgrade_010_011():
     # populate new column
     rc = engine.execute("UPDATE registries set registry_name=registry where registry_name is null")
 
+
 def fixed_artifacts_upgrade_010_011():
     """
     Runs upgrade to add the 'fix_observed_at' column to fixed_artifacts records
@@ -959,6 +972,7 @@ def fixed_artifacts_upgrade_010_011():
 
     # populate new column
     rc = engine.execute("UPDATE feed_data_vulnerabilities_fixed_artifacts set fix_observed_at=updated_at where fix_observed_at is null and version!='None'")
+
 
 def update_users_010_011():
     """
@@ -1016,6 +1030,7 @@ def db_upgrade_010_011():
     fixed_artifacts_upgrade_010_011()
     update_users_010_011()
 
+
 def db_upgrade_package_size_011_012():
     """
     Update the column type for image package size from int to bigint
@@ -1043,24 +1058,65 @@ def event_type_index_upgrade_011_012():
 
     log.err("creating new column index")
     engine.execute("CREATE INDEX IF NOT EXISTS ix_type ON events using btree (type)")
-    
+
+
 def db_upgrade_011_012():
     event_type_index_upgrade_011_012()
     db_upgrade_package_size_011_012()
+
+
+def upgrade_feed_groups_013():
+    log.err('Upgrading feed and feed group schemas to add enabled flags')
+
+    from anchore_engine.db import session_scope
+    from anchore_engine.services.policy_engine.engine.feeds import sync
+
+    engine = anchore_engine.db.entities.common.get_engine()
+
+    # Add constraints and index
+    log.err('Updating feeds table to have enabled flag')
+    engine.execute("ALTER TABLE feeds ADD COLUMN IF NOT EXISTS enabled boolean")
+    engine.execute("UPDATE feeds set enabled = TRUE")
+
+    log.err('Updating feed_groups table to have enabled flag')
+    engine.execute("ALTER TABLE feed_groups ADD COLUMN IF NOT EXISTS enabled boolean")
+    engine.execute("UPDATE feed_groups set enabled = TRUE")
+
+    log.err('Updating feed groups table to have count for each group')
+    engine.execute("ALTER TABLE feed_groups ADD COLUMN IF NOT EXISTS count bigint")
+
+    log.err('Updating feed groups table to have last_update for each group')
+    engine.execute("ALTER TABLE feed_groups ADD COLUMN IF NOT EXISTS last_update timestamp")
+    engine.execute("UPDATE feed_groups set last_update = last_sync where last_update is NULL")
+
+    # Update the counts
+    sync.DataFeeds.update_counts()
+
+
+def db_upgrade_012_013():
+    """
+    Upgrade schema from 0.0.12 --> 0.0.13
+
+    :return:
+    """
+
+    upgrade_feed_groups_013()
+
 
 # Global upgrade definitions. For a given version these will be executed in order of definition here
 # If multiple functions are defined for a version pair, they will be executed in order.
 # If any function raises and exception, the upgrade is failed and halted.
 upgrade_functions = (
-    (('0.0.1', '0.0.2'), [ db_upgrade_001_002 ]),
-    (('0.0.2', '0.0.3'), [ db_upgrade_002_003 ]),
-    (('0.0.3', '0.0.4'), [ db_upgrade_003_004 ]),
-    (('0.0.4', '0.0.5'), [ db_upgrade_004_005 ]),
-    (('0.0.5', '0.0.6'), [ db_upgrade_005_006 ]),
-    (('0.0.6', '0.0.7'), [ db_upgrade_006_007 ]),
-    (('0.0.7', '0.0.8'), [ db_upgrade_007_008 ]),
-    (('0.0.8', '0.0.9'), [ db_upgrade_008_009 ]),
-    (('0.0.9', '0.0.10'), [ db_upgrade_009_010 ]),
-    (('0.0.10', '0.0.11'), [ db_upgrade_010_011 ]),
-    (('0.0.11', '0.0.12'), [ db_upgrade_011_012 ])
+    (('0.0.1', '0.0.2'), [db_upgrade_001_002]),
+    (('0.0.2', '0.0.3'), [db_upgrade_002_003]),
+    (('0.0.3', '0.0.4'), [db_upgrade_003_004]),
+    (('0.0.4', '0.0.5'), [db_upgrade_004_005]),
+    (('0.0.5', '0.0.6'), [db_upgrade_005_006]),
+    (('0.0.6', '0.0.7'), [db_upgrade_006_007]),
+    (('0.0.7', '0.0.8'), [db_upgrade_007_008]),
+    (('0.0.8', '0.0.9'), [db_upgrade_008_009]),
+    (('0.0.9', '0.0.10'), [db_upgrade_009_010]),
+    (('0.0.10', '0.0.11'), [db_upgrade_010_011]),
+    (('0.0.11', '0.0.12'), [db_upgrade_011_012]),
+    (('0.0.12', '0.0.13'), [db_upgrade_012_013])
 )

--- a/anchore_engine/services/apiext/api/controllers/system.py
+++ b/anchore_engine/services/apiext/api/controllers/system.py
@@ -41,7 +41,7 @@ def make_response_service(user_auth, service_record, params):
     for removekey in ['record_state_val', 'record_state_key']:
         ret.pop(removekey, None)
 
-    return (ret)
+    return ret
 
 
 def ping():
@@ -69,7 +69,7 @@ def version_noop():
     return '', 200
 
 
-@authorizer.requires([]) # Any authenticated user
+@authorizer.requires([])  # Any authenticated user
 def get_status():
     """
     GET /status
@@ -90,7 +90,7 @@ def get_status():
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
         httpcode = return_object['httpcode']
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @authorizer.requires([])
@@ -132,15 +132,15 @@ def get_service_detail():
                     pass
 
                 # Bring back when eventing subsystem is utilized
-                #service_detail['error_event'] = []
-                #try:
+                # service_detail['error_event'] = []
+                # try:
                 #    events = catalog.get_event(user_auth)
                 #    for event in events:
                 #        el = {}
                 #        for k in ['message_ts', 'hostId', 'message', 'level']:
                 #            el[k] = event[k]
                 #        service_detail['error_event'].append(el)
-                #except:
+                # except:
                 #    pass
                 httpcode = 200
 
@@ -154,7 +154,7 @@ def get_service_detail():
     except Exception as err:
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @authorizer.requires([ActionBoundPermission(domain=GLOBAL_RESOURCE_DOMAIN)])
@@ -182,7 +182,8 @@ def list_services():
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
         httpcode = return_object['httpcode']
 
-    return (return_object, httpcode)
+    return return_object, httpcode
+
 
 @authorizer.requires([ActionBoundPermission(domain=GLOBAL_RESOURCE_DOMAIN)])
 def get_services_by_name(servicename):
@@ -201,7 +202,7 @@ def get_services_by_name(servicename):
     return_object = []
     httpcode = 500
     try:
-        client = CatalogClient(user=user_auth[0], password=user_auth[1])
+        client = internal_client_for(CatalogClient, ApiRequestContextProxy.namespace())
         service_records = client.get_service(servicename=servicename)
         for service_record in service_records:
             return_object.append(make_response_service(user_auth, service_record, params))
@@ -211,7 +212,7 @@ def get_services_by_name(servicename):
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
         httpcode = return_object['httpcode']
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @authorizer.requires([ActionBoundPermission(domain=GLOBAL_RESOURCE_DOMAIN)])
@@ -241,7 +242,7 @@ def get_services_by_name_and_host(servicename, hostid):
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
         httpcode = return_object['httpcode']
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @authorizer.requires([ActionBoundPermission(domain=GLOBAL_RESOURCE_DOMAIN)])
@@ -267,7 +268,8 @@ def delete_service(servicename, hostid):
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
         httpcode = return_object['httpcode']
 
-    return (return_object, httpcode)
+    return return_object, httpcode
+
 
 @authorizer.requires([])
 def get_system_feeds():
@@ -284,7 +286,8 @@ def get_system_feeds():
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
         httpcode = return_object['httpcode']
 
-    return (return_object, httpcode)    
+    return return_object, httpcode
+
 
 @authorizer.requires([ActionBoundPermission(domain=GLOBAL_RESOURCE_DOMAIN)])
 def post_system_feeds(flush=False):
@@ -302,7 +305,68 @@ def post_system_feeds(flush=False):
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
         httpcode = return_object['httpcode']
 
-    return (return_object, httpcode)    
+    return return_object, httpcode
+
+
+@authorizer.requires([ActionBoundPermission(domain=GLOBAL_RESOURCE_DOMAIN)])
+def toggle_feed_enabled(feed, enabled):
+    httpcode = 500
+    try:
+        p_client = internal_client_for(PolicyEngineClient, userId=ApiRequestContextProxy.namespace())
+        return_object = p_client.toggle_feed_enabled(feed, enabled)
+        if return_object is not None:
+            httpcode = 200
+    except Exception as err:
+        return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
+        httpcode = return_object['httpcode']
+
+    return return_object, httpcode
+
+
+@authorizer.requires([ActionBoundPermission(domain=GLOBAL_RESOURCE_DOMAIN)])
+def toggle_group_enabled(feed, group, enabled):
+    httpcode = 500
+    try:
+        p_client = internal_client_for(PolicyEngineClient, userId=ApiRequestContextProxy.namespace())
+        return_object = p_client.toggle_feed_group_enabled(feed, group, enabled)
+        if return_object is not None:
+            httpcode = 200
+    except Exception as err:
+        return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
+        httpcode = return_object['httpcode']
+
+    return return_object, httpcode
+
+
+@authorizer.requires([ActionBoundPermission(domain=GLOBAL_RESOURCE_DOMAIN)])
+def delete_feed(feed):
+    httpcode = 500
+    try:
+        p_client = internal_client_for(PolicyEngineClient, userId=ApiRequestContextProxy.namespace())
+        return_object = p_client.delete_feed(feed)
+        if return_object is not None:
+            httpcode = 200
+    except Exception as err:
+        return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
+        httpcode = return_object['httpcode']
+
+    return return_object, httpcode
+
+
+@authorizer.requires([ActionBoundPermission(domain=GLOBAL_RESOURCE_DOMAIN)])
+def delete_feed_group(feed, group):
+    httpcode = 500
+    try:
+        p_client = internal_client_for(PolicyEngineClient, userId=ApiRequestContextProxy.namespace())
+        return_object = p_client.delete_feed_group(feed, group)
+        if return_object is not None:
+            httpcode = 200
+    except Exception as err:
+        return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
+        httpcode = return_object['httpcode']
+
+    return return_object, httpcode
+
 
 @authorizer.requires([])
 def describe_policy():
@@ -319,6 +383,7 @@ def describe_policy():
         httpcode = return_object['httpcode']
 
     return return_object, httpcode
+
 
 @authorizer.requires([])
 def describe_error_codes():

--- a/anchore_engine/services/apiext/swagger/swagger.yaml
+++ b/anchore_engine/services/apiext/swagger/swagger.yaml
@@ -1278,7 +1278,7 @@ paths:
       tags:
       - System
       summary: "list feeds operations and information"
-      description: ""
+      description: "Return a list of feed and their groups along with update and record count information. This data reflects the state of the policy engine, not the upstream feed service itself."
       operationId: "get_system_feeds"
       x-anchore-authz-action: listFeeds
       responses:
@@ -1297,7 +1297,7 @@ paths:
       tags:
       - System
       summary: "trigger feeds operations"
-      description: ""
+      description: "Execute a synchronous feed sync operation. The response will block until complete, then return the result summary."
       operationId: "post_system_feeds"
       x-anchore-authz-action: updateFeeds
       parameters:
@@ -1321,7 +1321,122 @@ paths:
           schema:
             $ref: "#/definitions/ApiErrorResponse"
       x-swagger-router-controller: "anchore_engine.services.apiext.api.controllers.system"
-
+  /system/feeds/{feed}:
+    put:
+      tags:
+      - System
+      x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.system
+      operationId: toggle_feed_enabled
+      x-anchore-authz-action: updateFeeds
+      description: "Disable the feed so that it does not sync on subsequent sync operations"
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - name: feed
+          in: path
+          required: true
+          type: string
+        - name: enabled
+          type: boolean
+          required: true
+          in: query
+      responses:
+        200:
+          description: "FeedInfo"
+          schema:
+            $ref: "#/definitions/FeedMetadata"
+        500:
+          description: "Internal server error processing the request. Retry expected"
+        400:
+          description: "Bad request, fix and resend"
+    delete:
+      tags:
+      - System
+      x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.system
+      operationId: delete_feed
+      x-anchore-authz-action: updateFeeds
+      description: "Delete the groups and data for the feed and disable the feed itself"
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - name: feed
+          in: path
+          required: true
+          type: string
+      responses:
+        200:
+          description: "Successfully deleted"
+        500:
+          description: "Internal server error processing the request. Retry expected"
+        404:
+          description: "Not found"
+  /system/feeds/{feed}/{group}:
+    put:
+      tags:
+      - System
+      x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.system
+      x-anchore-authz-action: updateFeeds
+      operationId: toggle_group_enabled
+      description: "Disable a specific group within a feed to not sync"
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - name: feed
+          in: path
+          required: true
+          type: string
+        - name: group
+          in: path
+          type: string
+          required: true
+        - name: enabled
+          type: boolean
+          required: true
+          in: query
+      responses:
+        200:
+          description: "FeedInfo listing"
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/FeedMetadata"
+        500:
+          description: "Internal server error processing the request. Retry expected"
+        400:
+          description: "Bad request, fix and resend"
+    delete:
+      tags:
+      - System
+      x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.system
+      operationId: delete_feed_group
+      x-anchore-authz-action: updateFeeds
+      description: "Delete the group data and disable the group itself"
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - name: feed
+          in: path
+          required: true
+          type: string
+        - name: group
+          in: path
+          type: string
+          required: true
+      responses:
+        200:
+          description: "Successfully deleted"
+        500:
+          description: "Internal server error processing the request. Retry expected"
+        404:
+          description: "Not found"
   /system/services:
     get:
       tags:

--- a/anchore_engine/services/policy_engine/api/controllers/feeds.py
+++ b/anchore_engine/services/policy_engine/api/controllers/feeds.py
@@ -2,51 +2,80 @@ from flask import jsonify
 
 from anchore_engine.common.errors import AnchoreError
 from anchore_engine.apis.authorization import get_authorizer, INTERNAL_SERVICE_ALLOWED
+from anchore_engine.apis.exceptions import BadRequest, ConflictingRequest, ResourceNotFound, InternalError
 from anchore_engine.clients.services.simplequeue import LeaseAcquisitionFailedError, LeaseUnavailableError
 from anchore_engine.common.helpers import make_response_error
 from anchore_engine.services.policy_engine.api.models import FeedMetadata, FeedGroupMetadata
 from anchore_engine.services.policy_engine.engine.feeds import db, sync
 from anchore_engine.services.policy_engine.engine.tasks import FeedsUpdateTask
 from anchore_engine.subsys import logger as log
+from anchore_engine.db import FeedMetadata as DbFeedMetadata, FeedGroupMetadata as DbFeedGroupMetadata
 
 authorizer = get_authorizer()
 
 
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
-def list_feeds(include_counts=False):
+def list_feeds(include_counts=False, refresh_counts=False):
     """
     GET /feeds
+
+    :param include_counts (ignored since counts are handled in the record now)
+    :param refresh_counts: forcibly update the group counts (not normally necessary)
     :return:
     """
 
-    meta = db.get_all_feeds_detached()
-    response = []
+    if refresh_counts:
+        sync.DataFeeds.update_counts()
 
-    for feed in meta:
-        i = FeedMetadata()
-        i.name = feed.name
-        i.last_full_sync = feed.last_full_sync.isoformat() if feed.last_full_sync else None
-        i.created_at = feed.created_at.isoformat() if feed.created_at else None
-        i.updated_at = feed.last_update.isoformat() if feed.last_update else None
-        i.groups = []
-
-        for group in feed.groups:
-            g = FeedGroupMetadata()
-            g.name = group.name
-            g.last_sync = group.last_sync.isoformat() if group.last_sync else None
-            g.created_at = group.created_at.isoformat() if group.created_at else None
-
-            if include_counts:
-                # Compute count (this is slow)
-                g.record_count = sync.DataFeeds.records_for(i.name, g.name)
-            else:
-                g.record_count = None
-
-            i.groups.append(g.to_dict())
-
-        response.append(i.to_dict())
+    response = _marshall_feeds_response(refresh_counts)
 
     return jsonify(response)
+
+
+def _marshall_feeds_response(include_counts: bool):
+    response = []
+    meta = db.get_all_feeds_detached()
+
+    for feed in meta:
+        response.append(_marshall_feed_response(feed, include_counts))
+
+    return response
+
+
+def _marshall_feed_response(feed: DbFeedMetadata, include_counts=True):
+    if not feed:
+        return ValueError(feed)
+
+    i = FeedMetadata()
+    i.name = feed.name
+    i.last_full_sync = feed.last_full_sync.isoformat() if feed.last_full_sync else None
+    i.created_at = feed.created_at.isoformat() if feed.created_at else None
+    i.updated_at = feed.last_update.isoformat() if feed.last_update else None
+    i.enabled = feed.enabled
+    i.groups = []
+
+    for group in feed.groups:
+        i.groups.append(_marshall_group_response(group, include_counts=include_counts))
+
+    return i.to_dict()
+
+
+def _marshall_group_response(group: DbFeedGroupMetadata, include_counts=True):
+    if not group:
+        raise ValueError(group)
+
+    g = FeedGroupMetadata()
+    g.name = group.name
+    g.last_sync = group.last_sync.isoformat() if group.last_sync else None
+    g.created_at = group.created_at.isoformat() if group.created_at else None
+    g.updated_at = group.last_update.isoformat() if group.last_update else None
+    g.enabled = group.enabled
+    if include_counts:
+        g.record_count = group.count
+    else:
+        g.record_count = None
+
+    return g.to_dict()
 
 
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
@@ -72,3 +101,97 @@ def sync_feeds(sync=True, force_flush=False):
             return jsonify(make_response_error(e, in_httpcode=500)), 500
 
     return jsonify(result), 200
+
+
+@authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
+def toggle_feed_enabled(feed, enabled):
+    if type(enabled) != bool:
+        raise BadRequest(message='state must be a boolean', detail={'value': enabled})
+
+    session = db.get_session()
+    try:
+        f = db.set_feed_enabled(session, feed, enabled)
+        session.flush()
+
+        updated = _marshall_feed_response(f)
+        session.commit()
+
+        return jsonify(updated), 200
+    except Exception:
+        log.error('Could not update feed enabled status')
+        session.rollback()
+        raise
+
+
+@authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
+def toggle_group_enabled(feed, group, enabled):
+    if type(enabled) != bool:
+        raise BadRequest(message='state must be a boolean', detail={'value': enabled})
+
+    session = db.get_session()
+    try:
+        g = db.set_feed_group_enabled(session, feed, group, enabled)
+        session.flush()
+
+        grp = _marshall_group_response(g)
+        session.commit()
+
+        return jsonify(grp), 200
+    except Exception:
+        log.error('Could not update feed group enabled status')
+        session.rollback()
+        raise
+
+
+@authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
+def delete_feed(feed):
+    session = db.get_session()
+    try:
+        f = db.lookup_feed(db_session=session, feed_name=feed)
+        if not f:
+            raise ResourceNotFound(resource=feed, detail={})
+        elif f.enabled:
+            raise ConflictingRequest(message='Cannot delete an enabled feed. Disable the feed first', detail={})
+    finally:
+        session.rollback()
+
+    try:
+        sync.DataFeeds.delete_feed(feed)
+    except Exception:
+        log.error('Could not update feed group enabled status')
+        raise
+
+    session = db.get_session()
+    try:
+        fd = db.get_feed_json(db_session=session, feed_name=feed)
+        return jsonify(fd)
+    except Exception:
+        raise
+
+
+@authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
+def delete_group(feed, group):
+    session = db.get_session()
+    try:
+        f = db.lookup_feed_group(db_session=session, feed_name=feed, group_name=group)
+        if not f:
+            raise ResourceNotFound(resource=feed, detail={})
+        elif f.enabled:
+            raise ConflictingRequest(message='Cannot delete an enabled feed group. Disable the feed group first', detail={})
+    except KeyError as e:
+        raise ResourceNotFound(str(e), detail={})
+    finally:
+        session.rollback()
+
+    try:
+        g = sync.DataFeeds.delete_feed_group(feed_name=feed, group_name=group)
+        log.info('Flushed group records {}'.format(g))
+        if g:
+            return jsonify(_marshall_group_response(g)), 200
+        else:
+            raise ResourceNotFound(group, detail={})
+    except KeyError as e:
+        raise ResourceNotFound(resource=str(e), detail={'feed': feed, 'group': group})
+    except Exception:
+        log.error('Could not flush feed group {}/{}'.format(feed, group))
+        raise

--- a/anchore_engine/services/policy_engine/api/controllers/feeds.py
+++ b/anchore_engine/services/policy_engine/api/controllers/feeds.py
@@ -15,7 +15,7 @@ authorizer = get_authorizer()
 
 
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
-def list_feeds(include_counts=False, refresh_counts=False):
+def list_feeds(refresh_counts=False):
     """
     GET /feeds
 
@@ -27,22 +27,22 @@ def list_feeds(include_counts=False, refresh_counts=False):
     if refresh_counts:
         sync.DataFeeds.update_counts()
 
-    response = _marshall_feeds_response(refresh_counts)
+    response = _marshall_feeds_response()
 
     return jsonify(response)
 
 
-def _marshall_feeds_response(include_counts: bool):
+def _marshall_feeds_response():
     response = []
     meta = db.get_all_feeds_detached()
 
     for feed in meta:
-        response.append(_marshall_feed_response(feed, include_counts))
+        response.append(_marshall_feed_response(feed))
 
     return response
 
 
-def _marshall_feed_response(feed: DbFeedMetadata, include_counts=True):
+def _marshall_feed_response(feed: DbFeedMetadata):
     if not feed:
         return ValueError(feed)
 
@@ -55,12 +55,12 @@ def _marshall_feed_response(feed: DbFeedMetadata, include_counts=True):
     i.groups = []
 
     for group in feed.groups:
-        i.groups.append(_marshall_group_response(group, include_counts=include_counts))
+        i.groups.append(_marshall_group_response(group))
 
     return i.to_dict()
 
 
-def _marshall_group_response(group: DbFeedGroupMetadata, include_counts=True):
+def _marshall_group_response(group: DbFeedGroupMetadata):
     if not group:
         raise ValueError(group)
 
@@ -70,11 +70,7 @@ def _marshall_group_response(group: DbFeedGroupMetadata, include_counts=True):
     g.created_at = group.created_at.isoformat() if group.created_at else None
     g.updated_at = group.last_update.isoformat() if group.last_update else None
     g.enabled = group.enabled
-    if include_counts:
-        g.record_count = group.count
-    else:
-        g.record_count = None
-
+    g.record_count = group.count
     return g.to_dict()
 
 

--- a/anchore_engine/services/policy_engine/api/models/feed_group_metadata.py
+++ b/anchore_engine/services/policy_engine/api/models/feed_group_metadata.py
@@ -15,7 +15,7 @@ class FeedGroupMetadata(Model):
     Do not edit the class manually.
     """
 
-    def __init__(self, name=None, created_at=None, last_sync=None, record_count=None):  # noqa: E501
+    def __init__(self, name=None, created_at=None, last_sync=None, record_count=None, enabled=None, updated_at=None):  # noqa: E501
         """FeedGroupMetadata - a model defined in Swagger
 
         :param name: The name of this FeedGroupMetadata.  # noqa: E501
@@ -31,20 +31,26 @@ class FeedGroupMetadata(Model):
             'name': str,
             'created_at': datetime,
             'last_sync': datetime,
-            'record_count': int
+            'record_count': int,
+            'enabled': bool,
+            'updated_at': datetime
         }
 
         self.attribute_map = {
             'name': 'name',
             'created_at': 'created_at',
             'last_sync': 'last_sync',
-            'record_count': 'record_count'
+            'record_count': 'record_count',
+            'enabled': 'enabled',
+            'updated_at': 'updated_at'
         }
 
         self._name = name
         self._created_at = created_at
         self._last_sync = last_sync
         self._record_count = record_count
+        self._enabled = enabled
+        self._updated_at = updated_at
 
     @classmethod
     def from_dict(cls, dikt):
@@ -140,3 +146,19 @@ class FeedGroupMetadata(Model):
         """
 
         self._record_count = record_count
+
+    @property
+    def enabled(self):
+        return self._enabled
+
+    @enabled.setter
+    def enabled(self, enabled):
+        self._enabled = enabled
+
+    @property
+    def updated_at(self):
+        return self._updated_at
+
+    @updated_at.setter
+    def updated_at(self, updated_at):
+        self._updated_at = updated_at

--- a/anchore_engine/services/policy_engine/api/models/feed_metadata.py
+++ b/anchore_engine/services/policy_engine/api/models/feed_metadata.py
@@ -16,7 +16,7 @@ class FeedMetadata(Model):
     Do not edit the class manually.
     """
 
-    def __init__(self, name=None, created_at=None, updated_at=None, groups=None, last_full_sync=None):  # noqa: E501
+    def __init__(self, name=None, created_at=None, updated_at=None, groups=None, last_full_sync=None, enabled=None):  # noqa: E501
         """FeedMetadata - a model defined in Swagger
 
         :param name: The name of this FeedMetadata.  # noqa: E501
@@ -35,7 +35,8 @@ class FeedMetadata(Model):
             'created_at': datetime,
             'updated_at': datetime,
             'groups': List[FeedGroupMetadata],
-            'last_full_sync': datetime
+            'last_full_sync': datetime,
+            'enabled': bool
         }
 
         self.attribute_map = {
@@ -43,7 +44,8 @@ class FeedMetadata(Model):
             'created_at': 'created_at',
             'updated_at': 'updated_at',
             'groups': 'groups',
-            'last_full_sync': 'last_full_sync'
+            'last_full_sync': 'last_full_sync',
+            'enabled': 'enabled'
         }
 
         self._name = name
@@ -51,6 +53,7 @@ class FeedMetadata(Model):
         self._updated_at = updated_at
         self._groups = groups
         self._last_full_sync = last_full_sync
+        self._enabled = enabled
 
     @classmethod
     def from_dict(cls, dikt):
@@ -173,3 +176,11 @@ class FeedMetadata(Model):
         """
 
         self._last_full_sync = last_full_sync
+
+    @property
+    def enabled(self):
+        return self._enabled
+
+    @enabled.setter
+    def enabled(self, enabled):
+        self._enabled = enabled

--- a/anchore_engine/services/policy_engine/engine/feeds/db.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/db.py
@@ -21,6 +21,45 @@ def lookup_feed_group(db_session, feed_name, group_name):
     return db_session.query(FeedGroupMetadata).filter_by(name=group_name, feed_name=feed_name).one_or_none()
 
 
+def set_feed_group_enabled(db_session, feed_name, group_name, is_enabled):
+    """
+    Update the group's enabled state
+
+    :param db_session: active db session to use
+    :param feed_name: string name of feed
+    :param group_name: string group name
+    :param is_enabled: boolean to set enabled flag
+    :return:
+    """
+    if db_session is None or not db_session.is_active:
+        raise ValueError('db_session must be an open, valid session')
+
+    meta = db_session.query(FeedGroupMetadata).filter_by(name=group_name, feed_name=feed_name).one_or_none()
+    if meta:
+        meta.enabled = is_enabled
+
+    return meta
+
+
+def set_feed_enabled(db_session, feed_name, is_enabled):
+    """
+    Update the group's enabled state
+
+    :param db_session: active db session to use
+    :param feed_name: string name of feed
+    :param is_enabled: boolean to set enabled flag
+    :return:
+    """
+    if db_session is None or not db_session.is_active:
+        raise ValueError('db_session must be an open, valid session')
+
+    meta = db_session.query(FeedMetadata).filter_by(name=feed_name).one_or_none()
+    if meta:
+        meta.enabled = is_enabled
+
+    return meta
+
+
 def get_feed_json(db_session, feed_name):
     cache = local_named_cache(cache_name)
     cached = cache.lookup(feed_name)

--- a/anchore_engine/services/policy_engine/swagger/swagger.yaml
+++ b/anchore_engine/services/policy_engine/swagger/swagger.yaml
@@ -459,7 +459,12 @@ paths:
         in: query
         required: false
         type: boolean
-        description: If set, include record counts for each group, this can incur a lot of latency in the response
+        description: If set, include record counts for each group.
+      - name: refresh_counts
+        in: query
+        required: false
+        type: boolean
+        description: If set, include record counts in response but also recalculate the counts. This is a more expensive operation.
       responses:
         200:
           description: "FeedInfo listing"
@@ -476,10 +481,14 @@ paths:
       produces:
       - "application/json"
       parameters:
-      - name: "force_flush"
-        in: "query"
+      - name: force_flush
+        in: query
         required: false
         type: boolean
+      - name: feed
+        in: query
+        required: false
+        type: string
       responses:
         200:
           description: "Processed successfully"
@@ -492,6 +501,110 @@ paths:
           description: "Internal server error processing the request. Retry expected"
         400:
           description: "Bad request, fix and resend"
+  /feeds/{feed}:
+    put:
+      x-swagger-router-controller: anchore_engine.services.policy_engine.api.controllers.feeds
+      operationId: toggle_feed_enabled
+      description: "Disable the feed so that it does not sync on subsequent sync operations"
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - name: feed
+          in: path
+          required: true
+          type: string
+        - name: enabled
+          type: boolean
+          required: true
+          in: query
+      responses:
+        200:
+          description: "FeedInfo"
+          schema:
+            $ref: "#/definitions/FeedMetadata"
+        500:
+          description: "Internal server error processing the request. Retry expected"
+        400:
+          description: "Bad request, fix and resend"
+    delete:
+      x-swagger-router-controller: anchore_engine.services.policy_engine.api.controllers.feeds
+      operationId: delete_feed
+      description: "Delete the groups and data for the feed and disable the feed itself"
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - name: feed
+          in: path
+          required: true
+          type: string
+      responses:
+        200:
+          description: "Successfully deleted"
+        500:
+          description: "Internal server error processing the request. Retry expected"
+        404:
+          description: "Not found"
+  /feeds/{feed}/{group}:
+    put:
+      x-swagger-router-controller: anchore_engine.services.policy_engine.api.controllers.feeds
+      operationId: toggle_group_enabled
+      description: "Disable a specific group within a feed to not sync"
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - name: feed
+          in: path
+          required: true
+          type: string
+        - name: group
+          in: path
+          type: string
+          required: true
+        - name: enabled
+          type: boolean
+          required: true
+          in: query
+      responses:
+        200:
+          description: "FeedInfo listing"
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/FeedMetadata"
+        500:
+          description: "Internal server error processing the request. Retry expected"
+        400:
+          description: "Bad request, fix and resend"
+    delete:
+      x-swagger-router-controller: anchore_engine.services.policy_engine.api.controllers.feeds
+      operationId: delete_group
+      description: "Delete the group data and disable the group itself"
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - name: feed
+          in: path
+          required: true
+          type: string
+        - name: group
+          in: path
+          type: string
+          required: true
+      responses:
+        200:
+          description: "Successfully deleted"
+        500:
+          description: "Internal server error processing the request. Retry expected"
+        404:
+          description: "Not found"
 definitions:
   Image:
     type: object
@@ -1155,6 +1268,8 @@ definitions:
       last_full_sync:
         type: string
         format: date-time
+      enabled:
+        type: boolean
   FeedGroupMetadata:
     type: object
     properties:
@@ -1168,6 +1283,8 @@ definitions:
         format: date-time
       record_count:
         type: integer
+      enabled:
+        type: boolean
   PolicyEvaluationCacheEnabledStatus:
     type: object
     description: The enabled status of policy evaluation caching for a specific policy engine instance

--- a/anchore_engine/version.py
+++ b/anchore_engine/version.py
@@ -1,2 +1,2 @@
 version="0.6.2-dev"
-db_version="0.0.12"
+db_version="0.0.13"


### PR DESCRIPTION
Adds APIs and controls for managing the feeds and groups that will be synced during a feed sync. Also optimizes the record count updates to ensure they can be returned on all calls without table scans.

Adds new 'enabled' field to the feed and feed_group db tables, bumps the db version and handles upgrades of those tables.
