### PR TITLE
bump urllib3 version to avoid CVE-2020-7212

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ toastedmarshmallow==2.15.2.post1
 treelib==1.5.5
 Twisted[tls]==19.10.0
 typing==3.7.4.1
-urllib3==1.25.7
+urllib3==1.25.8
 watchdog==0.9.0
 Werkzeug==0.16.0
 yosai==0.3.2


### PR DESCRIPTION

**What this PR does / why we need it**: The current pinned version of `urllib3` (`1.25.7`) has a recent vulnerability reported. This PR bumps that to the next bug-fix release that addresses CVE-2020-7212


**Which issue this PR fixes**  Fixes https://github.com/anchore/anchore-cli/issues/58

**Special notes**:


