### PR TITLE
lint: removes unnecesary use of parens on statements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ commands:
             - v1-dependencies-{{ .Branch }}-{{ checksum "requirements.txt" }}
       - run:
           name: run tests
-          command: make test-<< parameters.test_type >>
+          command: make << parameters.test_type >>
       - save_cache:
           paths:
             - ~/project/.tox
@@ -91,7 +91,16 @@ jobs:
     steps:
       - checkout
       - run_tests:
-          test_type: unit
+          test_type: test-unit
+
+  lint:
+    docker:
+      - image: circleci/python:3.6
+    environment: *global_environment_vars
+    steps:
+      - checkout
+      - run_tests:
+          test_type: lint
 
   integration_tests:
     docker:
@@ -105,7 +114,7 @@ jobs:
         environment:
           POSTGRES_PASSWORD: "postgres"
     resource_class: large
-    environment: 
+    environment:
       <<: *global_environment_vars
       ANCHORE_TEST_S3_ACCESS_KEY: "9EB92C7W61YPFQ6QLDOU"
       ANCHORE_TEST_S3_SECRET_KEY: "TuHo2UbBx+amD3YiCeidy+R3q82MPTPiyd+dlW+s"
@@ -124,7 +133,7 @@ jobs:
     steps:
       - checkout
       - run_tests:
-          test_type: integration
+          test_type: test-integration
 
   build:
     docker:
@@ -160,7 +169,7 @@ jobs:
       - <<: *load_docker_image
       - <<: *ssh_forward_port
       - run_tests:
-          test_type: functional
+          test_type: test-functional
 
   e2e_tests:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,11 +207,13 @@ workflows:
   default_workflow:
     jobs:
       - unit_tests
+      - lint
       - integration_tests:
           requires:
             - unit_tests
       - build:
           requires:
+            - lint
             - unit_tests
       - functional_tests:
           requires:
@@ -240,8 +242,12 @@ workflows:
 
   rc_image_workflow:
     jobs:
+      - lint:
+          filters: *filter_rc_tags
       - build:
           filters: *filter_rc_tags
+          requires:
+            - lint
       - e2e_tests:
           name: rc_e2e_tests
           context: e2e-testing
@@ -288,13 +294,17 @@ workflows:
     jobs:
       - unit_tests:
           filters: *filter_rebuild_tags
+      - lint:
+          filters: *filter_rebuild_tags
       - integration_tests:
           filters: *filter_rebuild_tags
           requires:
+            - lint
             - unit_tests
       - build:
           filters: *filter_rebuild_tags
           requires:
+            - lint
             - unit_tests
       - functional_tests:
           filters: *filter_rebuild_tags

--- a/anchore_engine/analyzers/utils.py
+++ b/anchore_engine/analyzers/utils.py
@@ -41,7 +41,7 @@ def init_analyzer_cmdline(argv, name):
             ret['analyzer_config'] = anchore_analyzer_config[name]
 
     ret['name'] = name
-    
+
     with open(argv[0], 'r') as FH:
         ret['selfcsum'] = hashlib.md5(FH.read().encode('utf-8')).hexdigest()
 
@@ -97,7 +97,7 @@ def run_tarfile_member_function(tarfilename, *args, member_regexp=None, func=_de
 
                 ret[member.name] = func(tfl, member, *args, **kwargs)
 
-    return ret    
+    return ret
 
 def run_tarfile_function(tarfile, func=None, *args, **kwargs):
 
@@ -150,7 +150,7 @@ def get_distro_from_squashtar(squashtar, unpackdir=None):
             "debian_version": _search_tarfilenames_for_file(tarfilenames, "etc/debian_version"),
         }
 
-        
+
         success = False
         if not success and metamap['os-release'] in tarfilenames:
             try:
@@ -173,7 +173,7 @@ def get_distro_from_squashtar(squashtar, unpackdir=None):
             except:
                 success = False
 
-        if not success and metamap['system-release-cpe'] in tarfilenames: 
+        if not success and metamap['system-release-cpe'] in tarfilenames:
             try:
                 with tfl.extractfile(tfl.getmember(metamap['system-release-cpe'])) as FH:
                     for l in FH.readlines():
@@ -199,7 +199,7 @@ def get_distro_from_squashtar(squashtar, unpackdir=None):
             except:
                 success = False
 
-        if not success and metamap["redhat-release"] in tarfilenames: 
+        if not success and metamap["redhat-release"] in tarfilenames:
             try:
                 with tfl.extractfile(tfl.getmember(metamap["redhat-release"])) as FH:
                     for l in FH.readlines():
@@ -250,7 +250,7 @@ def get_distro_from_squashtar(squashtar, unpackdir=None):
             except:
                 success = False
 
-        if meta['DISTRO'] == 'debian' and not meta['DISTROVERS'] and metamap["debian_version"] in tarfilenames: 
+        if meta['DISTRO'] == 'debian' and not meta['DISTROVERS'] and metamap["debian_version"] in tarfilenames:
             try:
                 with tfl.extractfile(tfl.getmember(metamap["debian_version"])) as FH:
                     meta['DISTRO'] = 'debian'
@@ -276,7 +276,7 @@ def get_distro_from_squashtar(squashtar, unpackdir=None):
     return meta
 
 def grouper(inlist, chunksize):
-    return inlist[pos:pos + chunksize] for pos in range(0, len(inlist), chunksize)
+    return (inlist[pos:pos + chunksize] for pos in range(0, len(inlist), chunksize))
 
 
 ### Metadata helpers
@@ -347,7 +347,7 @@ def _get_extractable_member(tfl, member, deref_symlink=False, alltfiles={}, memb
 
     if not memberhash:
         memberhash = get_memberhash(tfl)
-        
+
     if deref_symlink and member.issym():
         if not alltfiles:
             alltfiles = {}
@@ -363,7 +363,7 @@ def _get_extractable_member(tfl, member, deref_symlink=False, alltfiles={}, memb
 
         while not done and count < max_links:
             newmember = None
-            
+
             # attempt to get the softlink destination
             if nmember.linkname[1:] in alltfiles:
                 #newmember = tfl.getmember(nmember.linkname[1:])
@@ -477,17 +477,17 @@ def get_checksums_from_squashtar(squashtar, csums=['sha256', 'md5']):
             if not fkey or fkey[0] != '/':
                 fkey = "/{}".format(filename)
             if fkey not in allfiles:
-                allfiles[fkey] = results[filename]        
+                allfiles[fkey] = results[filename]
     except Exception as err:
         print("EXC: {}".format(err))
 
     return allfiles
-        
+
 def get_files_from_squashtar(squashtar, unpackdir=None):
 
     filemap = {}
     allfiles = {}
-    
+
     tfl = None
     try:
         with tarfile.open(squashtar, mode='r', format=tarfile.PAX_FORMAT) as tfl:
@@ -500,10 +500,10 @@ def get_files_from_squashtar(squashtar, unpackdir=None):
                     filename = "/"
                 if not re.match("^/", filename):
                     filename = "/{}".format(filename)
-                
+
                 finfo = {}
                 finfo['name'] = filename
-                finfo['fullpath'] = filename 
+                finfo['fullpath'] = filename
                 finfo['size'] = member.size
                 #finfo['mode'] = member.mode
                 modemask = 0o00000000
@@ -553,7 +553,7 @@ def get_files_from_squashtar(squashtar, unpackdir=None):
                         dstlist = finfo['linkdst'].split('/')
                         srclist = finfo['name'].split('/')
                         srcpath = srclist[0:-1]
-                        fullpath = os.path.normpath(os.path.join(finfo['linkdst'], filename)) 
+                        fullpath = os.path.normpath(os.path.join(finfo['linkdst'], filename))
                     finfo['linkdst_fullpath'] = fullpath
 
                 fullpath = finfo['fullpath']
@@ -610,7 +610,7 @@ def rpm_get_all_packages_from_squashtar(unpackdir, squashtar):
         print(err.output)
         raise ValueError("could not get package list from RPM database: " + str(err))
 
-    return rpms, rpmdbdir 
+    return rpms, rpmdbdir
 
 def rpm_get_all_pkgfiles(unpackdir):
     rpmfiles = {}
@@ -667,7 +667,7 @@ def java_prepdb_from_squashtar(unpackdir, squashtar, java_file_regexp):
         try:
             os.makedirs(javatmpdir)
         except Exception as err:
-            raise (err)
+            raise err
 
     ret = os.path.join(javatmpdir, "rootfs")
     javafilepatt = re.compile(java_file_regexp)
@@ -683,7 +683,7 @@ def java_prepdb_from_squashtar(unpackdir, squashtar, java_file_regexp):
             tfl.extractall(path=os.path.join(javatmpdir, "rootfs"), members=javamembers)
         ret = os.path.join(javatmpdir, "rootfs")
 
-    return ret    
+    return ret
 
 def python_prepdb_from_squashtar(unpackdir, squashtar, py_file_regexp):
     pytmpdir = os.path.join(unpackdir, "pytmp")
@@ -691,7 +691,7 @@ def python_prepdb_from_squashtar(unpackdir, squashtar, py_file_regexp):
         try:
             os.makedirs(pytmpdir)
         except Exception as err:
-            raise (err)
+            raise err
 
     ret = os.path.join(pytmpdir, "rootfs")
 
@@ -718,7 +718,7 @@ def python_prepdb_from_squashtar(unpackdir, squashtar, py_file_regexp):
             tfl.extractall(path=os.path.join(pytmpdir, "rootfs"), members=pymembers)
         ret = os.path.join(pytmpdir, "rootfs")
 
-    return ret    
+    return ret
 
 def apk_prepdb_from_squashtar(unpackdir, squashtar):
     apktmpdir = os.path.join(unpackdir, "apktmp")
@@ -726,7 +726,7 @@ def apk_prepdb_from_squashtar(unpackdir, squashtar):
         try:
             os.makedirs(apktmpdir)
         except Exception as err:
-            raise (err)
+            raise err
 
     ret = os.path.join(apktmpdir, "rootfs")
 
@@ -740,7 +740,7 @@ def apk_prepdb_from_squashtar(unpackdir, squashtar):
             tfl.extractall(path=os.path.join(apktmpdir, "rootfs"), members=apkmembers)
         ret = os.path.join(apktmpdir, "rootfs")
 
-    return ret    
+    return ret
 
 def dpkg_prepdb_from_squashtar(unpackdir, squashtar):
     dpkgtmpdir = os.path.join(unpackdir, "dpkgtmp")
@@ -748,7 +748,7 @@ def dpkg_prepdb_from_squashtar(unpackdir, squashtar):
         try:
             os.makedirs(dpkgtmpdir)
         except Exception as err:
-            raise (err)
+            raise err
 
     ret = os.path.join(dpkgtmpdir, "rootfs")
 
@@ -773,7 +773,7 @@ def rpm_prepdb_from_squashtar(unpackdir, squashtar):
         try:
             os.makedirs(rpmtmpdir)
         except Exception as err:
-            raise (err)
+            raise err
 
     ret = os.path.join(rpmtmpdir, "rpmdbfinal")
 
@@ -790,7 +790,7 @@ def rpm_prepdb_from_squashtar(unpackdir, squashtar):
 
         rc = rpm_prepdb(rpmtmpdir)
         ret = os.path.join(rpmtmpdir, "rpmdbfinal") #, "var", "lib", "rpm")
-        
+
     return ret
 
 def rpm_prepdb(unpackdir):
@@ -825,7 +825,7 @@ def dpkg_get_all_pkgfiles_from_squashtar(unpackdir, squashtar):
             l = str(l, 'utf-8')
             #l = l.decode('utf8')
             allfiles[l] = True
-            
+
     except Exception as err:
         print("Could not run command: " + str(' '.join(cmd)))
         print("Exception: " + str(err))
@@ -834,19 +834,19 @@ def dpkg_get_all_pkgfiles_from_squashtar(unpackdir, squashtar):
 
     return allfiles
 
-def dpkg_get_all_packages_detail_from_squashtar(unpackdir, squashtar):    
+def dpkg_get_all_packages_detail_from_squashtar(unpackdir, squashtar):
     all_packages = {}
     actual_packages = {}
     all_packages_simple = {}
     other_packages = {}
-    
+
     dpkg_db_base_dir = dpkg_prepdb_from_squashtar(unpackdir, squashtar)
     dpkgdbdir = os.path.join(dpkg_db_base_dir, "var", "lib", "dpkg")
     dpkgdocsdir = os.path.join(dpkg_db_base_dir, "usr", "share", "doc")
     dpkgstatusddir = os.path.join(dpkg_db_base_dir, "var", "lib", "dpkg", "status.d")
 
     package_tuples = {}
-    
+
     cmd = ["dpkg-query", "--admindir={}".format(dpkgdbdir), "-W", "-f="+"${Package}|ANCHORETOK|${Version}|ANCHORETOK|${Architecture}|ANCHORETOK|${Installed-Size}|ANCHORETOK|${source:Package}|ANCHORETOK|${source:Version}|ANCHORETOK|${Maintainer}|ANCHORETOK|${db:Status-Abbrev}\\n"]
     try:
         sout = subprocess.check_output(cmd)
@@ -859,7 +859,7 @@ def dpkg_get_all_packages_detail_from_squashtar(unpackdir, squashtar):
                 # skip this package if the status is returned, and is not reporting as explicitly installed (ii*)
                 continue
             if p not in package_tuples:
-                package_tuples[p] = (p,v,arch,rawsize,sp,sv,vendor,status) 
+                package_tuples[p] = (p,v,arch,rawsize,sp,sv,vendor,status)
 
     except Exception as err:
         print("Could not run command: {} - exception: {}".format(str(cmd), err))
@@ -968,7 +968,7 @@ def deb_copyright_getlics(licfile):
     return ret
 
 def apkg_parse_apkdb(apkdbfh):
-    apkgs = {}                
+    apkgs = {}
     apkg = {
         'version':"N/A",
         'sourcepkg':"N/A",
@@ -1024,7 +1024,7 @@ def apkg_parse_apkdb(apkdbfh):
                         (vers, rel) = vpatt.group(1, 2)
                     else:
                         vers = v
-                        rel = "N/A"                    
+                        rel = "N/A"
                     apkg['version'] = vers
                     apkg['release'] = rel
                 elif k == 'm':
@@ -1068,7 +1068,7 @@ def apkg_get_all_pkgfiles_from_squashtar(unpackdir, squashtar):
 
 def apkg_get_all_pkgfiles(unpackdir):
     apkdb = '/'.join([unpackdir, 'rootfs/lib/apk/db/installed'])
-    
+
     if not os.path.exists(apkdb):
         raise ValueError("cannot locate APK installed DB '"+str(apkdb)+"'")
 
@@ -1321,7 +1321,7 @@ def rpm_get_file_package_metadata_from_squashtar(unpackdir, squashtar):
 
                         if fname not in result:
                             result[fname] = []
-                            
+
                         el = copy.deepcopy(record_template)
                         el.update({'digest': fdigest or None, 'digestalgo': fdigestalgo or None, 'mode': fmode or None, 'group': fgroup or None, 'user': fuser or None, 'size': fsize or None, 'package': fpackage or None, 'conffile': cfile})
                         result[fname].append(el)
@@ -1342,10 +1342,10 @@ def dpkg_get_file_package_metadata_from_squashtar(unpackdir, squashtar):
     record_template = {'digest': None, 'digestalgo': None, 'mode': None, 'group': None, 'user': None, 'size': None, 'package': None, 'conffile': False}
 
     conffile_csums = {}
-    
+
     dpkg_db_base_dir = dpkg_prepdb_from_squashtar(unpackdir, squashtar)
     dpkgdbdir = os.path.join(dpkg_db_base_dir, "var", "lib", "dpkg")
-    dpkgdocsdir = os.path.join(dpkg_db_base_dir, "usr", "share", "doc")    
+    dpkgdocsdir = os.path.join(dpkg_db_base_dir, "usr", "share", "doc")
     statuspath = os.path.join(dpkg_db_base_dir, "var", "lib", "dpkg", "status")
 
     try:
@@ -1404,7 +1404,7 @@ def dpkg_get_file_package_metadata_from_squashtar(unpackdir, squashtar):
                         pkg = patt.group(1)
                     else:
                         pkg = pkgraw
-                        
+
                     conffiles[pkg] = os.path.join(metapath, f)
         else:
             raise Exception("no dpkg info path found in image: " + str(metapath))
@@ -1469,17 +1469,17 @@ def dpkg_get_file_package_metadata_from_squashtar(unpackdir, squashtar):
 
 def apk_get_file_package_metadata_from_squashtar(unpackdir, squashtar):
     # derived from alpine apk checksum logic
-    # 
+    #
     # a = "Q1XxRCAhhQ6eotekmwp6K9/4+DLwM="
     # sha1sum = a[2:].decode('base64').encode('hex')
-    # 
+    #
 
     result = {}
     record_template = {'digest': None, 'digestalgo': None, 'mode': None, 'group': None, 'user': None, 'size': None, 'package': None, 'conffile': False}
-    
+
     apk_db_base_dir = apk_prepdb_from_squashtar(unpackdir, squashtar)
     apkdbpath = os.path.join(apk_db_base_dir, 'lib', 'apk', 'db', 'installed')
-    
+
     try:
         if os.path.exists(apkdbpath):
             buf = None
@@ -1543,7 +1543,7 @@ def apk_get_file_package_metadata_from_squashtar(unpackdir, squashtar):
 
                             el = copy.deepcopy(record_template)
                             el.update({"package": pkg or None, "digest": sha1sum or None, "digestalgo": "sha1", "mode": fmode or None, "group": gid or None, "user": uid or None})
-                            result[fname].append(el)                                
+                            result[fname].append(el)
                             fmode = raw_csum = uid = gid = sha1sum = fname = therealfile_apk = therealfile_fs = None
 
     except Exception as err:

--- a/anchore_engine/analyzers/utils.py
+++ b/anchore_engine/analyzers/utils.py
@@ -71,7 +71,7 @@ def init_analyzer_cmdline(argv, name):
                 print("ERROR: cannot find/create input dir '"+ret['dirs'][d]+"'")
                 raise err
 
-    return(ret)
+    return ret
 
 def _default_member_function(tfl, member, a, t=None):
     print ("{} {} - {}".format(a, t, member.name))
@@ -97,7 +97,7 @@ def run_tarfile_member_function(tarfilename, *args, member_regexp=None, func=_de
 
                 ret[member.name] = func(tfl, member, *args, **kwargs)
 
-    return(ret)    
+    return ret    
 
 def run_tarfile_function(tarfile, func=None, *args, **kwargs):
 
@@ -108,7 +108,7 @@ def run_tarfile_function(tarfile, func=None, *args, **kwargs):
     with tarfile.open(tarfile, mode='r', format=tarfile.PAX_FORMAT) as tfl:
         ret = func(tfl, *args, **kwargs)
 
-    return(ret)
+    return ret
 
 def _search_tarfilenames_for_file(tarfilenames, searchfile):
     ret = None
@@ -120,18 +120,18 @@ def _search_tarfilenames_for_file(tarfilenames, searchfile):
         ret = "/{}".format(searchfile)
     elif re.sub("^/", "", searchfile) in tarfilenames:
         ret = re.sub("^/", "", searchfile)
-    return(ret)
+    return ret
 
 def get_memberhash(tfl):
     memberhash = {}
     for member in tfl.getmembers():
         memberhash[member.name] = member
-    return(memberhash)
+    return memberhash
 
 def get_distro_from_squashtar(squashtar, unpackdir=None):
     if unpackdir and os.path.exists(os.path.join(unpackdir, 'analyzer_meta.json')):
         with open(os.path.join(unpackdir, 'analyzer_meta.json'), 'r') as FH:
-            return(json.loads(FH.read()))
+            return json.loads(FH.read())
 
     meta = {
         'DISTRO':None,
@@ -273,10 +273,10 @@ def get_distro_from_squashtar(squashtar, unpackdir=None):
     if not meta['LIKEDISTRO']:
         meta['LIKEDISTRO'] = meta['DISTRO']
 
-    return(meta)
+    return meta
 
 def grouper(inlist, chunksize):
-    return (inlist[pos:pos + chunksize] for pos in range(0, len(inlist), chunksize))
+    return inlist[pos:pos + chunksize] for pos in range(0, len(inlist), chunksize)
 
 
 ### Metadata helpers
@@ -337,13 +337,13 @@ def get_distro_flavor(distro, version, likedistro=None):
             ret['version'] = vmaj + "." + vmin
             ret['likeversion'] = vmaj + "." + vmin
 
-    return(ret)
+    return ret
 
 def _get_extractable_member(tfl, member, deref_symlink=False, alltfiles={}, memberhash={}):
     ret = None
 
     if member.isreg():
-        return(member)
+        return member
 
     if not memberhash:
         memberhash = get_memberhash(tfl)
@@ -433,7 +433,7 @@ def _get_extractable_member(tfl, member, deref_symlink=False, alltfiles={}, memb
         else:
             ret = None
 
-    return(ret)
+    return ret
 
 def _checksum_member_function(tfl, member, csums=['sha256', 'md5'], memberhash={}):
     ret = {}
@@ -459,7 +459,7 @@ def _checksum_member_function(tfl, member, csums=['sha256', 'md5'], memberhash={
         else:
             ret[ctype] = "DIRECTORY_OR_OTHER"
 
-    return(ret)
+    return ret
 
 def get_checksums_from_squashtar(squashtar, csums=['sha256', 'md5']):
     allfiles = {}
@@ -481,7 +481,7 @@ def get_checksums_from_squashtar(squashtar, csums=['sha256', 'md5']):
     except Exception as err:
         print("EXC: {}".format(err))
 
-    return(allfiles)
+    return allfiles
         
 def get_files_from_squashtar(squashtar, unpackdir=None):
 
@@ -587,7 +587,7 @@ def get_files_from_squashtar(squashtar, unpackdir=None):
     except Exception as err:
         print ("EXC: {}".format(err))
 
-    return(filemap, allfiles)
+    return filemap, allfiles
 
 
 ### Package helpers
@@ -610,7 +610,7 @@ def rpm_get_all_packages_from_squashtar(unpackdir, squashtar):
         print(err.output)
         raise ValueError("could not get package list from RPM database: " + str(err))
 
-    return(rpms, rpmdbdir) 
+    return rpms, rpmdbdir 
 
 def rpm_get_all_pkgfiles(unpackdir):
     rpmfiles = {}
@@ -626,7 +626,7 @@ def rpm_get_all_pkgfiles(unpackdir):
     except Exception as err:
         raise ValueError("could not get file list from RPM database: " + str(err))
 
-    return(rpmfiles)
+    return rpmfiles
 
 def rpm_get_all_packages_detail_from_squashtar(unpackdir, squashtar):
     rpms = {}
@@ -651,15 +651,15 @@ def rpm_get_all_packages_detail_from_squashtar(unpackdir, squashtar):
     except:
         raise ValueError("could not get package list from RPM database: " + str(err))
 
-    return(rpms, rpmdbdir)
+    return rpms, rpmdbdir
 
 def make_anchoretmpdir(tmproot):
     tmpdir = '/'.join([tmproot, str(random.randint(0, 9999999)) + ".anchoretmp"])
     try:
         os.makedirs(tmpdir)
-        return(tmpdir)
+        return tmpdir
     except:
-        return(False)
+        return False
 
 def java_prepdb_from_squashtar(unpackdir, squashtar, java_file_regexp):
     javatmpdir = os.path.join(unpackdir, "javatmp")
@@ -683,7 +683,7 @@ def java_prepdb_from_squashtar(unpackdir, squashtar, java_file_regexp):
             tfl.extractall(path=os.path.join(javatmpdir, "rootfs"), members=javamembers)
         ret = os.path.join(javatmpdir, "rootfs")
 
-    return(ret)    
+    return ret    
 
 def python_prepdb_from_squashtar(unpackdir, squashtar, py_file_regexp):
     pytmpdir = os.path.join(unpackdir, "pytmp")
@@ -718,7 +718,7 @@ def python_prepdb_from_squashtar(unpackdir, squashtar, py_file_regexp):
             tfl.extractall(path=os.path.join(pytmpdir, "rootfs"), members=pymembers)
         ret = os.path.join(pytmpdir, "rootfs")
 
-    return(ret)    
+    return ret    
 
 def apk_prepdb_from_squashtar(unpackdir, squashtar):
     apktmpdir = os.path.join(unpackdir, "apktmp")
@@ -740,7 +740,7 @@ def apk_prepdb_from_squashtar(unpackdir, squashtar):
             tfl.extractall(path=os.path.join(apktmpdir, "rootfs"), members=apkmembers)
         ret = os.path.join(apktmpdir, "rootfs")
 
-    return(ret)    
+    return ret    
 
 def dpkg_prepdb_from_squashtar(unpackdir, squashtar):
     dpkgtmpdir = os.path.join(unpackdir, "dpkgtmp")
@@ -765,7 +765,7 @@ def dpkg_prepdb_from_squashtar(unpackdir, squashtar):
 
         ret = os.path.join(dpkgtmpdir, "rootfs")
 
-    return(ret)
+    return ret
 
 def rpm_prepdb_from_squashtar(unpackdir, squashtar):
     rpmtmpdir = os.path.join(unpackdir, "rpmtmp")
@@ -791,7 +791,7 @@ def rpm_prepdb_from_squashtar(unpackdir, squashtar):
         rc = rpm_prepdb(rpmtmpdir)
         ret = os.path.join(rpmtmpdir, "rpmdbfinal") #, "var", "lib", "rpm")
         
-    return(ret)
+    return ret
 
 def rpm_prepdb(unpackdir):
     origrpmdir = os.path.join(unpackdir, 'rootfs', 'var', 'lib', 'rpm')
@@ -811,7 +811,7 @@ def rpm_prepdb(unpackdir):
         except:
             pass
 
-    return(ret)
+    return ret
 
 def dpkg_get_all_pkgfiles_from_squashtar(unpackdir, squashtar):
     allfiles = {}
@@ -832,7 +832,7 @@ def dpkg_get_all_pkgfiles_from_squashtar(unpackdir, squashtar):
         print("Please ensure the command 'dpkg' is available and try again")
         raise err
 
-    return(allfiles)
+    return allfiles
 
 def dpkg_get_all_packages_detail_from_squashtar(unpackdir, squashtar):    
     all_packages = {}
@@ -947,7 +947,7 @@ def dpkg_get_all_packages_detail_from_squashtar(unpackdir, squashtar):
             if p == sp and v != sv:
                 other_packages[p] = [{'version':sv, 'arch':arch}]
 
-    return(all_packages, all_packages_simple, actual_packages, other_packages, dpkgdbdir)
+    return all_packages, all_packages_simple, actual_packages, other_packages, dpkgdbdir
 
 def deb_copyright_getlics(licfile):
     ret = {}
@@ -965,7 +965,7 @@ def deb_copyright_getlics(licfile):
                     ret[lic] = True
                     found=True
         FH.close()
-    return(ret)
+    return ret
 
 def apkg_parse_apkdb(apkdbfh):
     apkgs = {}                
@@ -1050,7 +1050,7 @@ def apkg_parse_apkdb(apkdbfh):
                 elif k == 'R':
                     thefiles.append(v)
 
-    return(apkgs)
+    return apkgs
 
 def apkg_get_all_pkgfiles_from_squashtar(unpackdir, squashtar):
     ret = {}
@@ -1064,7 +1064,7 @@ def apkg_get_all_pkgfiles_from_squashtar(unpackdir, squashtar):
         except Exception as err:
             raise ValueError("cannot locate APK installed DB in squashed.tar - exception: {}".format(err))
 
-    return(ret)
+    return ret
 
 def apkg_get_all_pkgfiles(unpackdir):
     apkdb = '/'.join([unpackdir, 'rootfs/lib/apk/db/installed'])
@@ -1076,7 +1076,7 @@ def apkg_get_all_pkgfiles(unpackdir):
     with open(apkdb, 'r') as FH:
         ret = apkg_parse_apkdb(FH)
 
-    return(ret)
+    return ret
 
 def gem_parse_meta(gem):
     ret = {}
@@ -1099,7 +1099,7 @@ def gem_parse_meta(gem):
                 replline = line
                 mat = "\\\\u{.*?}"
                 patt = re.match(r".*("+mat+").*", replline)
-                while(patt):
+                while patt:
                     replstr = ""
                     subpatt = re.match("\\\\u{(.*)}", patt.group(1))
                     if subpatt:
@@ -1152,12 +1152,12 @@ def gem_parse_meta(gem):
 
     except Exception as err:
         print("WARN could not fully parse gemspec file: " + str(name) + ": exception: " + str(err))
-        return({})
+        return {}
 
     if name:
         ret[name] = {'name':name, 'lics':lics, 'versions':versions, 'latest':latest, 'origins':origins, 'sourcepkg':sourcepkg, 'files':rfiles}
 
-    return(ret)
+    return ret
 
 def npm_parse_meta(npm):
 
@@ -1165,7 +1165,7 @@ def npm_parse_meta(npm):
 
     name = npm.pop('name', None)
     if not name:
-        return(record)
+        return record
 
     lics = list()
     versions = list()
@@ -1269,7 +1269,7 @@ def npm_parse_meta(npm):
     if name:
         record[name] = {'name':name, 'lics':lics, 'versions':versions, 'latest':latest, 'origins':origins, 'sourcepkg':sourcepkg}
 
-    return(record)
+    return record
 
 def rpm_get_file_package_metadata_from_squashtar(unpackdir, squashtar):
     # derived from rpm source code rpmpgp.h
@@ -1334,7 +1334,7 @@ def rpm_get_file_package_metadata_from_squashtar(unpackdir, squashtar):
     except Exception as err:
         raise Exception("WARN: distro package metadata gathering failed - exception: " + str(err))
 
-    return(result)
+    return result
 
 def dpkg_get_file_package_metadata_from_squashtar(unpackdir, squashtar):
 
@@ -1465,7 +1465,7 @@ def dpkg_get_file_package_metadata_from_squashtar(unpackdir, squashtar):
         traceback.print_exc()
         raise Exception("WARN: could not find/parse dpkg info metadata files - exception: " + str(err))
 
-    return(result)
+    return result
 
 def apk_get_file_package_metadata_from_squashtar(unpackdir, squashtar):
     # derived from alpine apk checksum logic
@@ -1551,14 +1551,14 @@ def apk_get_file_package_metadata_from_squashtar(unpackdir, squashtar):
         traceback.print_exc()
         raise Exception("WARN: could not parse apk DB file, looking for file checksums - exception: " + str(err))
 
-    return(result)
+    return result
 
 
 ##### File IO helpers
 
 def read_kvfile_todict(file):
     if not os.path.isfile(file):
-        return ({})
+        return {}
 
     ret = {}
     with open(file, 'r') as FH:
@@ -1570,17 +1570,17 @@ def read_kvfile_todict(file):
                 k = re.sub("____", " ", k)
                 ret[k] = v
 
-    return (ret)
+    return ret
 
 def read_plainfile_tostr(file):
     if not os.path.isfile(file):
-        return ("")
+        return ""
 
     with open(file, 'r') as FH:
         ret = FH.read()
         #ret = FH.read().decode('utf8')
 
-    return (ret)
+    return ret
 
 def write_plainfile_fromstr(file, instr):
     with open(file, 'w') as FH:

--- a/anchore_engine/apis/__init__.py
+++ b/anchore_engine/apis/__init__.py
@@ -45,4 +45,4 @@ def do_request_prep(request, default_params=None):
         logger.error("error processing request parameters - exception: " + str(err))
         raise err
 
-    return(ret)
+    return ret

--- a/anchore_engine/auth/aws_ecr.py
+++ b/anchore_engine/auth/aws_ecr.py
@@ -95,5 +95,5 @@ def refresh_ecr_credentials(registry, access_key_id, secret_access_key):
     ret['authorizationToken'] = utils.ensure_str(base64.decodebytes(utils.ensure_bytes(ecr_data['authorizationToken'])))
     ret['expiresAt'] = int(ecr_data['expiresAt'].strftime('%s'))
 
-    return(ret)
+    return ret
 

--- a/anchore_engine/auth/common.py
+++ b/anchore_engine/auth/common.py
@@ -59,5 +59,5 @@ def registry_record_matches(registry_record_str, registry, repository):
     :return: bool true if a match, false if not
     """
 
-    return registry_record_str[-1] == '*' and '{}/{}'.format(registry, repository).startswith(registry_record_str[:-1])) or ('/' in registry_record_str and registry_record_str == '{}/{}'.format(registry, repository)) or (registry_record_str == registry
+    return (registry_record_str[-1] == '*' and '{}/{}'.format(registry, repository).startswith(registry_record_str[:-1])) or ('/' in registry_record_str and registry_record_str == '{}/{}'.format(registry, repository)) or (registry_record_str == registry)
 

--- a/anchore_engine/auth/common.py
+++ b/anchore_engine/auth/common.py
@@ -21,7 +21,7 @@ def get_docker_registry_userpw(registry_record):
         logger.error("cannot fetch registry creds from registry record - exception: " + str(err))
         raise err
 
-    return(user, pw)
+    return user, pw
 
 
 def get_creds_by_registry(registry, repository, registry_creds=None):
@@ -47,7 +47,7 @@ def get_creds_by_registry(registry, repository, registry_creds=None):
         except Exception as err:
             raise err
 
-    return(user, pw, registry_verify)
+    return user, pw, registry_verify
 
 
 def registry_record_matches(registry_record_str, registry, repository):
@@ -59,5 +59,5 @@ def registry_record_matches(registry_record_str, registry, repository):
     :return: bool true if a match, false if not
     """
 
-    return (registry_record_str[-1] == '*' and '{}/{}'.format(registry, repository).startswith(registry_record_str[:-1])) or ('/' in registry_record_str and registry_record_str == '{}/{}'.format(registry, repository)) or (registry_record_str == registry)
+    return registry_record_str[-1] == '*' and '{}/{}'.format(registry, repository).startswith(registry_record_str[:-1])) or ('/' in registry_record_str and registry_record_str == '{}/{}'.format(registry, repository)) or (registry_record_str == registry
 

--- a/anchore_engine/clients/docker_registry.py
+++ b/anchore_engine/clients/docker_registry.py
@@ -62,7 +62,7 @@ def get_image_manifest_docker_registry(url, registry, repo, tag, user=None, pw=N
     except Exception as err:
         raise err
 
-    return(manifest, digest)
+    return manifest, digest
 
 def ping_docker_registry_v2(base_url, u, p, verify=True):
     httpcode = 500
@@ -164,7 +164,7 @@ def ping_docker_registry_v2(base_url, u, p, verify=True):
     except Exception as err:
         message = "{}".format(err)
 
-    return(httpcode, message)
+    return httpcode, message
 
 def ping_docker_registry(registry_record):
     ret = False
@@ -193,7 +193,7 @@ def ping_docker_registry(registry_record):
         logger.warn("failed check to access registry ("+str(url)+","+str(user)+") - exception: " + str(err))
         raise Exception("failed check to access registry ("+str(url)+","+str(user)+") - exception: " + str(err))
 
-    return(ret)
+    return ret
 
 
 def get_repo_tags(userId, image_info, registry_creds=None):
@@ -222,7 +222,7 @@ def get_repo_tags(userId, image_info, registry_creds=None):
 
     alltags = get_repo_tags_skopeo(url, registry, repo, lookuptag=lookuptag, user=user, pw=pw, verify=registry_verify)
         
-    return(alltags)
+    return alltags
 
 def get_image_manifest(userId, image_info, registry_creds):
     logger.debug("get_image_manifest input: " + str(userId) + " : " + str(image_info) + " : " + str(time.time()))
@@ -272,7 +272,7 @@ def get_image_manifest(userId, image_info, registry_creds):
         err = ex
 
     if manifest and digest:
-        return(manifest, digest, parentdigest, parentmanifest)
+        return manifest, digest, parentdigest, parentmanifest
 
     logger.error("could not get manifest/digest for image ({}) from registry ({}) - error: {}".format(fulltag, url, err))
     if err:

--- a/anchore_engine/clients/localanchore_standalone.py
+++ b/anchore_engine/clients/localanchore_standalone.py
@@ -54,17 +54,17 @@ def get_layertarfile(unpackdir, cachedir, layer):
                     os.utime(layer_candidate, None)
                 except:
                     pass
-                return(layer_candidate)
+                return layer_candidate
         except:
             pass
 
-    return(None)
+    return None
 
 def handle_tar_error_post(unpackdir=None, rootfsdir=None, handled_post_metadata={}):
 
     if not unpackdir or not rootfsdir or not handled_post_metadata:
         # nothing to do
-        return(True)
+        return True
 
     logger.debug("handling post with metadata: {}".format(handled_post_metadata))
     if handled_post_metadata.get('temporary_file_adds', []):
@@ -86,7 +86,7 @@ def handle_tar_error_post(unpackdir=None, rootfsdir=None, handled_post_metadata=
                     except:
                         pass
 
-    return(True)
+    return True
 
 def handle_tar_error(tarcmd, rc, sout, serr, unpackdir=None, rootfsdir=None, cachedir=None, layer=None, layertar=None, layers=[]):
     handled = False
@@ -178,7 +178,7 @@ def handle_tar_error(tarcmd, rc, sout, serr, unpackdir=None, rootfsdir=None, cac
         raise err
 
     logger.debug("tar error handled: {}".format(handled))
-    return(handled, handled_post_metadata)
+    return handled, handled_post_metadata
 
 def get_tar_filenames(layertar):
     ret = []
@@ -210,11 +210,11 @@ def get_tar_filenames(layertar):
         if layertarfile:
             layertarfile.close()
 
-    return(ret)
+    return ret
 
 def tree_id(id):
     toks = id.split('/')
-    return(toks[-1], id, '/'.join(toks[:-1]))
+    return toks[-1], id, '/'.join(toks[:-1])
 
 def tree_create_branch(ftree, id, data, stree=None, populate_intermediate_nodes=False):
     ftoks = id.split("/")
@@ -238,7 +238,7 @@ def squash(unpackdir, cachedir, layers):
     rootfsdir = unpackdir + "/rootfs"
 
     if os.path.exists(unpackdir + "/squashed.tar"):
-        return (True)
+        return True
     
 
     tree_time = time.time()
@@ -438,7 +438,7 @@ def squash(unpackdir, cachedir, layers):
     if os.path.exists(os.path.join(unpackdir,"squashed.tar")):
         imageSize = os.path.getsize(os.path.join(unpackdir, "squashed.tar"))
 
-    return ("done", imageSize)
+    return "done", imageSize
                 
 
 def make_staging_dirs(rootdir, use_cache_dir=None):
@@ -465,7 +465,7 @@ def make_staging_dirs(rootdir, use_cache_dir=None):
         except Exception as err:
             raise Exception("unable to prep staging directory - exception: " + str(err))
 
-    return(ret)
+    return ret
 
 def _rmtree_error_handler(infunc, inpath, inerr):
     (cls, exc, trace) = inerr
@@ -490,7 +490,7 @@ def rmtree_force(inpath):
             if os.path.exists(inpath):
                 shutil.rmtree(inpath)
 
-    return(True)
+    return True
 
 def delete_staging_dirs(staging_dirs):
     for k in list(staging_dirs.keys()):
@@ -509,7 +509,7 @@ def delete_staging_dirs(staging_dirs):
         else:
             logger.debug("keep_image_analysis_tmpfiles is enabled - leaving analysis tmpdir in place {}".format(staging_dirs))
 
-    return(True)
+    return True
 
 def pull_image(staging_dirs, pullstring, registry_creds=[], manifest=None, parent_manifest=None, dest_type='oci'):
     outputdir = staging_dirs['outputdir']
@@ -535,7 +535,7 @@ def pull_image(staging_dirs, pullstring, registry_creds=[], manifest=None, paren
     except Exception as err:
         raise err
 
-    return(True)
+    return True
 
 def get_image_metadata_v1(staging_dirs, imageDigest, imageId, manifest_data, dockerfile_contents="", dockerfile_mode=""):
     outputdir = staging_dirs['outputdir']
@@ -619,7 +619,7 @@ def get_image_metadata_v1(staging_dirs, imageDigest, imageId, manifest_data, doc
 
     layers.reverse()
 
-    return(docker_history, layers, dockerfile_contents, dockerfile_mode, imageArch)
+    return docker_history, layers, dockerfile_contents, dockerfile_mode, imageArch
 
 
 def get_image_metadata_v2(staging_dirs, imageDigest, imageId, manifest_data, dockerfile_contents="", dockerfile_mode=""):
@@ -643,7 +643,7 @@ def get_image_metadata_v2(staging_dirs, imageDigest, imageId, manifest_data, doc
             image_config = os.path.join(copydir, ifile)
             break
 
-    if (image_config):
+    if image_config:
         try:
             with open(image_config, 'r') as FH:
                 configdata = json.loads(FH.read())
@@ -759,7 +759,7 @@ def get_image_metadata_v2(staging_dirs, imageDigest, imageId, manifest_data, doc
     elif not dockerfile_mode:
         dockerfile_mode = "Actual"
 
-    return(docker_history, layers, dockerfile_contents, dockerfile_mode, imageArch)
+    return docker_history, layers, dockerfile_contents, dockerfile_mode, imageArch
 
 def unpack(staging_dirs, layers):
     outputdir = staging_dirs['outputdir']
@@ -771,7 +771,7 @@ def unpack(staging_dirs, layers):
         squashtar, imageSize = squash(unpackdir, cachedir, layers)
     except Exception as err:
         raise err
-    return(imageSize)
+    return imageSize
 
 
 def list_analyzers():
@@ -835,7 +835,7 @@ def run_anchore_analyzers(staging_dirs, imageDigest, imageId, localconfig):
         if not analyzer_report[analyzer_output]:
             analyzer_report.pop(analyzer_output, None)
 
-    return(analyzer_report)
+    return analyzer_report
 
 def generate_image_export(staging_dirs, imageDigest, imageId, analyzer_report, imageSize, fulltag, docker_history, dockerfile_mode, dockerfile_contents, layers, familytree, imageArch, rdigest, analyzer_manifest):
     image_report = []
@@ -876,7 +876,7 @@ def generate_image_export(staging_dirs, imageDigest, imageId, analyzer_report, i
             }
         }
     )
-    return(image_report)
+    return image_report
 
 def get_manifest_from_staging(staging_dirs):
     copydir = staging_dirs['copydir']
@@ -888,7 +888,7 @@ def get_manifest_from_staging(staging_dirs):
         with open(dfile, 'r') as FFH:
             ret = FFH.read()
 
-    return(ret)
+    return ret
 
 def analyze_image(userId, manifest, image_record, tmprootdir, localconfig, registry_creds=[], use_cache_dir=None, image_source='registry', image_source_meta=None, parent_manifest=None):
     # need all this
@@ -1004,7 +1004,7 @@ def analyze_image(userId, manifest, image_record, tmprootdir, localconfig, regis
     if not image_report:
         raise Exception("failed to analyze")
 
-    return(image_report, manifest)
+    return image_report, manifest
 
 
 class AnalysisError(AnchoreException):
@@ -1117,7 +1117,7 @@ def get_anchorelock(lockId=None, driver=None):
     else:
         ret = anchorelock
 
-    return(ret)
+    return ret
 
 
 def get_config():
@@ -1133,5 +1133,5 @@ def get_config():
         except Exception as err:
             logger.error(str(err))
 
-    return(ret)
+    return ret
 

--- a/anchore_engine/clients/services/common.py
+++ b/anchore_engine/clients/services/common.py
@@ -50,7 +50,7 @@ def update_service_cache(servicename, skipcache=False):
             scache[servicename]['records'] = new_records
             scache[servicename]['last_updated'] = time.time()
 
-    return(fromCache)
+    return fromCache
     
 def get_enabled_services(servicename, skipcache=False):
     global scache, scache_template
@@ -67,7 +67,7 @@ def get_enabled_services(servicename, skipcache=False):
     if not ret:
         logger.debug("no services of type ("+str(servicename)+") are yet available in the system")
        
-    return(ret)
+    return ret
     
 def choose_service(servicename, skipcache=False):
     global scache, scache_template
@@ -84,7 +84,7 @@ def choose_service(servicename, skipcache=False):
     if not ret:
         logger.debug("no service of type ("+str(servicename)+") is yet available in the system")
         
-    return(ret)
+    return ret
     
 def get_service_endpoint(servicename, api_post=None):
     global localconfig
@@ -99,7 +99,7 @@ def get_service_endpoint(servicename, api_post=None):
         base_url = re.sub("/+$", "", localconfig[servicename+'_endpoint'])
         if api_post:
             base_url = '/'.join([base_url, api_post])
-        return(base_url)
+        return base_url
 
     try:
         service_record = choose_service(servicename)
@@ -119,7 +119,7 @@ def get_service_endpoint(servicename, api_post=None):
         raise Exception("could not find valid endpoint for service ("+servicename+") - exception: " + str(err))
     
     logger.debug("got endpoint ("+servicename+"): " + str(base_url))
-    return(base_url)
+    return base_url
 
 def get_service_endpoints(servicename, api_post=None):
     global localconfig
@@ -136,7 +136,7 @@ def get_service_endpoints(servicename, api_post=None):
         if api_post:
             base_url = '/'.join([base_url, api_post])
         base_urls = [base_url]
-        return(base_urls)
+        return base_urls
 
     try:
         service_records = get_enabled_services(servicename)
@@ -161,7 +161,7 @@ def get_service_endpoints(servicename, api_post=None):
         raise Exception("could not find valid endpoint for service ("+servicename+") - exception: " + str(err))
     
     logger.debug("got endpoints ("+servicename+"): " + str([base_urls]))
-    return(base_urls)
+    return base_urls
 
 
 def check_services_ready(servicelist):
@@ -181,4 +181,4 @@ def check_services_ready(servicelist):
         logger.error("could not check service status - exception: " + str(err))
         all_ready = False
 
-    return(all_ready)
+    return all_ready

--- a/anchore_engine/clients/services/http.py
+++ b/anchore_engine/clients/services/http.py
@@ -6,16 +6,16 @@ from anchore_engine.subsys import logger
 http = urllib3.PoolManager()
 
 def fpost(url, **kwargs):
-    return(fpost_req(url, **kwargs))
+    return fpost_req(url, **kwargs)
 
 def fget(url, **kwargs):
-    return(fget_req(url, **kwargs))
+    return fget_req(url, **kwargs)
 
 def fput(url, **kwargs):
-    return(fput_req(url, **kwargs))
+    return fput_req(url, **kwargs)
 
 def fdelete(url, **kwargs):
-    return(fdelete_req(url, **kwargs))
+    return fdelete_req(url, **kwargs)
 
 def fpost_urllib(url, **kwargs):
     global http
@@ -48,7 +48,7 @@ def fpost_urllib(url, **kwargs):
     except Exception as err:
         rawdata = str(err)
 
-    return(httpcode, jsondata, rawdata)
+    return httpcode, jsondata, rawdata
 
 def fpost_req(url, **kwargs):
     httpcode = 500
@@ -67,7 +67,7 @@ def fpost_req(url, **kwargs):
             jsondata = {}
     except Exception as err:
         rawdata = str(err)
-    return(httpcode, jsondata, rawdata)
+    return httpcode, jsondata, rawdata
 
 def fput_urllib(url, **kwargs):
     global http
@@ -99,7 +99,7 @@ def fput_urllib(url, **kwargs):
     except Exception as err:
         rawdata = str(err)
 
-    return(httpcode, jsondata, rawdata)
+    return httpcode, jsondata, rawdata
 
 def fput_req(url, **kwargs):
     httpcode = 500
@@ -118,7 +118,7 @@ def fput_req(url, **kwargs):
             jsondata = {}
     except Exception as err:
         rawdata = str(err)
-    return(httpcode, jsondata, rawdata)
+    return httpcode, jsondata, rawdata
 
 def fget_urllib(url, **kwargs):
     global http
@@ -151,7 +151,7 @@ def fget_urllib(url, **kwargs):
     except Exception as err:
         rawdata = str(err)
 
-    return(httpcode, jsondata, rawdata)
+    return httpcode, jsondata, rawdata
 
 def fget_req(url, **kwargs):
     httpcode = 500
@@ -171,7 +171,7 @@ def fget_req(url, **kwargs):
     except Exception as err:
         rawdata = str(err)
 
-    return(httpcode, jsondata, rawdata)
+    return httpcode, jsondata, rawdata
 
 def fdelete_urllib(url, **kwargs):
     global http
@@ -204,7 +204,7 @@ def fdelete_urllib(url, **kwargs):
     except Exception as err:
         rawdata = str(err)
 
-    return(httpcode, jsondata, rawdata)
+    return httpcode, jsondata, rawdata
 
 def fdelete_req(url, **kwargs):
     httpcode = 500
@@ -223,7 +223,7 @@ def fdelete_req(url, **kwargs):
             jsondata = {}
     except Exception as err:
         rawdata = str(err)
-    return(httpcode, jsondata, rawdata)
+    return httpcode, jsondata, rawdata
 
 def anchy_get(url, raw=False, **kwargs):
     ret = True
@@ -246,7 +246,7 @@ def anchy_get(url, raw=False, **kwargs):
         e.__dict__.update({'httpcode':httpcode, 'anchore_error_raw':str(rawdata), 'anchore_error_json':jsondata})
         raise e
 
-    return(ret)
+    return ret
 
 def anchy_post(url, raw=False, **kwargs):
     ret = True
@@ -268,7 +268,7 @@ def anchy_post(url, raw=False, **kwargs):
         e.__dict__.update({'httpcode':httpcode, 'anchore_error_raw':str(rawdata), 'anchore_error_json':jsondata})
         raise e
 
-    return(ret)
+    return ret
 
 
 def anchy_put(url, raw=False, **kwargs):
@@ -291,7 +291,7 @@ def anchy_put(url, raw=False, **kwargs):
         e.__dict__.update({'httpcode':httpcode, 'anchore_error_raw':str(rawdata), 'anchore_error_json':jsondata})
         raise e
 
-    return(ret)
+    return ret
 
 
 def anchy_delete(url, raw=False, **kwargs):
@@ -314,7 +314,7 @@ def anchy_delete(url, raw=False, **kwargs):
         e.__dict__.update({'httpcode':httpcode, 'anchore_error_raw':str(rawdata), 'anchore_error_json':jsondata})
         raise e
 
-    return(ret)
+    return ret
 
 def anchy_aa(method, base_urls, url_postfix, **kwargs):
     success = False
@@ -334,4 +334,4 @@ def anchy_aa(method, base_urls, url_postfix, **kwargs):
         else:
             raise Exception("could not run client")
 
-    return(ret)
+    return ret

--- a/anchore_engine/clients/services/simplequeue.py
+++ b/anchore_engine/clients/services/simplequeue.py
@@ -102,7 +102,7 @@ def run_target_with_queue_ttl(account, queue, visibility_timeout, target, max_wa
     logger.debug('Got msg: {}'.format(qobj))
     if not qobj:
         logger.debug("Got empty message from queue - nothing to do")
-        return(True)
+        return True
 
     receipt_handle = qobj.get('receipt_handle')
     msg_id = qobj.get('id')

--- a/anchore_engine/clients/skopeo_wrapper.py
+++ b/anchore_engine/clients/skopeo_wrapper.py
@@ -43,7 +43,7 @@ def manifest_to_digest_shellout(rawmanifest):
         if tmpmanifest:
             os.remove(tmpmanifest)
 
-    return(ret)
+    return ret
 
 def copy_image_from_docker_archive(source_archive, dest_dir):
     cmdstr = "skopeo copy docker-archive:{} oci:{}:image".format(source_archive, dest_dir)
@@ -158,7 +158,7 @@ def download_image(fulltag, copydir, user=None, pw=None, verify=True, manifest=N
     except Exception as err:
         raise err
 
-    return(True)
+    return True
 
 def get_repo_tags_skopeo(url, registry, repo, user=None, pw=None, verify=None, lookuptag=None):
     try:
@@ -216,7 +216,7 @@ def get_repo_tags_skopeo(url, registry, repo, user=None, pw=None, verify=None, l
     if not repotags:
         raise Exception("no tags found for input repo from skopeo")
 
-    return(repotags)
+    return repotags
 
 def get_image_manifest_skopeo_raw(pullstring, user=None, pw=None, verify=True):
     ret = None
@@ -281,7 +281,7 @@ def get_image_manifest_skopeo_raw(pullstring, user=None, pw=None, verify=True):
     except Exception as err:
         raise err
 
-    return(ret)
+    return ret
 
 def get_image_manifest_skopeo(url, registry, repo, intag=None, indigest=None, topdigest=None, user=None, pw=None, verify=True, topmanifest=None):
     manifest = {}
@@ -327,7 +327,7 @@ def get_image_manifest_skopeo(url, registry, repo, intag=None, indigest=None, to
     if not manifest or not digest:
         raise SkopeoError(msg="No digest/manifest from skopeo")
 
-    return(manifest, digest, topdigest, topmanifest)
+    return manifest, digest, topdigest, topmanifest
 
 class SkopeoError(AnchoreException):
 

--- a/anchore_engine/common/helpers.py
+++ b/anchore_engine/common/helpers.py
@@ -42,7 +42,7 @@ def make_response_error(errmsg, in_httpcode=None, details=None):
                     logger.warn("unable to marshal error details: source error {}".format(errmsg.__dict__))
                 except:
                     pass
-    return(ret)
+    return ret
 
 
 def make_anchore_exception(err, input_message=None, input_httpcode=None, input_detail=None, override_existing=False, input_error_codes=None):
@@ -95,7 +95,7 @@ def make_anchore_exception(err, input_message=None, input_httpcode=None, input_d
         if error_codes:
             ret.anchore_error_json['detail']['error_codes'].extend(error_codes)
                                    
-    return(ret)
+    return ret
 
 
 def make_response_routes(apiversion, inroutes):
@@ -115,7 +115,7 @@ def make_response_routes(apiversion, inroutes):
         httpcode = 200
         return_object = routes
 
-    return(return_object, httpcode)
+    return return_object, httpcode
 
 
 def update_image_record_with_analysis_data(image_record, image_data):
@@ -158,7 +158,7 @@ def update_image_record_with_analysis_data(image_record, image_data):
             logger.debug("setting image_detail: ")
             image_detail['dockerfile'] = str(base64.b64encode(dockerfile_content.encode('utf-8')), 'utf-8')
 
-    return(True)
+    return True
 
 
 def extract_dockerfile_content(image_data):
@@ -172,7 +172,7 @@ def extract_dockerfile_content(image_data):
         dockerfile_content = ""
         dockerfile_mode = "Guessed"
 
-    return(dockerfile_content, dockerfile_mode)
+    return dockerfile_content, dockerfile_mode
 
 
 def extract_analyzer_content(image_data, content_type, manifest=None):
@@ -284,7 +284,7 @@ def extract_analyzer_content(image_data, content_type, manifest=None):
         logger.warn("exception: " + str(err))
         raise err
 
-    return(ret)
+    return ret
 
 
 def make_policy_record(userId, bundle, policy_source="local", active=False):
@@ -298,7 +298,7 @@ def make_policy_record(userId, bundle, policy_source="local", active=False):
     payload['policybundle'] = bundle
     payload['policy_source'] = policy_source
 
-    return(payload)
+    return payload
 
 
 def make_eval_record(userId, evalId, policyId, imageDigest, tag, final_action, eval_url):
@@ -314,4 +314,4 @@ def make_eval_record(userId, evalId, policyId, imageDigest, tag, final_action, e
     payload["created_at"] = int(time.time())
     payload["last_updated"] = payload['created_at']
 
-    return(payload)
+    return payload

--- a/anchore_engine/common/images.py
+++ b/anchore_engine/common/images.py
@@ -22,7 +22,7 @@ def lookup_registry_image(userId, image_info, registry_creds):
     except Exception as err:
         raise anchore_engine.common.helpers.make_anchore_exception(err, input_message="cannot fetch image digest/manifest from registry", input_httpcode=400)
 
-    return(digest, manifest)
+    return digest, manifest
 
 
 def get_image_info(userId, image_type, input_string, registry_lookup=False, registry_creds=[]):
@@ -66,7 +66,7 @@ def get_image_info(userId, image_type, input_string, registry_lookup=False, regi
     else:
         raise Exception("image type ("+str(image_type)+") not supported")
 
-    return(ret)
+    return ret
 
 
 def clean_docker_image_details_for_update(image_details):
@@ -78,7 +78,7 @@ def clean_docker_image_details_for_update(image_details):
             if image_detail[k] != None:
                 el[k] = image_detail[k]
         ret.append(el)
-    return(ret)
+    return ret
 
 
 def make_image_record(userId, image_type, input_string, image_metadata={}, registry_lookup=True, registry_creds=[]):
@@ -116,12 +116,12 @@ def make_image_record(userId, image_type, input_string, image_metadata={}, regis
         parentdigest = image_metadata.get('parentdigest', None)
         created_at = image_metadata.get('created_at', None)
 
-        return(make_docker_image(userId, input_string=input_string, tag=tag, digest=digest, imageId=imageId, parentdigest=parentdigest, created_at=created_at, dockerfile=dockerfile, dockerfile_mode=dockerfile_mode, registry_lookup=registry_lookup, registry_creds=registry_creds, annotations=annotations))
+        return make_docker_image(userId, input_string=input_string, tag=tag, digest=digest, imageId=imageId, parentdigest=parentdigest, created_at=created_at, dockerfile=dockerfile, dockerfile_mode=dockerfile_mode, registry_lookup=registry_lookup, registry_creds=registry_creds, annotations=annotations)
 
     else:
         raise Exception("image type ("+str(image_type)+") not supported")
 
-    return(None)
+    return None
 
 
 def make_docker_image(userId, input_string=None, tag=None, digest=None, imageId=None, parentdigest=None, created_at=None, dockerfile=None, dockerfile_mode=None, registry_lookup=True, registry_creds=[], annotations={}):
@@ -185,4 +185,4 @@ def make_docker_image(userId, input_string=None, tag=None, digest=None, imageId=
         new_image['image_detail'] = [new_docker_image]
 
     ret = new_image
-    return(ret)
+    return ret

--- a/anchore_engine/common/pagination.py
+++ b/anchore_engine/common/pagination.py
@@ -7,7 +7,7 @@ def do_simple_pagination(input_items, page=1, limit=None, dosort=True, sortfunc=
     page = int(page)
     next_page = None
     if not limit:
-        return(1, None, input_items)
+        return 1, None, input_items
 
     limit = int(limit)
     if dosort:
@@ -22,7 +22,7 @@ def do_simple_pagination(input_items, page=1, limit=None, dosort=True, sortfunc=
     if len(paginated_items) == limit and (paginated_items[-1] != input_items[-1]):
         next_page = page + 1
 
-    return(page, next_page, paginated_items)
+    return page, next_page, paginated_items
 
 
 pagination_cache = {}
@@ -36,10 +36,10 @@ def get_cached_pagination(query_digest=""):
     elif pagination_cache.get(query_digest, {}).get('ttl', 0.0) < current_time:
         logger.debug("expiring query cache content: {}".format(query_digest))
         el = pagination_cache.pop(query_digest, None)
-        del(el)
+        del el
         raise Exception("document is expired in pagination cache.")
 
-    return(pagination_cache[query_digest]['content'])
+    return pagination_cache[query_digest]['content']
 
 
 def do_cached_pagination(input_items, page=None, limit=None, dosort=True, sortfunc=lambda x: x, query_digest="", ttl=0.0):
@@ -53,7 +53,7 @@ def do_cached_pagination(input_items, page=None, limit=None, dosort=True, sortfu
             'ttl': current_time + float(ttl),
             'content': list(input_items),
         }
-    return(do_simple_pagination(input_items, page=page, limit=limit, dosort=dosort, sortfunc=sortfunc, query_digest=query_digest, ttl=ttl))
+    return do_simple_pagination(input_items, page=page, limit=limit, dosort=dosort, sortfunc=sortfunc, query_digest=query_digest, ttl=ttl)
 
 
 def make_response_paginated_envelope(input_items, envelope_key='result', page="1", limit=None, dosort=True, sortfunc=lambda x: x, pagination_func=do_simple_pagination, query_digest="", ttl=0.0):
@@ -67,4 +67,4 @@ def make_response_paginated_envelope(input_items, envelope_key='result', page="1
     if next_page:
         return_object['next_page'] = "{}".format(next_page)
 
-    return(return_object)
+    return return_object

--- a/anchore_engine/configuration/localconfig.py
+++ b/anchore_engine/configuration/localconfig.py
@@ -140,7 +140,7 @@ def get_host_id():
                     time.sleep(1)
                     pass
 
-    return (ret)
+    return ret
 
 
 def load_defaults(configdir=None):
@@ -152,7 +152,7 @@ def load_defaults(configdir=None):
     localconfig.update(copy.deepcopy(DEFAULT_CONFIG))
     localconfig['service_dir'] = configdir
 
-    return (localconfig)
+    return localconfig
 
 
 def load_config(configdir=None, configfile=None, validate_params=None):
@@ -257,7 +257,7 @@ def load_config(configdir=None, configfile=None, validate_params=None):
         pass
 
     
-    return (localconfig)
+    return localconfig
 
 
 def read_config(configfile=None):
@@ -310,7 +310,7 @@ def read_config(configfile=None):
         except Exception as err:
             raise err
 
-    return (ret)
+    return ret
 
 
 def validate_config(config, validate_params=None):
@@ -395,7 +395,7 @@ def validate_config(config, validate_params=None):
         raise err
 
     # raise Exception("TEST")
-    return (ret)
+    return ret
 
 
 def validate_user_auth_config(config):
@@ -445,7 +445,7 @@ def validate_key_config(config, required=False):
 
 def get_config():
     global localconfig
-    return (localconfig)
+    return localconfig
 
 
 def get_versions():
@@ -455,7 +455,7 @@ def get_versions():
     ret['service_version'] = version.version
     ret['db_version'] = version.db_version
 
-    return (ret)
+    return ret
 
 
 class OauthNotConfiguredError(Exception):

--- a/anchore_engine/db/db_anchore.py
+++ b/anchore_engine/db/db_anchore.py
@@ -16,7 +16,7 @@ def get(session=None):
         obj = dict((key,value) for key, value in vars(result).items() if not key.startswith('_'))
         ret = obj
 
-    return(ret)
+    return ret
 
 def add(service_version, db_version, inobj, session=None):
     if not session:
@@ -41,10 +41,10 @@ def add(service_version, db_version, inobj, session=None):
 #    finally:
 #        session.rollback()
     
-    return(True)
+    return True
 
 def update(service_version, db_version, scanner_version, inobj, session=None):
-    return(add(service_version, db_version, scanner_version, inobj, session=session))
+    return add(service_version, db_version, scanner_version, inobj, session=session)
 
 def update_record(input_record, session=None):
     if not session:
@@ -54,4 +54,4 @@ def update_record(input_record, session=None):
     if our_result:
         our_result.update(input_record)
         
-    return(True)
+    return True

--- a/anchore_engine/db/db_archivedocument.py
+++ b/anchore_engine/db/db_archivedocument.py
@@ -25,7 +25,7 @@ def add(userId, bucket, archiveId, documentName, inobj, session=None):
         our_result.update(dbobj)
         dbobj.clear()
 
-    return(True)
+    return True
 
 def get_all_iter(session=None):
     if not session:
@@ -47,7 +47,7 @@ def get_all(session=None):
         obj = dict((key,value) for key, value in vars(result).items() if not key.startswith('_'))
         ret.append(obj)
 
-    return(ret)
+    return ret
 
 def get(userId, bucket, archiveId, session=None):
     ret = {}
@@ -57,7 +57,7 @@ def get(userId, bucket, archiveId, session=None):
         obj = dict((key,value) for key, value in vars(result).items() if not key.startswith('_'))
         ret.update(obj)
 
-    return(ret)
+    return ret
 
 def get_onlymeta(userId, bucket, archiveId, session=None):
     ret = {}
@@ -68,7 +68,7 @@ def get_onlymeta(userId, bucket, archiveId, session=None):
             k = list(result.keys())[i]
             ret[k] = result[i]
 
-    return(ret)
+    return ret
 
 def get_byname(userId, documentName, session=None):
     if not session:
@@ -82,7 +82,7 @@ def get_byname(userId, documentName, session=None):
         obj = dict((key,value) for key, value in vars(result).items() if not key.startswith('_'))
         ret = obj
 
-    return(ret)
+    return ret
 
 def exists(userId, bucket, archiveId, session=None):
     if not session:
@@ -97,7 +97,7 @@ def exists(userId, bucket, archiveId, session=None):
             k = list(result.keys())[i]
             ret[k] = result[i]
 
-    return(ret)
+    return ret
 
 def list_all_notempty(session=None):
     ret = []
@@ -111,7 +111,7 @@ def list_all_notempty(session=None):
         if obj:
             ret.append(obj)
     
-    return(ret)
+    return ret
 
 def list_all(session=None, **dbfilter):
     if not session:
@@ -128,7 +128,7 @@ def list_all(session=None, **dbfilter):
         if obj:
             ret.append(obj)
 
-    return(ret)
+    return ret
 
 def list_all_byuserId(userId, session=None, **dbfilter):
     if not session:
@@ -148,10 +148,10 @@ def list_all_byuserId(userId, session=None, **dbfilter):
         if obj:
             ret.append(obj)
 
-    return(ret)
+    return ret
 
 def update(userId, bucket, archiveId, documentName, inobj, session=None):
-    return(add(userId, bucket, archiveId, documentName, inobj, session=session))
+    return add(userId, bucket, archiveId, documentName, inobj, session=session)
 
 def delete_byfilter(userId, remove=True, session=None, **dbfilter):
     if not session:
@@ -168,7 +168,7 @@ def delete_byfilter(userId, remove=True, session=None, **dbfilter):
                 result.update({"record_state_key": "to_delete", "record_state_val": str(time.time())})
             ret = True
     
-    return(ret)
+    return ret
 
 def delete(userId, bucket, archiveId, remove=True, session=None):
     if not session:
@@ -181,5 +181,5 @@ def delete(userId, bucket, archiveId, remove=True, session=None):
         else:
             result.update({"record_state_key": "to_delete", "record_state_val": str(time.time())})
     
-    return(True)
+    return True
 

--- a/anchore_engine/db/db_archivemetadata.py
+++ b/anchore_engine/db/db_archivemetadata.py
@@ -17,7 +17,7 @@ def add(userId, bucket, archiveId, documentName, content_url=None, metadata=None
 
     doc_record = ObjectStorageMetadata(userId=userId, bucket=bucket, archiveId=archiveId, documentName=documentName, content_url=content_url, document_metadata=metadata, is_compressed=is_compressed, digest=content_digest, size=size)
     merged_result = session.merge(doc_record)
-    return (True)
+    return True
 
 
 def get_all(session=None):
@@ -31,7 +31,7 @@ def get_all(session=None):
         obj = dict((key, value) for key, value in vars(result).items() if not key.startswith('_'))
         ret.append(obj)
 
-    return (ret)
+    return ret
 
 
 def get(userId, bucket, archiveId, session=None):
@@ -42,7 +42,7 @@ def get(userId, bucket, archiveId, session=None):
         obj = dict((key, value) for key, value in vars(result).items() if not key.startswith('_'))
         ret.update(obj)
 
-    return (ret)
+    return ret
 
 
 def get_onlymeta(userId, bucket, archiveId, session=None):
@@ -67,7 +67,7 @@ def get_byname(userId, documentName, session=None):
         obj = dict((key, value) for key, value in vars(result).items() if not key.startswith('_'))
         ret = obj
 
-    return (ret)
+    return ret
 
 
 def exists(userId, bucket, archiveId, session=None):
@@ -114,7 +114,7 @@ def list_all_notempty(session=None):
         if obj:
             ret.append(obj)
 
-    return (ret)
+    return ret
 
 
 def list_all(session=None, **dbfilter):
@@ -135,7 +135,7 @@ def list_all(session=None, **dbfilter):
         #if obj:
         #    ret.append(obj)
 
-    return (ret)
+    return ret
 
 
 def list_all_byuserId(userId, limit=None, session=None, **dbfilter):
@@ -161,11 +161,11 @@ def list_all_byuserId(userId, limit=None, session=None, **dbfilter):
         #if obj:
         #    ret.append(obj)
 
-    return (ret)
+    return ret
 
 
 def update(userId, bucket, archiveId, documentName, content_url=None, metadata=None, session=None):
-    return (add(userId, bucket, archiveId, documentName, content_url, metadata, session=session))
+    return add(userId, bucket, archiveId, documentName, content_url, metadata, session=session)
 
 
 def delete_byfilter(userId, remove=True, session=None, **dbfilter):
@@ -183,7 +183,7 @@ def delete_byfilter(userId, remove=True, session=None, **dbfilter):
                 result.update({"record_state_key": "to_delete", "record_state_val": str(time.time())})
             ret = True
 
-    return (ret)
+    return ret
 
 
 def delete(userId, bucket, archiveId, remove=True, session=None):
@@ -197,4 +197,4 @@ def delete(userId, bucket, archiveId, remove=True, session=None):
         else:
             result.update({"record_state_key": "to_delete", "record_state_val": str(time.time())})
 
-    return (True)
+    return True

--- a/anchore_engine/db/db_catalog_image.py
+++ b/anchore_engine/db/db_catalog_image.py
@@ -31,7 +31,7 @@ def add_record(input_image_record, session=None):
         our_result = CatalogImage(**image_record)
         session.add(our_result)
     
-    return(True)
+    return True
 
 def update_record(input_image_record, session=None):
     if not session:
@@ -69,7 +69,7 @@ def update_record(input_image_record, session=None):
 
         our_result.update(image_record)
     
-    return(True)
+    return True
 
 def update_record_image_detail(input_image_record, updated_image_detail, session=None):
     if not session:
@@ -85,9 +85,9 @@ def update_record_image_detail(input_image_record, updated_image_detail, session
         for tag_record in updated_image_detail:
             if tag_record not in image_record['image_detail']:
                 image_record['image_detail'].append(tag_record)
-                return(update_record(image_record, session=session))
+                return update_record(image_record, session=session)
 
-    return(image_record)
+    return image_record
 
 def get(imageDigest, userId, session=None):
     if not session:
@@ -104,7 +104,7 @@ def get(imageDigest, userId, session=None):
             imgobj = db.db_catalog_image_docker.get_alltags(imageDigest, userId, session=session)
             ret['image_detail'] = imgobj
 
-    return(ret)
+    return ret
 
 def get_docker_created_at(record):
     latest_ts = 0
@@ -118,12 +118,12 @@ def get_docker_created_at(record):
                 pass
     except:
         pass
-    return(latest_ts)
+    return latest_ts
 
 def get_created_at(record):
     if 'created_at' in record and record['created_at']:
-        return(record['created_at'])
-    return(0)
+        return record['created_at']
+    return 0
 
 def get_byimagefilter(userId, image_type, dbfilter={}, onlylatest=False, session=None):
     if not session:
@@ -151,16 +151,16 @@ def get_byimagefilter(userId, image_type, dbfilter={}, onlylatest=False, session
         if latest:
             ret = [latest]
 
-    return(ret)
+    return ret
 
 def get_all_tagsummary(userId, session=None):
     
     results = session.query(CatalogImage.imageDigest, CatalogImage.parentDigest, CatalogImageDocker.registry, CatalogImageDocker.repo, CatalogImageDocker.tag, CatalogImage.analysis_status, CatalogImageDocker.created_at, CatalogImageDocker.imageId, CatalogImage.analyzed_at, CatalogImageDocker.tag_detected_at).filter(and_(CatalogImage.userId == userId, CatalogImage.imageDigest == CatalogImageDocker.imageDigest, CatalogImageDocker.userId == userId))
     def mymap(x):
-        return({'imageDigest': x[0], 'parentDigest': x[1], 'fulltag': x[2]+"/"+x[3]+":"+x[4], 'analysis_status': x[5], 'created_at': x[6], 'imageId': x[7], 'analyzed_at': x[8], 'tag_detected_at': x[9]})
+        return {'imageDigest': x[0], 'parentDigest': x[1], 'fulltag': x[2]+"/"+x[3]+":"+x[4], 'analysis_status': x[5], 'created_at': x[6], 'imageId': x[7], 'analyzed_at': x[8], 'tag_detected_at': x[9]}
     ret = list(map(mymap, list(results)))
 
-    return(ret)
+    return ret
 
 def get_all_byuserId(userId, limit=None, session=None):
     if not session:
@@ -192,7 +192,7 @@ def get_all_byuserId(userId, limit=None, session=None):
                     dbobj['image_detail'] = []                
 
             ret.append(dbobj)
-    return(ret)
+    return ret
 
 def get_all_iter(session=None):
     if not session:
@@ -225,7 +225,7 @@ def get_all(session=None):
                 dbobj['image_detail'] = imgobj
             ret.append(dbobj)
 
-    return(ret)
+    return ret
 
 def get_byfilter(userId, session=None, **kwargs):
     if not session:
@@ -246,7 +246,7 @@ def get_byfilter(userId, session=None, **kwargs):
                 dbobj['image_detail'] = imgobj
             ret.append(dbobj)
 
-    return(ret)
+    return ret
 
 def delete(imageDigest, userId, session=None):
     if not session:
@@ -262,7 +262,7 @@ def delete(imageDigest, userId, session=None):
     for result in our_results:
         session.delete(result)
 
-    return(True)
+    return True
 
 #
 # def get_tags_by_time_range(session, userId, start=None, end=None):

--- a/anchore_engine/db/db_catalog_image_docker.py
+++ b/anchore_engine/db/db_catalog_image_docker.py
@@ -15,7 +15,7 @@ def update_record(record, session=None):
     if our_result:
         our_result.update(record)
 
-    return(True)
+    return True
 
 def add_record(record, session=None):
     if not session:
@@ -26,7 +26,7 @@ def add_record(record, session=None):
         our_result = CatalogImageDocker(**record)
         session.add(our_result)
 
-    return(True)
+    return True
 
 def add(imageDigest, userId, tag, registry=None, user=None, repo=None, digest=None, imageId=None, dockerfile=None, tag_detected_at=None, session=None):
     if not session:
@@ -51,10 +51,10 @@ def add(imageDigest, userId, tag, registry=None, user=None, repo=None, digest=No
     else:
         our_result.update(dbobj)
 
-    return(True)
+    return True
 
 def update(imageDigest, userId, tag, registry=None, user=None, repo=None, digest=None, imageId=None, dockerfile=None, tag_detected_at=None, session=None):
-    return(add(imageDigest, userId, tag, registry=registry, user=user, repo=repo, digest=digest, imageId=imageId, dockerfile=dockerfile, session=session))
+    return add(imageDigest, userId, tag, registry=registry, user=user, repo=repo, digest=digest, imageId=imageId, dockerfile=dockerfile, session=session)
 
 def get_byfilter(userId, session=None, **kwargs):
     if not session:
@@ -69,7 +69,7 @@ def get_byfilter(userId, session=None, **kwargs):
         dbobj = dict((key,value) for key, value in vars(result).items() if not key.startswith('_'))
         ret.append(dbobj)
 
-    return(ret)
+    return ret
 
 def get_alltags(imageDigest, userId, session=None):
     if not session:
@@ -85,7 +85,7 @@ def get_alltags(imageDigest, userId, session=None):
             #dbobj.pop('_sa_instance_state', None)
             ret.append(dbobj)
 
-    return(ret)
+    return ret
 
 def get(imageDigest, userId, tag, session=None):
     if not session:
@@ -98,7 +98,7 @@ def get(imageDigest, userId, tag, session=None):
         dbobj = dict((key,value) for key, value in vars(result).items() if not key.startswith('_'))
         ret = dbobj
 
-    return(ret)
+    return ret
 
 def get_all(userId, session=None):
     if not session:
@@ -112,13 +112,13 @@ def get_all(userId, session=None):
             dbobj = dict((key,value) for key, value in vars(result).items() if not key.startswith('_'))
             ret.append(dbobj)
             
-    return(ret)
+    return ret
 
 def delete(imageDigest, userId, tag, session=None):
     if not session:
         session = db.Session
 
-    return(True)
+    return True
 
 
 def get_tag_histories(session, userId, registries=None, repositories=None, tags=None):

--- a/anchore_engine/db/db_objectstorage.py
+++ b/anchore_engine/db/db_objectstorage.py
@@ -45,7 +45,7 @@ def get_metadata(userId, bucket, key, session=None):
                 ret[k] = json.loads(result[i])
             else:
                 ret[k] = result[i]
-    return (ret)
+    return ret
 
 
 def exists(userId, bucket, key, session=None):
@@ -72,7 +72,7 @@ def list_all(session=None, **dbfilter):
         if obj:
             ret.append(obj)
 
-    return (ret)
+    return ret
 
 
 def delete(userId, bucket, key, session=None):
@@ -83,4 +83,4 @@ def delete(userId, bucket, key, session=None):
     if result:
         session.delete(result)
 
-    return (True)
+    return True

--- a/anchore_engine/db/db_policybundle.py
+++ b/anchore_engine/db/db_policybundle.py
@@ -25,7 +25,7 @@ def add(policyId, userId, active, inobj, session=None):
         inobj['last_updated'] = anchore_now()
         our_result.update(inobj)
 
-    return(True)
+    return True
 
 def get_all(session=None):
     if not session:
@@ -38,7 +38,7 @@ def get_all(session=None):
         obj = dict((key,value) for key, value in vars(result).items() if not key.startswith('_'))
         ret.append(obj)
 
-    return(ret)
+    return ret
 
 def get_all_byuserId(userId, limit=None, session=None):
     if not session:
@@ -54,7 +54,7 @@ def get_all_byuserId(userId, limit=None, session=None):
         obj = dict((key,value) for key, value in vars(result).items() if not key.startswith('_'))
         ret.append(obj)
 
-    return(ret)
+    return ret
 
 def get_byfilter(userId, session=None, **dbfilter):
     if not session:
@@ -70,7 +70,7 @@ def get_byfilter(userId, session=None, **dbfilter):
             obj = dict((key,value) for key, value in vars(result).items() if not key.startswith('_'))
             ret.append(obj)
 
-    return(ret)
+    return ret
 
 def get(userId, policyId, session=None):
     if not session:
@@ -83,7 +83,7 @@ def get(userId, policyId, session=None):
         obj = dict((key,value) for key, value in vars(result).items() if not key.startswith('_'))
         ret = obj
 
-    return(ret)
+    return ret
 
 def get_active_policy(userId, session=None):
     if not session:
@@ -96,7 +96,7 @@ def get_active_policy(userId, session=None):
         obj = dict((key,value) for key, value in vars(result).items() if not key.startswith('_'))
         ret = obj
 
-    return(ret)
+    return ret
 
 def set_active_policy(policyId, userId, session=None):
     if not session:
@@ -112,10 +112,10 @@ def set_active_policy(policyId, userId, session=None):
         for result in results:
             result.update({'active':False})
 
-    return(True)
+    return True
 
 def update(policyId, userId, active, inobj, session=None):
-    return(add(policyId, userId, active, inobj, session=session))
+    return add(policyId, userId, active, inobj, session=session)
 
 def update_record(input_record, session=None):
     if not session:
@@ -125,7 +125,7 @@ def update_record(input_record, session=None):
     if our_result:
         our_result.update(input_record)
         
-    return(True)
+    return True
 
 def delete(policyId, userId, session=None):
     if not session:
@@ -138,5 +138,5 @@ def delete(policyId, userId, session=None):
         session.delete(result)
         ret = True
 
-    return(ret)
+    return ret
 

--- a/anchore_engine/db/db_policyeval.py
+++ b/anchore_engine/db/db_policyeval.py
@@ -34,7 +34,7 @@ def tsadd(policyId, userId, imageDigest, tag, final_action, inobj, session=None)
 #    finally:
 #        session.rollback()
 
-    return(True)
+    return True
 
 def tsget_all(userId, imageDigest, tag, policyId=None, session=None):
     if not session:
@@ -53,7 +53,7 @@ def tsget_all(userId, imageDigest, tag, policyId=None, session=None):
             obj = dict((key,value) for key, value in vars(result).items() if not key.startswith('_'))
             ret.append(obj)
 
-    return(ret)
+    return ret
 
 def tsget_all_bytag(userId, tag, policyId=None, session=None):
     if not session:
@@ -71,7 +71,7 @@ def tsget_all_bytag(userId, tag, policyId=None, session=None):
             obj = dict((key,value) for key, value in vars(result).items() if not key.startswith('_'))
             ret.append(obj)
 
-    return(ret)
+    return ret
 
 
 def tsget_latest(userId, imageDigest, tag, policyId=None, session=None):
@@ -83,7 +83,7 @@ def tsget_latest(userId, imageDigest, tag, policyId=None, session=None):
     if results:
         ret = results[0]
 
-    return(ret)
+    return ret
 
 def tsget_byfilter(userId, session=None, **dbfilter):
     if not session:
@@ -99,7 +99,7 @@ def tsget_byfilter(userId, session=None, **dbfilter):
             obj = dict((key,value) for key, value in vars(result).items() if not key.startswith('_'))
             ret.append(obj)
 
-    return(ret)
+    return ret
 
 def add(policyId, userId, imageDigest, tag, final_action, created_at, inobj, session=None):
     if not session:
@@ -121,7 +121,7 @@ def add(policyId, userId, imageDigest, tag, final_action, created_at, inobj, ses
 #    finally:
 #        session.rollback()
     
-    return(True)
+    return True
 
 def get_all(session=None):
     if not session:
@@ -134,7 +134,7 @@ def get_all(session=None):
         obj = dict((key,value) for key, value in vars(result).items() if not key.startswith('_'))
         ret.append(obj)
 
-    return(ret)
+    return ret
 
 def get_all_byuserId(userId, limit=None, session=None):
     if not session:
@@ -150,7 +150,7 @@ def get_all_byuserId(userId, limit=None, session=None):
         obj = dict((key,value) for key, value in vars(result).items() if not key.startswith('_'))
         ret.append(obj)
 
-    return(ret)
+    return ret
 
 def get_all_bydigest(userId, imageDigest, session):
     if not session:
@@ -164,7 +164,7 @@ def get_all_bydigest(userId, imageDigest, session):
         obj = dict((key,value) for key, value in vars(result).items() if not key.startswith('_'))
         ret.append(obj)
 
-    return(ret)
+    return ret
 
 def add_all_for_digest(userId, records, session):
     """
@@ -201,7 +201,7 @@ def get(userId, imageDigest, tag, policyId=None, session=None):
         obj = dict((key,value) for key, value in vars(result).items() if not key.startswith('_'))
         ret = obj
 
-    return(ret)
+    return ret
 
 def update(policyId, userId, imageDigest, tag, final_action, created_at, inobj, session=None):
     if not session:
@@ -209,12 +209,12 @@ def update(policyId, userId, imageDigest, tag, final_action, created_at, inobj, 
 
     our_result = session.query(PolicyEval).filter_by(policyId=policyId, userId=userId, imageDigest=imageDigest, tag=tag, final_action=final_action).order_by(desc(PolicyEval.created_at)).first()
     if not our_result:
-        return(add(policyId, userId, imageDigest, tag, final_action, created_at, inobj))
+        return add(policyId, userId, imageDigest, tag, final_action, created_at, inobj)
     else:
         inobj['created_at'] = created_at
         our_result.update(inobj)
 
-    return(True)
+    return True
 
 def delete_record(input_record, session=None):
     if not session:
@@ -227,7 +227,7 @@ def delete_record(input_record, session=None):
         session.delete(result)
         ret = True
 
-    return(ret)
+    return ret
 
 def delete_byfilter(userId, session=None, **dbfilter):
     if not session:
@@ -243,7 +243,7 @@ def delete_byfilter(userId, session=None, **dbfilter):
             session.delete(result)
             ret = True
 
-    return(ret)
+    return ret
 
 def delete(userId, imageDigest, tag, policyId=None, session=None):
     if not session:
@@ -267,4 +267,4 @@ def delete(userId, imageDigest, tag, policyId=None, session=None):
 #        finally:
 #            session.rollback()
     
-    return(ret)
+    return ret

--- a/anchore_engine/db/db_queue.py
+++ b/anchore_engine/db/db_queue.py
@@ -41,13 +41,13 @@ def create(queueName, userId, session=None, max_outstanding_msgs=-1, visibility_
         ret = _to_dict(record)
         config_cache().cache_it(key=(userId, queueName), obj=copy.deepcopy(ret))
         
-    return(ret)
+    return ret
 
 
 def generate_dataId(inobj):
     datajson = json.dumps(inobj)
     dataId = hashlib.md5(datajson.encode('utf-8')).hexdigest()
-    return(dataId, datajson)
+    return dataId, datajson
 
 
 def is_inqueue(queueName, userId, data, session=None):
@@ -63,7 +63,7 @@ def is_inqueue(queueName, userId, data, session=None):
         ret.update(dbobj)
         ret['data'] = json.loads(dbobj['data'])
 
-    return(ret)
+    return ret
     
 
 def enqueue(queueName, userId, data, qcount=0, max_qcount=0, priority=False, session=None):
@@ -82,7 +82,7 @@ def enqueue(queueName, userId, data, qcount=0, max_qcount=0, priority=False, ses
     rcount = session.query(Queue).filter_by(queueName=queueName, userId=userId).count()
     metarecord.update({'qlen': rcount})
 
-    return(True)
+    return True
 
 
 def dequeue(queueName, userId, visibility_timeout=None, session=None):
@@ -149,7 +149,7 @@ def dequeue(queueName, userId, visibility_timeout=None, session=None):
             # Threshold of outstanding messages exceeded.
             pass
 
-    return(ret)
+    return ret
 
 
 def _not_visible_msg_count(queueName, userId, session):
@@ -195,7 +195,7 @@ def get_qlen(queueName, userId, session=None):
 
     ret = session.query(Queue).filter_by(queueName=queueName, userId=userId).count()
 
-    return(int(ret))
+    return int(ret)
 
 
 def get_queuenames(userId, session=None):
@@ -207,7 +207,7 @@ def get_queuenames(userId, session=None):
     for record in records:
         ret.append(record.queueName)
 
-    return(ret)
+    return ret
 
 
 def get_all(session=None):
@@ -220,7 +220,7 @@ def get_all(session=None):
     for result in our_results:
         ret.append(_to_dict(result))
 
-    return(ret)
+    return ret
 
 
 def get_byuserId(userId, session=None):
@@ -233,7 +233,7 @@ def get_byuserId(userId, session=None):
     for result in our_results:
         ret.append(_to_dict(result))
 
-    return(ret)
+    return ret
 
 
 def get_queue(queueName, userId, session=None):

--- a/anchore_engine/db/db_queues.py
+++ b/anchore_engine/db/db_queues.py
@@ -21,10 +21,10 @@ def add(queueId, userId, dataId, data, tries, max_tries, session=None):
     #else:
     #    our_result.update(inobj)
 
-    return(True)
+    return True
 
 def add_record(queue_record, session=None):
-    return(add(queue_record['queueId'], queue_record['userId'], queue_record['dataId'], queue_record['data'], queue_record['tries'], queue_record['max_tries'], session=session))
+    return add(queue_record['queueId'], queue_record['userId'], queue_record['dataId'], queue_record['data'], queue_record['tries'], queue_record['max_tries'], session=session)
 
 def get_all(queueId, userId, session=None):
     if not session:
@@ -39,7 +39,7 @@ def get_all(queueId, userId, session=None):
         ret.append(obj)
         #session.delete(result)
 
-    return(ret)
+    return ret
 
 def drain_all(queueId, userId, session=None):
     if not session:
@@ -54,7 +54,7 @@ def drain_all(queueId, userId, session=None):
         ret.append(obj)
         session.delete(result)
 
-    return(ret)
+    return ret
 
 def update_record(queue_record, session=None):
     if not session:
@@ -67,7 +67,7 @@ def update_record(queue_record, session=None):
         dbobj['data'] = json.dumps(queue_record['data'])
         result.update(dbobj)
 
-    return(True)
+    return True
 
 def delete_record(queue_record, session=None):
     if not session:
@@ -80,5 +80,5 @@ def delete_record(queue_record, session=None):
         session.delete(result)
         ret = True
     
-    return(ret)
+    return ret
 

--- a/anchore_engine/db/db_registries.py
+++ b/anchore_engine/db/db_registries.py
@@ -19,7 +19,7 @@ def add(registry, userId, inobj, session=None):
     else:
         our_service.update(inobj)
 
-    return(True)
+    return True
 
 def delete(registry, userId, session=None):
     if not session:
@@ -29,11 +29,11 @@ def delete(registry, userId, session=None):
     if our_service:
         session.delete(our_service)
 
-    return(True)
+    return True
 
 # add and update amount to the same operation since we're using upserts                
 def update(registry, userId, inobj, session=None):
-    return(add(registry, userId, inobj, session=session))
+    return add(registry, userId, inobj, session=session)
 
 def update_record(input_record, session=None):
     if not session:
@@ -43,7 +43,7 @@ def update_record(input_record, session=None):
     if our_result:
         our_result.update(input_record)
         
-    return(True)
+    return True
 
 # get all services from the DB for all registered services/hosts
 def get_all(session=None):
@@ -56,10 +56,10 @@ def get_all(session=None):
     for result in our_results:
         ret.append(dict((key,value) for key, value in vars(result).items() if not key.startswith('_')))
 
-    return(ret)
+    return ret
 
 def get_all_byuserId(userId, limit=None, session=None):
-    return(get_byuserId(userId, limit=limit, session=session))
+    return get_byuserId(userId, limit=limit, session=session)
 
 def get_byuserId(userId, limit=None, session=None):
     if not session:
@@ -74,7 +74,7 @@ def get_byuserId(userId, limit=None, session=None):
     for result in our_results:
         ret.append(dict((key,value) for key, value in vars(result).items() if not key.startswith('_')))
 
-    return(ret)
+    return ret
     
 def get(registry, userId, session=None):
     if not session:
@@ -90,4 +90,4 @@ def get(registry, userId, session=None):
     if record:
         ret.append(record)
 
-    return(ret)
+    return ret

--- a/anchore_engine/db/db_services.py
+++ b/anchore_engine/db/db_services.py
@@ -7,7 +7,7 @@ def make(session=None):
     if not session:
         session = db.Session
 
-    return(Service().make())
+    return Service().make()
 
 def add(hostid, servicename, inobj, session=None):
     if not session:
@@ -23,18 +23,18 @@ def add(hostid, servicename, inobj, session=None):
     else:
         our_service.update(inobj)
 
-    return(True)
+    return True
 
 def delete(hostid, servicename, session=None):
     our_service = session.query(Service).filter_by(hostid=hostid).filter_by(servicename=servicename).first()
     if our_service:
         session.delete(our_service)
 
-    return(True)
+    return True
 
 # add and update amount to the same operation since we're using upserts                
 def update(hostid, servicename, inobj, session=None):
-    return(add(hostid, servicename, inobj, session=session))
+    return add(hostid, servicename, inobj, session=session)
 
 def update_record(input_record, session=None):
     if not session:
@@ -44,7 +44,7 @@ def update_record(input_record, session=None):
     if our_result:
         our_result.update(input_record)
         
-    return(True)
+    return True
 
 # get all services from the DB for all registered services/hosts
 def get_all(session=None):
@@ -57,7 +57,7 @@ def get_all(session=None):
     for result in our_results:
         ret.append(dict((key,value) for key, value in vars(result).items() if not key.startswith('_')))
 
-    return(ret)
+    return ret
 
 def get(hostid, servicename, base_url, session=None):
     if not session:
@@ -69,7 +69,7 @@ def get(hostid, servicename, base_url, session=None):
     if result:
         ret.update(dict((key,value) for key, value in vars(result).items() if not key.startswith('_')))
 
-    return(ret)
+    return ret
 
 def get_byname(servicename, session=None):
     if not session:
@@ -83,5 +83,5 @@ def get_byname(servicename, session=None):
             dbobj = dict((key,value) for key, value in vars(result).items() if not key.startswith('_'))
             ret.append(dbobj)
 
-    return(ret)
+    return ret
 

--- a/anchore_engine/db/db_subscriptions.py
+++ b/anchore_engine/db/db_subscriptions.py
@@ -32,7 +32,7 @@ def add(userId, subscription_key, subscription_type, inobj, session=None):
     else:
         our_result.update(inobj)
 
-    return (True)
+    return True
 
 
 def get_all_byuserId(userId, limit=None, session=None):
@@ -48,7 +48,7 @@ def get_all_byuserId(userId, limit=None, session=None):
     for result in our_results:
         ret.append(result.to_dict())
 
-    return (ret)
+    return ret
 
 
 def get_all(session=None):
@@ -61,7 +61,7 @@ def get_all(session=None):
     for result in our_results:
         ret.append(result.to_dict())
 
-    return (ret)
+    return ret
 
 
 def get(userId, subscription_id, session=None):
@@ -75,7 +75,7 @@ def get(userId, subscription_id, session=None):
     if result:
         ret = result.to_dict()
 
-    return (ret)
+    return ret
 
 
 def get_byfilter(userId, session=None, **dbfilter):
@@ -91,7 +91,7 @@ def get_byfilter(userId, session=None, **dbfilter):
         for result in results:
             ret.append(result.to_dict())
 
-    return (ret)
+    return ret
 
 
 def get_bysubscription_key(userId, subscription_key, session=None):
@@ -107,11 +107,11 @@ def get_bysubscription_key(userId, subscription_key, session=None):
             obj = dict((key, value) for key, value in vars(result).items() if not key.startswith('_'))
             ret.append(obj)
 
-    return (ret)
+    return ret
 
 
 def update(userId, subscription_key, subscription_type, inobj, session=None):
-    return (add(userId, subscription_key, subscription_type, inobj, session=session))
+    return add(userId, subscription_key, subscription_type, inobj, session=session)
 
 
 def delete(userId, subscriptionId, remove=False, session=None):
@@ -131,7 +131,7 @@ def delete(userId, subscriptionId, remove=False, session=None):
 
             ret = True
 
-    return (ret)
+    return ret
 
 
 def delete_bysubscription_key(userId, subscription_key, remove=False, session=None):
@@ -150,7 +150,7 @@ def delete_bysubscription_key(userId, subscription_key, remove=False, session=No
 
             ret = True
 
-    return (ret)
+    return ret
 
 
 def delete_byfilter(userId, remove=False, session=None, **dbfilter):
@@ -170,4 +170,4 @@ def delete_byfilter(userId, remove=False, session=None, **dbfilter):
                 result.update({"record_state_key": "to_delete", "record_state_val": str(time.time())})
             ret = True
 
-    return (ret)
+    return ret

--- a/anchore_engine/db/entities/catalog.py
+++ b/anchore_engine/db/entities/catalog.py
@@ -227,7 +227,7 @@ class Subscription(Base, UtilMixin):
         m = inspect(self)
         for c in m.attrs:
             ret[c.key] = None
-        return (ret)
+        return ret
 
     def __repr__(self):
         return "userId='%s' subscription_type='%s' subscription_key='%s'" % (
@@ -254,7 +254,7 @@ class Subscription(Base, UtilMixin):
 #             for c in m.attrs:
 #                 ret[c.key] = None
 #
-#             return (ret)
+#             return ret
 #
 #         def __repr__(self):
 #             return "registry='%s'" % (self.registry)
@@ -293,7 +293,7 @@ class CatalogImage(Base, UtilMixin):
         for c in m.attrs:
             ret[c.key] = None
 
-        return (ret)
+        return ret
 
     def __repr__(self):
         return "imageDigest='%s'" % (self.imageDigest)
@@ -322,7 +322,7 @@ class CatalogImageDocker(Base, UtilMixin):
         m = inspect(self)
         for c in m.attrs:
             ret[c.key] = None
-        return (ret)
+        return ret
 
     def __repr__(self):
         return '<{} {}/{}:{},digest={},detected_at={}>'.format(super().__repr__(), self.registry, self.repo, self.tag, self.imageDigest, self.tag_detected_at)
@@ -528,7 +528,7 @@ class PolicyEval(Base, UtilMixin):
         m = inspect(self)
         for c in m.attrs:
             ret[c.key] = None
-        return (ret)
+        return ret
 
     def content_compare(self, other):
         selfdata = dict((key, value) for key, value in vars(self).items() if not key.startswith('_'))
@@ -536,10 +536,10 @@ class PolicyEval(Base, UtilMixin):
         for k in ['userId', 'imageDigest', 'tag', 'policyId', 'final_action']:
             try:
                 if selfdata[k] != otherdata[k]:
-                    return (False)
+                    return False
             except:
-                return (False)
-        return (True)
+                return False
+        return True
 
     def __repr__(self):
         return "policyId='%s' userId='%s' imageDigest='%s' tag='%s'" % (
@@ -569,7 +569,7 @@ class Service(Base, UtilMixin):
         m = inspect(self)
         for c in m.attrs:
             ret[c.key] = None
-        return (ret)
+        return ret
 
     def __repr__(self):
         return "hostid='%s'" % (self.hostid)

--- a/anchore_engine/db/entities/common.py
+++ b/anchore_engine/db/entities/common.py
@@ -81,7 +81,7 @@ def anchore_now():
 
     :return: integer unix epoch time
     """
-    return (int(time.time()))
+    return int(time.time())
 
 
 def anchore_now_datetime():
@@ -100,12 +100,12 @@ def get_entity_tables(entity):
     entity_names = [x[1].__tablename__ for x in [x for x in inspect.getmembers(entity) if inspect.isclass(x[1]) and issubclass(x[1], Base) and x[1] != Base]]
     ftables = [x for x in Base.metadata.sorted_tables if x.name in entity_names]
 
-    return(ftables)
+    return ftables
 
 # some DB management funcs
 def get_engine():
     global engine
-    return(engine)
+    return engine
 
 def test_connection():
     global engine
@@ -119,7 +119,7 @@ def test_connection():
     finally:
         if test_connection:
             test_connection.close()
-    return(True)
+    return True
 
 def do_connect(db_params):
     global engine, Session, SerializableSession
@@ -163,7 +163,7 @@ def do_connect(db_params):
     # set up thread-local session factory
     init_thread_session()
 
-    return(True)
+    return True
 
 def do_disconnect():
     global engine
@@ -203,7 +203,7 @@ def get_params(localconfig):
         'db_echo': db_echo
     }
     ret = normalize_db_params(db_params)
-    return(ret)
+    return ret
 
 def normalize_db_params(db_params):
     try:
@@ -223,7 +223,7 @@ def normalize_db_params(db_params):
                 db_connect_args['sslmode'] = 'require'
             
 
-    return(db_params)
+    return db_params
         
 
 def do_create(specific_tables=None, base=Base):
@@ -274,7 +274,7 @@ def initialize(localconfig=None, versions=None):
                 log.err("WARN: could not connect to/initialize db, retrying in 5 seconds - exception: " + str(err))
                 time.sleep(5)
 
-    return (ret)
+    return ret
 
 
 def get_session():

--- a/anchore_engine/db/entities/exceptions.py
+++ b/anchore_engine/db/entities/exceptions.py
@@ -36,7 +36,7 @@ def _get_pgcode_from_ex(ex):
     if not pgcode:
         logger.warn("cannot extract PG code from driver exception - exception details: {}".format(ex))
 
-    return(pgcode)
+    return pgcode
 
 def is_unique_violation(ex):
     """
@@ -49,7 +49,7 @@ def is_unique_violation(ex):
     pgcode = _get_pgcode_from_ex(ex)
     if pgcode and pgcode == PG_UNIQUE_CONSTRAINT_VIOLATION_CODE:
         ret = True
-    return(ret)
+    return ret
     #return isinstance(ex, ProgrammingError) and hasattr(ex, 'orig') and str(ex.orig.args[0]) == 'ERROR' and str(ex.orig.args[2]) == PG_UNIQUE_CONSTRAINT_VIOLATION_CODE
 
 
@@ -64,7 +64,7 @@ def is_lock_acquisition_error(ex):
     pgcode = _get_pgcode_from_ex(ex)
     if pgcode and pgcode == PG_COULD_NOT_GET_ROWLOCK_CODE:
         ret = True
-    return(ret)
+    return ret
     #return isinstance(ex, ProgrammingError) and hasattr(ex, 'orig') and str(ex.orig.args[0]) == 'ERROR' and str(ex.orig.args[2]) == PG_COULD_NOT_GET_ROWLOCK_CODE
 
 
@@ -73,5 +73,5 @@ def is_table_not_found(ex):
     pgcode = _get_pgcode_from_ex(ex)
     if pgcode and pgcode == PG_RELATION_NOT_FOUND_CODE:
         ret = True
-    return(ret)
+    return ret
     #return isinstance(ex, ProgrammingError) and hasattr(ex, 'orig') and str(ex.orig.args[0]) == 'ERROR' and (str(ex.orig.args[2]) == PG_RELATION_NOT_FOUND_CODE or str(ex.orig.args[2]) == PG_RELATION_NOT_FOUND_CODE)

--- a/anchore_engine/db/entities/policy_engine.py
+++ b/anchore_engine/db/entities/policy_engine.py
@@ -200,9 +200,9 @@ class Vulnerability(Base):
     def additional_metadata(self):
         if self.metadata_json:
             if isinstance(self.metadata_json, str):
-                return(json.loads(self.metadata_json))
-            return(self.metadata_json)
-        return(None)
+                return json.loads(self.metadata_json)
+            return self.metadata_json
+        return None
 
     @additional_metadata.setter
     def additional_metadata(self, value):
@@ -249,7 +249,7 @@ class Vulnerability(Base):
                 sev = "Unknown"
         except:
             sev = "Unknown"
-        return(sev)
+        return sev
 
     def get_nvd_vulnerabilities(self, cvss_version=3, _nvd_cls=None, _cpe_cls=None):
         ret = []
@@ -268,7 +268,7 @@ class Vulnerability(Base):
         if nvd_records:
             ret = nvd_records
 
-        return(ret)
+        return ret
 
     def get_nvd_identifiers(self,_nvd_cls, _cpe_cls):
         cves = []
@@ -443,7 +443,7 @@ class FixedArtifact(Base):
                 pkgversion = package_obj.fullversion
 
             if langpack_compare_versions(fix_obj.version, pkgversion, language=package_obj.pkg_type):
-                return(True)
+                return True
 
         # Newer or the same
         return False
@@ -1109,7 +1109,7 @@ class CpeVulnerability(Base):
         except:
             ret = None
 
-        return(ret)
+        return ret
 
     def get_fixed_in(self):
         return []
@@ -1162,7 +1162,7 @@ class CpeV2Vulnerability(Base):
         except:
             ret = None
 
-        return(ret)
+        return ret
 
     def get_cpe23string(self):
         ret = None
@@ -1183,7 +1183,7 @@ class CpeV2Vulnerability(Base):
         except:
             ret = None
 
-        return(ret)
+        return ret
 
     def get_fixed_in(self):
         return []
@@ -1605,7 +1605,7 @@ class ImageCpe(Base):
         return '<{} user_id={}, img_id={}, name={}>'.format(self.__class__, self.image_user_id, self.image_id, self.name)
 
     def fixed_in(self):
-        return(None)
+        return None
 
     def get_cpestring(self):
         ret = None
@@ -1621,7 +1621,7 @@ class ImageCpe(Base):
         except:
             ret = None
 
-        return(ret)
+        return ret
 
     def get_cpe23string(self):
         ret = None
@@ -1641,7 +1641,7 @@ class ImageCpe(Base):
             ret = ':'.join(final_cpe)
         except:
             ret = None
-        return(ret)
+        return ret
 
 class FilesystemAnalysis(Base):
     """
@@ -1792,7 +1792,7 @@ class Image(Base):
     def get_packages_by_type(self, pkg_type):
         db = get_thread_scoped_session()
         typed_packages = db.query(ImagePackage).filter(ImagePackage.image_id==self.id, ImagePackage.image_user_id==self.user_id, ImagePackage.pkg_type==pkg_type).all()
-        return(typed_packages)
+        return typed_packages
 
     def vulnerabilities(self):
         """
@@ -1952,7 +1952,7 @@ class ImagePackageVulnerability(Base):
 
     # To support hash functions like set operations, ensure these align with primary key comparisons to ensure two identical records would match as such.
     def __eq__(self, other):
-        return (isinstance(other, type(self)) and (self.pkg_user_id, self.pkg_image_id, self.pkg_name, self.pkg_version, self.pkg_type, self.pkg_arch, self.vulnerability_id, self.pkg_path) == ((other.pkg_user_id, other.pkg_image_id, other.pkg_name, other.pkg_version, other.pkg_type, other.pkg_arch, other.vulnerability_id, other.pkg_path)))
+        return isinstance(other, type(self)) and (self.pkg_user_id, self.pkg_image_id, self.pkg_name, self.pkg_version, self.pkg_type, self.pkg_arch, self.vulnerability_id, self.pkg_path) == ((other.pkg_user_id, other.pkg_image_id, other.pkg_name, other.pkg_version, other.pkg_type, other.pkg_arch, other.vulnerability_id, other.pkg_path))
 
     def __hash__(self):
         return hash((self.pkg_user_id, self.pkg_image_id, self.pkg_name, self.pkg_version, self.pkg_type, self.pkg_arch, self.vulnerability_id, self.pkg_path))
@@ -2241,4 +2241,4 @@ def select_nvd_classes(db=None):
         log.warn("could not query for nvdv2 sync: {}".format(err))
 
     log.debug("selected {}/{} nvd classes".format(_nvd_cls, _cpe_cls))
-    return(_nvd_cls, _cpe_cls)
+    return _nvd_cls, _cpe_cls

--- a/anchore_engine/db/entities/policy_engine.py
+++ b/anchore_engine/db/entities/policy_engine.py
@@ -1952,7 +1952,7 @@ class ImagePackageVulnerability(Base):
 
     # To support hash functions like set operations, ensure these align with primary key comparisons to ensure two identical records would match as such.
     def __eq__(self, other):
-        return isinstance(other, type(self)) and (self.pkg_user_id, self.pkg_image_id, self.pkg_name, self.pkg_version, self.pkg_type, self.pkg_arch, self.vulnerability_id, self.pkg_path) == ((other.pkg_user_id, other.pkg_image_id, other.pkg_name, other.pkg_version, other.pkg_type, other.pkg_arch, other.vulnerability_id, other.pkg_path))
+        return isinstance(other, type(self)) and (self.pkg_user_id, self.pkg_image_id, self.pkg_name, self.pkg_version, self.pkg_type, self.pkg_arch, self.vulnerability_id, self.pkg_path) == (other.pkg_user_id, other.pkg_image_id, other.pkg_name, other.pkg_version, other.pkg_type, other.pkg_arch, other.vulnerability_id, other.pkg_path)
 
     def __hash__(self):
         return hash((self.pkg_user_id, self.pkg_image_id, self.pkg_name, self.pkg_version, self.pkg_type, self.pkg_arch, self.vulnerability_id, self.pkg_path))

--- a/anchore_engine/db/entities/upgrade.py
+++ b/anchore_engine/db/entities/upgrade.py
@@ -32,7 +32,7 @@ def do_db_compatibility_check():
     try:
         engine = anchore_engine.db.entities.common.get_engine()
         if engine.dialect.server_version_info >= required_pg_version:
-            return (True)
+            return True
         else:
             raise Exception("discovered db version {} is not >= required db version {}".format(engine.dialect.server_version_info, required_pg_version))
     except Exception as err:
@@ -65,7 +65,7 @@ def get_versions():
         else:
             raise Exception("Cannot find existing/populated anchore DB tables in connected database - has anchore-engine initialized this DB?\n\nDB - exception: " + str(err))
 
-    return (code_versions, db_versions)
+    return code_versions, db_versions
 
 
 def do_version_update(db_versions, code_versions):
@@ -74,7 +74,7 @@ def do_version_update(db_versions, code_versions):
     with session_scope() as dbsession:
         db_anchore.add(code_versions['service_version'], code_versions['db_version'], code_versions, session=dbsession)
 
-    return (True)
+    return True
 
 
 @contextmanager
@@ -105,7 +105,7 @@ def do_create_tables(specific_tables=None):
     except Exception as err:
         raise err
     print("DB Tables created")
-    return (True)
+    return True
 
 
 def do_db_bootstrap(localconfig=None, db_versions=None, code_versions=None):
@@ -207,7 +207,7 @@ def do_upgrade(inplace, incode):
         print(("upgrading service: from=" + str(inplace['service_version']) + " to=" + str(incode['service_version'])))
 
     ret = True
-    return (ret)
+    return ret
 
 
 ### Individual upgrade routines - be sure to add to the function map at the end of this module if adding a new routine here
@@ -256,7 +256,7 @@ def db_upgrade_001_002():
     except Exception as err:
         raise Exception("failed to perform DB policy_bundle table upgrade - exception: " + str(err))
 
-    return (True)
+    return True
 
 
 def db_upgrade_002_003():

--- a/anchore_engine/db/legacy_db_users.py
+++ b/anchore_engine/db/legacy_db_users.py
@@ -28,7 +28,7 @@ def add(userId, password, inobj, session=None):
         inobj['password'] = password
         our_result.update(inobj)
 
-    return(True)
+    return True
 
 def get_all(session=None):
     if not session:
@@ -42,7 +42,7 @@ def get_all(session=None):
         obj.update(dict((key,value) for key, value in vars(result).items() if not key.startswith('_')))
         ret.append(obj)
 
-    return(ret)
+    return ret
 
 def get(userId, session=None):
     if not session:
@@ -56,10 +56,10 @@ def get(userId, session=None):
         obj = dict((key,value) for key, value in vars(result).items() if not key.startswith('_'))
         ret = obj
 
-    return(ret)
+    return ret
 
 def update(userId, password, inobj, session=None):
-    return(add(userId, password, inobj, session=session))
+    return add(userId, password, inobj, session=session)
 
 def delete(userId, session=None):
     if not session:
@@ -80,5 +80,5 @@ def delete(userId, session=None):
 #        finally:
 #            session.rollback()
     
-    return(ret)
+    return ret
 

--- a/anchore_engine/monitors.py
+++ b/anchore_engine/monitors.py
@@ -31,12 +31,12 @@ def default_monitor_func(**kwargs):
     if click < 5:
         click = click + 1
         logger.debug("service ("+str(servicename)+") starting in: " + str(5 - click))
-        return (True)
+        return True
 
     if round(time.time() - last_run) < kwargs['kick_timer']:
         logger.spew(
             "timer hasn't kicked yet: " + str(round(time.time() - last_run)) + " : " + str(kwargs['kick_timer']))
-        return (True)
+        return True
 
     try:
         running = True

--- a/anchore_engine/service.py
+++ b/anchore_engine/service.py
@@ -213,7 +213,7 @@ class BaseService(object, metaclass=ServiceMeta):
         :param global_config:
         :return: service configuration for this service
         """
-        assert(self.__service_name__ in global_config['services'])
+        assert self.__service_name__ in global_config['services']
         return global_config['services'][self.__service_name__]
 
     def configure(self):
@@ -522,7 +522,7 @@ class ApiService(BaseService):
                 enable_swagger_ui = self.configuration.get('enable_swagger_ui')
             elif self.global_configuration.get('enable_swagger_ui', None) is not None:
                 enable_swagger_ui = self.global_configuration.get('enable_swagger_ui')
-                
+
             flask_app_options = {'swagger_ui': enable_swagger_ui}
             self._application = connexion.FlaskApp(__name__, specification_dir=api_spec_dir, options=flask_app_options)
             flask_app = self._application.app

--- a/anchore_engine/services/analyzer/api/controllers/default_controller.py
+++ b/anchore_engine/services/analyzer/api/controllers/default_controller.py
@@ -21,7 +21,7 @@ def status():
     except Exception as err:
         return_object = str(err)
 
-    return(return_object, httpcode)
+    return return_object, httpcode
 
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
 def interactive_analyze(bodycontent):
@@ -76,5 +76,5 @@ def interactive_analyze(bodycontent):
         logger.error(str(err))
         return_object = str(err)
 
-    return(return_object, httpcode)
+    return return_object, httpcode
     #return(json.dumps(return_object, indent=4)+"\n", httpcode)

--- a/anchore_engine/services/apiext/api/controllers/images.py
+++ b/anchore_engine/services/apiext/api/controllers/images.py
@@ -38,11 +38,11 @@ def make_response_content(content_type, content_data):
     if content_type not in all_content_types:    
         logger.warn("input content_type (" + str(content_type) +") not supported (" + str(
             all_content_types) + ")")
-        return(ret)
+        return ret
 
     if not content_data:
         logger.warn("empty content data given to format - returning empty result")
-        return(ret)
+        return ret
 
     # type-specific formatting of content data
     if content_type == 'os':
@@ -191,7 +191,7 @@ def make_response_content(content_type, content_data):
             logger.debug("couldn't parse any generic package elements, returning raw content_data - exception: {}".format(err))
             ret = content_data
 
-    return(ret)
+    return ret
 
 def make_cvss_scores(metrics):
     """
@@ -267,7 +267,7 @@ def make_response_vulnerability(vulnerability_type, vulnerability_data):
 
     if not vulnerability_data:
         logger.warn("empty query data given to format - returning empty result")
-        return (ret)
+        return ret
 
     eltemplate = {
         'vuln': 'None',
@@ -415,7 +415,7 @@ def make_response_vulnerability(vulnerability_type, vulnerability_data):
     else:
         ret = vulnerability_data
 
-    return (ret)
+    return ret
 
 
 def make_response_policyeval(eval_record, params, catalog_client):
@@ -451,7 +451,7 @@ def make_response_policyeval(eval_record, params, catalog_client):
     except Exception as err:
         raise Exception("failed to format policy eval response: " + str(err))
 
-    return (ret)
+    return ret
 
 
 def make_response_image(image_record, include_detail=True):
@@ -503,7 +503,7 @@ def make_response_image(image_record, include_detail=True):
     for removekey in ['record_state_val', 'record_state_key']:
         image_record.pop(removekey, None)
 
-    return (ret)
+    return ret
 
 
 def impl_template(request_inputs):
@@ -520,7 +520,7 @@ def impl_template(request_inputs):
         return_object = make_response_error(err, in_httpcode=httpcode)
         httpcode = return_object['httpcode']
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 def lookup_imageDigest_from_imageId(request_inputs, imageId):
     user_auth = request_inputs['auth']
@@ -544,7 +544,7 @@ def lookup_imageDigest_from_imageId(request_inputs, imageId):
         logger.debug("operation exception: " + str(err))
         raise err
 
-    return (ret)
+    return ret
 
 def vulnerability_query(account, digest, vulnerability_type, force_refresh=False, vendor_only=True, doformat=False):
     # user_auth = request_inputs['auth']
@@ -601,7 +601,7 @@ def vulnerability_query(account, digest, vulnerability_type, force_refresh=False
         return_object = make_response_error(err, in_httpcode=httpcode)
         httpcode = return_object['httpcode']
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 def get_content(request_inputs, content_type, doformat=False):
     user_auth = request_inputs['auth']
@@ -672,7 +672,7 @@ def get_content(request_inputs, content_type, doformat=False):
         return_object = make_response_error(err, in_httpcode=httpcode)
         httpcode = return_object['httpcode']
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 # repositories
 @authorizer.requires([ActionBoundPermission(domain=RequestingAccountValue())])
@@ -725,7 +725,7 @@ def repositories(request_inputs):
         httpcode = return_object['httpcode']
 
 
-    return(return_object, httpcode)
+    return return_object, httpcode
 
 
 # images CRUD
@@ -1069,12 +1069,12 @@ def get_image_content_by_type(imageDigest, ctype):
 @flask_metrics.do_not_track()
 @authorizer.requires([ActionBoundPermission(domain=RequestingAccountValue())])
 def get_image_content_by_type_files(imageDigest):
-    return(get_image_content_by_type(imageDigest, 'files'))
+    return get_image_content_by_type(imageDigest, 'files')
 
 @flask_metrics.do_not_track()
 @authorizer.requires([ActionBoundPermission(domain=RequestingAccountValue())])
 def get_image_content_by_type_javapackage(imageDigest):
-    return(get_image_content_by_type(imageDigest, 'java'))
+    return get_image_content_by_type(imageDigest, 'java')
 
 @flask_metrics.do_not_track()
 @authorizer.requires([ActionBoundPermission(domain=RequestingAccountValue())])
@@ -1097,12 +1097,12 @@ def get_image_content_by_type_imageId(imageId, ctype):
 @flask_metrics.do_not_track()
 @authorizer.requires([ActionBoundPermission(domain=RequestingAccountValue())])
 def get_image_content_by_type_imageId_files(imageId):
-    return(get_image_content_by_type_imageId(imageId, 'files'))
+    return get_image_content_by_type_imageId(imageId, 'files')
 
 @flask_metrics.do_not_track()
 @authorizer.requires([ActionBoundPermission(domain=RequestingAccountValue())])
 def get_image_content_by_type_imageId_javapackage(imageId):
-    return(get_image_content_by_type_imageId(imageId, 'java'))
+    return get_image_content_by_type_imageId(imageId, 'java')
 
 
 @flask_metrics.do_not_track()
@@ -1436,7 +1436,7 @@ def images_imageDigest(request_inputs, imageDigest):
         return_object = make_response_error(err, in_httpcode=httpcode)
         httpcode = return_object['httpcode']
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 def images_check_impl(request_inputs, image_records):
@@ -1519,7 +1519,7 @@ def images_check_impl(request_inputs, image_records):
         return_object = make_response_error(err, in_httpcode=httpcode)
         httpcode = return_object['httpcode']
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 def images_imageDigest_check(request_inputs, imageDigest):
@@ -1547,7 +1547,7 @@ def images_imageDigest_check(request_inputs, imageDigest):
         return_object = make_response_error(err, in_httpcode=httpcode)
         httpcode = return_object['httpcode']
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 

--- a/anchore_engine/services/apiext/api/controllers/policies.py
+++ b/anchore_engine/services/apiext/api/controllers/policies.py
@@ -65,7 +65,7 @@ def make_response_policy(policy_record, params):
     for removekey in ['record_state_val', 'record_state_key']:
         ret.pop(removekey, None)
 
-    return (ret)
+    return ret
 
 
 @authorizer.requires([ActionBoundPermission(domain=RequestingAccountValue())])
@@ -100,7 +100,7 @@ def list_policies(detail=None):
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
         httpcode = return_object['httpcode']
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @authorizer.requires([ActionBoundPermission(domain=RequestingAccountValue())])
@@ -130,7 +130,7 @@ def add_policy(bundle):
             if not response.get('valid', False):
                 httpcode = 400
                 return_object = anchore_engine.common.helpers.make_response_error('Bundle failed validation', in_httpcode=400, details={'validation_details': response.get('validation_details')})
-                return (return_object, httpcode)
+                return return_object, httpcode
 
         except Exception as err:
             raise Exception('Error response from policy service during bundle validation. Validation could not be performed: {}'.format(err))
@@ -157,7 +157,7 @@ def add_policy(bundle):
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
         httpcode = return_object['httpcode']
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @authorizer.requires([ActionBoundPermission(domain=RequestingAccountValue())])
@@ -192,7 +192,7 @@ def get_policy(policyId, detail=None):
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
         httpcode = return_object['httpcode']
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @authorizer.requires([ActionBoundPermission(domain=RequestingAccountValue())])
@@ -251,7 +251,7 @@ def update_policy(bundle, policyId, active=False):
                     httpcode = 400
                     return_object = anchore_engine.common.helpers.make_response_error('Bundle failed validation',
                                                                                       in_httpcode=400, details={'validation_details': response.get('validation_details')})
-                    return (return_object, httpcode)
+                    return return_object, httpcode
 
             except Exception as err:
                 raise Exception(
@@ -267,7 +267,7 @@ def update_policy(bundle, policyId, active=False):
     except Exception as err:
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
         httpcode = return_object['httpcode']
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @authorizer.requires([ActionBoundPermission(domain=RequestingAccountValue())])
@@ -311,4 +311,4 @@ def delete_policy(policyId):
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
         httpcode = return_object['httpcode']
 
-    return (return_object, httpcode)
+    return return_object, httpcode

--- a/anchore_engine/services/apiext/api/controllers/query.py
+++ b/anchore_engine/services/apiext/api/controllers/query.py
@@ -53,7 +53,7 @@ def query_vulnerabilities(id=None, page=1, limit=None, affected_package=None, af
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
         httpcode = return_object['httpcode']
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 @authorizer.requires([ActionBoundPermission(domain=RequestingAccountValue())])
 def query_images_by_vulnerability(vulnerability_id=None, severity=None, namespace=None, affected_package=None, page=1, limit=None, vendor_only=True):
@@ -83,7 +83,7 @@ def query_images_by_vulnerability(vulnerability_id=None, severity=None, namespac
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
         httpcode = return_object['httpcode']
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 @authorizer.requires([ActionBoundPermission(domain=RequestingAccountValue())])
 def query_images_by_package(name=None, version=None, package_type=None, page=1, limit=None):
@@ -113,6 +113,6 @@ def query_images_by_package(name=None, version=None, package_type=None, page=1, 
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
         httpcode = return_object['httpcode']
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 

--- a/anchore_engine/services/apiext/api/controllers/registries.py
+++ b/anchore_engine/services/apiext/api/controllers/registries.py
@@ -34,7 +34,7 @@ def make_response_registry(user_auth, registry_record, params):
     for removekey in ['record_state_val', 'record_state_key']:
         ret.pop(removekey, None)
 
-    return (ret)
+    return ret
 
 @authorizer.requires([ActionBoundPermission(domain=RequestingAccountValue())])
 def list_registries():
@@ -62,7 +62,7 @@ def list_registries():
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
         httpcode = return_object['httpcode']
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @authorizer.requires([ActionBoundPermission(domain=RequestingAccountValue())])
@@ -91,7 +91,7 @@ def get_registry(registry):
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
         httpcode = return_object['httpcode']
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 @authorizer.requires([ActionBoundPermission(domain=RequestingAccountValue())])
 def create_registry(registrydata, validate=True):
@@ -139,7 +139,7 @@ def create_registry(registrydata, validate=True):
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
         httpcode = return_object['httpcode']
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 @authorizer.requires([ActionBoundPermission(domain=RequestingAccountValue())])
 def update_registry(registry, registrydata, validate=True):
@@ -183,7 +183,7 @@ def update_registry(registry, registrydata, validate=True):
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
         httpcode = return_object['httpcode']
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @authorizer.requires([ActionBoundPermission(domain=RequestingAccountValue())])
@@ -212,4 +212,4 @@ def delete_registry(registry):
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
         httpcode = return_object['httpcode']
 
-    return (return_object, httpcode)
+    return return_object, httpcode

--- a/anchore_engine/services/apiext/api/controllers/subscriptions.py
+++ b/anchore_engine/services/apiext/api/controllers/subscriptions.py
@@ -31,7 +31,7 @@ def make_response_subscription(subscription_record, params):
     for removekey in ['record_state_val', 'record_state_key']:
         ret.pop(removekey, None)
 
-    return (ret)
+    return ret
 
 
 @authorizer.requires([ActionBoundPermission(domain=RequestingAccountValue())])
@@ -58,7 +58,7 @@ def list_subscriptions(subscription_key=None, subscription_type=None):
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
         httpcode = return_object['httpcode']
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @authorizer.requires([ActionBoundPermission(domain=RequestingAccountValue())])
@@ -83,7 +83,7 @@ def get_subscription(subscriptionId):
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
         httpcode = return_object['httpcode']
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 @authorizer.requires([ActionBoundPermission(domain=RequestingAccountValue())])
 def add_subscription(subscription):
@@ -113,7 +113,7 @@ def add_subscription(subscription):
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
         httpcode = return_object['httpcode']
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 @authorizer.requires([ActionBoundPermission(domain=RequestingAccountValue())])
 def update_subscription(subscriptionId, subscription):
@@ -144,7 +144,7 @@ def update_subscription(subscriptionId, subscription):
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
         httpcode = return_object['httpcode']
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 @authorizer.requires([ActionBoundPermission(domain=RequestingAccountValue())])
 def delete_subscription(subscriptionId):
@@ -172,4 +172,4 @@ def delete_subscription(subscriptionId):
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
         httpcode = return_object['httpcode']
 
-    return (return_object, httpcode)
+    return return_object, httpcode

--- a/anchore_engine/services/catalog/__init__.py
+++ b/anchore_engine/services/catalog/__init__.py
@@ -79,7 +79,7 @@ def do_user_resources_delete(userId):
     return_object['all_deleted'] = all_deleted
     
     httpcode = 200
-    return(return_object, httpcode)
+    return return_object, httpcode
 
 def handle_account_resource_cleanup(*args, **kwargs):
     watcher = str(kwargs['mythread']['taskType'])
@@ -129,7 +129,7 @@ def handle_account_resource_cleanup(*args, **kwargs):
         anchore_engine.subsys.metrics.summary_observe('anchore_monitor_runtime_seconds', time.time() - timer,
                                                       function=watcher, status="fail")
 
-    return (True)
+    return True
 
 def handle_vulnerability_scan(*args, **kwargs):
     global feed_sync_updated
@@ -148,7 +148,7 @@ def handle_vulnerability_scan(*args, **kwargs):
                 kwargs['mythread']['last_return'] = False
             except:
                 pass
-            return (True)
+            return True
 
         with db.session_scope() as dbsession:
             mgr = manager_factory.for_session(dbsession)
@@ -226,7 +226,7 @@ def handle_vulnerability_scan(*args, **kwargs):
         anchore_engine.subsys.metrics.summary_observe('anchore_monitor_runtime_seconds', time.time() - timer,
                                                       function=watcher, status="fail")
 
-    return (True)
+    return True
 
 
 def handle_service_watcher(*args, **kwargs):
@@ -237,7 +237,7 @@ def handle_service_watcher(*args, **kwargs):
     max_service_orphaned_timer = 3600
     max_service_cleanup_timer = 86400
 
-    while (True):
+    while True:
         logger.debug("FIRING: service watcher")
 
         localconfig = anchore_engine.configuration.localconfig.get_config()
@@ -371,7 +371,7 @@ def handle_service_watcher(*args, **kwargs):
             pass
 
         time.sleep(cycle_timer)
-    return (True)
+    return True
 
 
 def handle_repo_watcher(*args, **kwargs):
@@ -526,7 +526,7 @@ def handle_repo_watcher(*args, **kwargs):
         anchore_engine.subsys.metrics.summary_observe('anchore_monitor_runtime_seconds', time.time() - timer,
                                                       function=watcher, status="fail")
 
-    return (True)
+    return True
 
 
 def handle_image_watcher(*args, **kwargs):
@@ -746,12 +746,12 @@ def handle_image_watcher(*args, **kwargs):
         anchore_engine.subsys.metrics.summary_observe('anchore_monitor_runtime_seconds', time.time() - timer,
                                                       function=watcher, status="fail")
 
-    return (True)
+    return True
 
 
 def check_feedmeta_update(dbsession):
     global feed_sync_updated
-    return (feed_sync_updated)
+    return feed_sync_updated
 
 
 def check_policybundle_update(userId, dbsession):
@@ -766,7 +766,7 @@ def check_policybundle_update(userId, dbsession):
             last_bundle_update = active_policy_record['last_updated']
         else:
             logger.warn("user has no active policy - queueing just in case" + str(userId))
-            return (is_updated)
+            return is_updated
 
         if userId not in bundle_user_last_updated:
             bundle_user_last_updated[userId] = last_bundle_update
@@ -783,7 +783,7 @@ def check_policybundle_update(userId, dbsession):
         bundle_user_last_updated[userId] = 0
         is_updated = True
 
-    return (is_updated)
+    return is_updated
 
 
 def handle_policyeval(*args, **kwargs):
@@ -803,7 +803,7 @@ def handle_policyeval(*args, **kwargs):
                 kwargs['mythread']['last_return'] = False
             except:
                 pass
-            return (True)
+            return True
 
         with db.session_scope() as dbsession:
             feed_updated = check_feedmeta_update(dbsession)
@@ -881,7 +881,7 @@ def handle_policyeval(*args, **kwargs):
         anchore_engine.subsys.metrics.summary_observe('anchore_monitor_runtime_seconds', time.time() - timer,
                                                       function=watcher, status="fail")
 
-    return (True)
+    return True
 
 
 def handle_analyzer_queue(*args, **kwargs):
@@ -909,7 +909,7 @@ def handle_analyzer_queue(*args, **kwargs):
             kwargs['mythread']['last_return'] = False
         except:
             pass
-        return (True)
+        return True
 
     with db.session_scope() as dbsession:
         mgr = manager_factory.for_session(dbsession)
@@ -1008,7 +1008,7 @@ def handle_analyzer_queue(*args, **kwargs):
         anchore_engine.subsys.metrics.summary_observe('anchore_monitor_runtime_seconds', time.time() - timer,
                                                       function=watcher, status="fail")
 
-    return (True)
+    return True
 
 
 def handle_notifications(*args, **kwargs):
@@ -1065,7 +1065,7 @@ def handle_notifications(*args, **kwargs):
                         err))
                 qlen = 0
 
-            while (qlen > 0):
+            while qlen > 0:
                 pupdate_record = q_client.dequeue(subscription_type)
                 if pupdate_record:
                     logger.debug("got notification from queue: " + json.dumps(pupdate_record, indent=4))
@@ -1151,13 +1151,13 @@ def handle_notifications(*args, **kwargs):
         anchore_engine.subsys.metrics.summary_observe('anchore_monitor_runtime_seconds', time.time() - timer,
                                                       function=watcher, status="fail")
 
-    return (True)
+    return True
 
 
 def handle_metrics(*args, **kwargs):
     cycle_timer = kwargs['mythread']['cycle_timer']
 
-    while (True):
+    while True:
 
         # perform some DB read/writes for metrics gathering
         if anchore_engine.subsys.metrics.is_enabled():
@@ -1258,7 +1258,7 @@ default_lease_ttl = 60  # 1 hour ttl, should be more than enough in most cases
 def watcher_func(*args, **kwargs):
     global system_user_auth
 
-    while (True):
+    while True:
         logger.debug("starting generic watcher")
         all_ready = anchore_engine.clients.services.common.check_services_ready(['simplequeue'])
         if not all_ready:
@@ -1305,7 +1305,7 @@ def schedule_watcher(watcher):
 
     if watcher not in watchers:
         logger.warn("input watcher {} not in list of available watchers {}".format(watcher, list(watchers.keys())))
-        return (False)
+        return False
 
     if watchers[watcher]['taskType']:
         logger.debug("should queue job: " + watcher)
@@ -1324,7 +1324,7 @@ def schedule_watcher(watcher):
         except Exception as err:
             logger.warn("failed to enqueue watcher task: " + str(err))
 
-    return (True)
+    return True
 
 
 def monitor_func(**kwargs):
@@ -1333,10 +1333,10 @@ def monitor_func(**kwargs):
     if click < 5:
         click = click + 1
         logger.debug("Catalog monitor starting in: " + str(5 - click))
-        return (True)
+        return True
 
     if running or ((time.time() - last_run) < kwargs['kick_timer']):
-        return (True)
+        return True
 
     logger.debug("FIRING: catalog_monitor")
     try:

--- a/anchore_engine/services/catalog/api/controllers/archives.py
+++ b/anchore_engine/services/catalog/api/controllers/archives.py
@@ -335,4 +335,4 @@ def import_archive(imageDigest, archive_file):
         logger.exception('Failed to import image archive')
         return make_response_error('Error importing image archive: {}'.format(ex), in_httpcode=500), 500
     
-    return("Success", 200)
+    return "Success", 200

--- a/anchore_engine/services/catalog/api/controllers/data_archive.py
+++ b/anchore_engine/services/catalog/api/controllers/data_archive.py
@@ -67,7 +67,7 @@ def create_archive(bucket, archiveid, bodycontent):
     except Exception as err:
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @flask_metrics.do_not_track()
@@ -84,4 +84,4 @@ def delete_archive(bucket, archiveid):
     except Exception as err:
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
 
-    return (return_object, httpcode)
+    return return_object, httpcode

--- a/anchore_engine/services/catalog/api/controllers/default_controller.py
+++ b/anchore_engine/services/catalog/api/controllers/default_controller.py
@@ -28,7 +28,7 @@ def status():
     except Exception as err:
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
 def repo_post(regrepo=None, autosubscribe=False, lookuptag=None, bodycontent={}):
@@ -40,7 +40,7 @@ def repo_post(regrepo=None, autosubscribe=False, lookuptag=None, bodycontent={})
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
@@ -53,7 +53,7 @@ def image_tags_get():
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
@@ -68,7 +68,7 @@ def list_images(tag=None, digest=None, imageId=None, registry_lookup=False, hist
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
@@ -99,7 +99,7 @@ def add_image(image_metadata=None, tag=None, digest=None, created_at=None, from_
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 # @api.route('/image/<imageDigest>', methods=['GET', 'PUT', 'DELETE'])
@@ -115,7 +115,7 @@ def get_image(imageDigest):
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 @flask_metrics.do_not_track()
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
@@ -129,7 +129,7 @@ def update_image(imageDigest, image):
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 @flask_metrics.do_not_track()
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
@@ -143,7 +143,7 @@ def delete_image(imageDigest, force=False):
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 # @api.route('/registry_lookup', methods=['GET'])
@@ -159,7 +159,7 @@ def registry_lookup(tag=None, digest=None):
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 # @api.route('/import', methods=['POST'])
@@ -174,7 +174,7 @@ def registry_lookup(tag=None, digest=None):
 #        httpcode = 500
 #        return_object = str(err)
 #
-#    return (return_object, httpcode)
+#    return return_object, httpcode
 
 
 
@@ -195,7 +195,7 @@ def subscriptions_get(subscription_key=None, subscription_type=None):
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
@@ -209,7 +209,7 @@ def subscriptions_post(bodycontent):
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 # @api.route('/subscriptions/<subscriptionId>', methods=['GET', 'PUT', 'DELETE'])
@@ -225,7 +225,7 @@ def subscriptions_subscriptionId_get(subscriptionId):
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 @flask_metrics.do_not_track()
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
@@ -239,7 +239,7 @@ def subscriptions_subscriptionId_put(subscriptionId, bodycontent):
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 @flask_metrics.do_not_track()
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
@@ -253,7 +253,7 @@ def subscriptions_subscriptionId_delete(subscriptionId):
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @flask_metrics.do_not_track()
@@ -278,7 +278,7 @@ def events_get(source_servicename=None, source_hostid=None, resource_type=None, 
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @flask_metrics.do_not_track()
@@ -293,7 +293,7 @@ def events_post(bodycontent):
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @flask_metrics.do_not_track()
@@ -308,7 +308,7 @@ def events_delete(since=None, before=None, level=None):
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @flask_metrics.do_not_track()
@@ -323,7 +323,7 @@ def events_eventId_get(eventId):
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @flask_metrics.do_not_track()
@@ -338,7 +338,7 @@ def events_eventId_delete(eventId):
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 # user calls
 # @api.route("/users", methods=['GET'])
@@ -353,7 +353,7 @@ def users_get():
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 # @api.route("/users/<inuserId>", methods=['GET', 'DELETE'])
@@ -369,7 +369,7 @@ def users_userId_get(inuserId):
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 @flask_metrics.do_not_track()
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
@@ -383,7 +383,7 @@ def users_userId_delete(inuserId):
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 # system/service calls
 # @api.route("/system", methods=['GET'])
@@ -398,7 +398,7 @@ def system_get():
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 # @api.route("/system/services", methods=['GET'])
@@ -413,7 +413,7 @@ def system_services_get():
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 # @api.route("/system/services/<servicename>", methods=['GET'])
@@ -429,7 +429,7 @@ def system_services_servicename_get(servicename):
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 # @api.route("/system/services/<servicename>/<hostId>", methods=['GET', 'DELETE'])
@@ -445,7 +445,7 @@ def system_services_servicename_hostId_get(servicename, hostId):
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 @flask_metrics.do_not_track()
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
@@ -459,7 +459,7 @@ def system_services_servicename_hostId_delete(servicename, hostId):
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 # @api.route("/system/registries", methods=['GET', 'POST'])
@@ -474,7 +474,7 @@ def system_registries_get():
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
 def system_registries_post(bodycontent, validate=True):
@@ -487,7 +487,7 @@ def system_registries_post(bodycontent, validate=True):
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 # @api.route("/system/registries/<registry>", methods=['GET', 'DELETE', 'PUT'])
@@ -503,7 +503,7 @@ def system_registries_registry_get(registry):
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @flask_metrics.do_not_track()
@@ -518,7 +518,7 @@ def system_registries_registry_delete(registry):
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @flask_metrics.do_not_track()
@@ -533,7 +533,7 @@ def system_registries_registry_put(registry, bodycontent, validate=True):
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 # @api.route("/system/subscriptions", methods=['GET'])
@@ -549,5 +549,5 @@ def system_subscriptions_get():
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 

--- a/anchore_engine/services/catalog/api/controllers/policy_evaluations.py
+++ b/anchore_engine/services/catalog/api/controllers/policy_evaluations.py
@@ -40,7 +40,7 @@ def get_evals(policyId=None, imageDigest=None, tag=None, evalId=None, newest_onl
     except Exception as err:
         return str(anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)), 500
 
-    # return (return_object, httpcode)
+    # return return_object, httpcode
     #     httpcode = 500
     #     return_object = str(err)
 
@@ -64,7 +64,7 @@ def add_eval(bodycontent):
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
@@ -86,7 +86,7 @@ def update_eval(bodycontent):
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
@@ -120,7 +120,7 @@ def delete_eval(bodycontent):
         httpcode = 500
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 def list_evals_impl(dbsession, userId, policyId=None, imageDigest=None, tag=None, evalId=None, newest_only=False, interactive=False):

--- a/anchore_engine/services/catalog/catalog_impl.py
+++ b/anchore_engine/services/catalog/catalog_impl.py
@@ -49,7 +49,7 @@ def policy_engine_image_load(client, imageUserId, imageId, imageDigest):
         logger.error("failed to add/check image: " + str(err))
         raise err
 
-    return(resp)
+    return resp
 
 def registry_lookup(dbsession, request_inputs):
     user_auth = request_inputs['auth']
@@ -93,7 +93,7 @@ def registry_lookup(dbsession, request_inputs):
     except Exception as err:
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
 
-    return(return_object, httpcode)
+    return return_object, httpcode
 
 def repo(dbsession, request_inputs, bodycontent={}):
     user_auth = request_inputs['auth']
@@ -184,7 +184,7 @@ def repo(dbsession, request_inputs, bodycontent={}):
     except Exception as err:
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
 
-    return(return_object, httpcode)
+    return return_object, httpcode
 
 def image_tags(dbsession, request_inputs):
     user_auth = request_inputs['auth']
@@ -202,7 +202,7 @@ def image_tags(dbsession, request_inputs):
     except Exception as err:
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
 
-    return(return_object, httpcode)
+    return return_object, httpcode
 
 def image(dbsession, request_inputs, bodycontent=None):
     user_auth = request_inputs['auth']
@@ -410,7 +410,7 @@ def image(dbsession, request_inputs, bodycontent=None):
         logger.exception('Error processing image request')
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
 
-    return(return_object, httpcode)
+    return return_object, httpcode
 
 def image_imageDigest(dbsession, request_inputs, imageDigest, bodycontent=None):
     method = request_inputs['method']
@@ -473,7 +473,7 @@ def image_imageDigest(dbsession, request_inputs, imageDigest, bodycontent=None):
     except Exception as err:
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
 
-    return(return_object, httpcode)
+    return return_object, httpcode
 
 #def image_import(dbsession, request_inputs, bodycontent=None):
 #    user_auth = request_inputs['auth']
@@ -650,7 +650,7 @@ def subscriptions(dbsession, request_inputs, subscriptionId=None, bodycontent=No
         logger.exception('Error handling subscriptions')
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
 
-    return(return_object, httpcode)
+    return return_object, httpcode
 
 def events(dbsession, request_inputs, bodycontent=None):
     user_auth = request_inputs['auth']
@@ -788,7 +788,7 @@ def events(dbsession, request_inputs, bodycontent=None):
         logger.exception('Error in events handler')
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
 
-    return(return_object, httpcode)
+    return return_object, httpcode
 
 def events_eventId(dbsession, request_inputs, eventId):
     user_auth = request_inputs['auth']
@@ -820,7 +820,7 @@ def events_eventId(dbsession, request_inputs, eventId):
     except Exception as err:
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
 
-    return(return_object, httpcode)
+    return return_object, httpcode
 
 
 def system(dbsession, request_inputs):
@@ -838,7 +838,7 @@ def system(dbsession, request_inputs):
     except Exception as err:
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
 
-    return(return_object, httpcode)
+    return return_object, httpcode
 
 def system_services(dbsession, request_inputs):
     user_auth = request_inputs['auth']
@@ -856,7 +856,7 @@ def system_services(dbsession, request_inputs):
     except Exception as err:
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
 
-    return(return_object, httpcode)
+    return return_object, httpcode
 
 def system_services_servicename(dbsession, request_inputs, inservicename):
     user_auth = request_inputs['auth']
@@ -877,7 +877,7 @@ def system_services_servicename(dbsession, request_inputs, inservicename):
     except Exception as err:
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
 
-    return(return_object, httpcode)
+    return return_object, httpcode
 
 def system_services_servicename_hostId(dbsession, request_inputs, inservicename, inhostId):
     user_auth = request_inputs['auth']
@@ -914,7 +914,7 @@ def system_services_servicename_hostId(dbsession, request_inputs, inservicename,
     except Exception as err:
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
 
-    return(return_object, httpcode)
+    return return_object, httpcode
 
 def system_registries(dbsession, request_inputs, bodycontent={}):
     user_auth = request_inputs['auth']
@@ -993,7 +993,7 @@ def system_registries(dbsession, request_inputs, bodycontent={}):
     except Exception as err:
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
 
-    return(return_object, httpcode)
+    return return_object, httpcode
 
 def refresh_registry_creds(registry_records, dbsession):
 
@@ -1019,7 +1019,7 @@ def refresh_registry_creds(registry_records, dbsession):
                     db_registries.update_record(registry_record, session=dbsession)
 
         logger.debug("registry up-to-date: " + str(registry_record['userId']) + " : " + str(registry_record['registry']) + " : " + str(registry_record['registry_type']))
-    return(True)
+    return True
 
 def system_registries_registry(dbsession, request_inputs, registry, bodycontent={}):
     user_auth = request_inputs['auth']
@@ -1090,7 +1090,7 @@ def system_registries_registry(dbsession, request_inputs, registry, bodycontent=
     except Exception as err:
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
 
-    return(return_object, httpcode)
+    return return_object, httpcode
 
 def system_subscriptions(dbsession, request_inputs):
     user_auth = request_inputs['auth']
@@ -1107,7 +1107,7 @@ def system_subscriptions(dbsession, request_inputs):
     except Exception as err:
         return_object = anchore_engine.common.helpers.make_response_error(err, in_httpcode=httpcode)
 
-    return(return_object, httpcode)
+    return return_object, httpcode
 
 
 ################################################################################
@@ -1211,7 +1211,7 @@ def perform_vulnerability_scan(userId, imageDigest, dbsession, scantag=None, for
             except Exception as err:
                 logger.warn("failed to enqueue notification - exception: " + str(err))
 
-    return(True)
+    return True
 
 def perform_policy_evaluation(userId, imageDigest, dbsession, evaltag=None, policyId=None, interactive=False, newest_only=False):
     ret = {}
@@ -1344,7 +1344,7 @@ def perform_policy_evaluation(userId, imageDigest, dbsession, evaltag=None, poli
 
         # done
 
-    return(curr_evaluation_record, curr_evaluation_result)
+    return curr_evaluation_record, curr_evaluation_result
 
 def add_or_update_image(dbsession, userId, imageId, tags=[], digests=[], parentdigest=None, created_at=None, anchore_data=None, dockerfile=None, dockerfile_mode=None, manifest=None, annotations={}, parent_manifest=None):
     ret = []
@@ -1506,7 +1506,7 @@ def add_or_update_image(dbsession, userId, imageId, tags=[], digests=[], parentd
     for imageDigest in list(addlist.keys()):
         ret.append(addlist[imageDigest])
 
-    return(ret)
+    return ret
 
 
 def do_image_delete(userId, image_record, dbsession, force=False):
@@ -1602,7 +1602,7 @@ def do_image_delete(userId, image_record, dbsession, force=False):
         logger.warn("DELETE failed - exception: " + str(err))
         return_object = str(err)
 
-    return(return_object, httpcode)
+    return return_object, httpcode
 
 def do_subscription_delete(userId, subscription_record, dbsession, force=False):
     return_object = False
@@ -1619,7 +1619,7 @@ def do_subscription_delete(userId, subscription_record, dbsession, force=False):
     except Exception as err:
         return_object = str(err)
 
-    return(return_object, httpcode)
+    return return_object, httpcode
 
 def do_policy_delete(userId, policy_record, dbsession, cleanup_evals=False, force=False):
     return_object = False
@@ -1644,7 +1644,7 @@ def do_policy_delete(userId, policy_record, dbsession, cleanup_evals=False, forc
     except Exception as err:
         return_object = str(err)
 
-    return(return_object, httpcode)
+    return return_object, httpcode
 
 def do_evaluation_delete(userId, eval_record, dbsession, force=False):
     return_object = False
@@ -1660,7 +1660,7 @@ def do_evaluation_delete(userId, eval_record, dbsession, force=False):
     except Exception as err:
         return_object = str(err)
 
-    return(return_object, httpcode)
+    return return_object, httpcode
         
 def do_archive_delete(userId, archive_document, session, force=False):
     return_object = False
@@ -1677,7 +1677,7 @@ def do_archive_delete(userId, archive_document, session, force=False):
     except Exception as err:
         return_object = str(err)
 
-    return(return_object, httpcode)
+    return return_object, httpcode
 
 
 def do_registry_delete(userId, registry_record, dbsession, force=False):
@@ -1695,7 +1695,7 @@ def do_registry_delete(userId, registry_record, dbsession, force=False):
     except Exception as err:
         return_object = str(err)
 
-    return(return_object, httpcode)
+    return return_object, httpcode
 
 
 def add_event(event, dbsession, quiet=True):

--- a/anchore_engine/services/policy_engine/api/controllers/synchronous_operations.py
+++ b/anchore_engine/services/policy_engine/api/controllers/synchronous_operations.py
@@ -85,7 +85,7 @@ def get_status():
     except Exception as err:
         return_object = str(err)
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 class ImageMessageMapper(object):
@@ -204,7 +204,7 @@ def delete_image(user_id, image_id):
             db.rollback()
 
         # Idempotently return 204. This isn't properly RESTY, but idempotency on delete makes clients much cleaner.
-        return (None, 204)
+        return None, 204
     except HTTPException:
         raise
     except Exception as e:
@@ -931,7 +931,7 @@ def _get_imageId_to_record(userId, dbsession=None):
                 'tag_history': tag_history[x['imageId']],
             }
 
-    return(imageId_to_record)
+    return imageId_to_record
 
 
 def query_images_by_package(dbsession, request_inputs):
@@ -1020,7 +1020,7 @@ def query_images_by_package(dbsession, request_inputs):
         log.error("{}".format(err))
         return_object = make_response_error(err, in_httpcode=httpcode)
 
-    return(return_object, httpcode)
+    return return_object, httpcode
 
 
 advisory_cache = {}
@@ -1031,7 +1031,7 @@ def check_no_advisory(image):
     if phash not in advisory_cache:
         advisory_cache[phash] = image.fix_has_no_advisory()
 
-    return(advisory_cache.get(phash))
+    return advisory_cache.get(phash)
 
 
 def query_images_by_vulnerability(dbsession, request_inputs):
@@ -1145,7 +1145,7 @@ def query_images_by_vulnerability(dbsession, request_inputs):
         log.error("{}".format(err))
         return_object = make_response_error(err, in_httpcode=httpcode)
 
-    return(return_object, httpcode)
+    return return_object, httpcode
 
 
 def query_vulnerabilities(dbsession, ids, package_name_filter, package_version_filter, namespace):
@@ -1313,7 +1313,7 @@ def query_vulnerabilities(dbsession, ids, package_name_filter, package_version_f
         log.error("{}".format(err))
         return_object = make_response_error(err, in_httpcode=httpcode)
 
-    return(return_object, httpcode)
+    return return_object, httpcode
 
 
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
@@ -1333,7 +1333,7 @@ def query_vulnerabilities_get(id=None, affected_package=None, affected_package_v
     finally:
         session.close()
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
@@ -1349,7 +1349,7 @@ def query_images_by_package_get(user_id, name=None, version=None, package_type=N
     finally:
         session.close()
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
@@ -1365,7 +1365,7 @@ def query_images_by_vulnerability_get(user_id, vulnerability_id=None, severity=N
     finally:
         session.close()
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)

--- a/anchore_engine/services/policy_engine/engine/feeds/client.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/client.py
@@ -373,7 +373,7 @@ class HTTPBasicAuthClient(IAuthenticatedHTTPClientBase):
                 logger.debug("attempt failed: " + str(err))
                 ret['content'] = ensure_bytes("server error: " + str(err))
 
-        return (ret)
+        return ret
 
 
 class AnchoreIOClientError(AnchoreException):

--- a/anchore_engine/services/policy_engine/engine/loaders.py
+++ b/anchore_engine/services/policy_engine/engine/loaders.py
@@ -809,7 +809,7 @@ class ImageLoader(object):
                 if n not in ret_names:
                     ret_names.append(n)
 
-        return(ret_names)
+        return ret_names
 
     def _fuzzy_npm(self, input_el):
         global nomatch_inclusions
@@ -823,7 +823,7 @@ class ImageLoader(object):
                 if n not in ret_names:
                     ret_names.append(n)
 
-        return(ret_names)
+        return ret_names
 
     def _fuzzy_gem(self, input_el):
         global nomatch_inclusions
@@ -837,7 +837,7 @@ class ImageLoader(object):
                 if n not in ret_names:
                     ret_names.append(n)
 
-        return(ret_names)
+        return ret_names
 
     def _fuzzy_java(self, input_el):
         global nomatch_inclusions
@@ -965,7 +965,7 @@ class ImageLoader(object):
                     if matchmap_candidate not in ret_names:
                         ret_names.append(matchmap_candidate)
 
-        return(ret_names, ret_versions)
+        return ret_names, ret_versions
 
     def load_cpes(self, analysis_json, containing_image):
         allcpes = {}

--- a/anchore_engine/services/policy_engine/engine/policy/gates/files.py
+++ b/anchore_engine/services/policy_engine/engine/policy/gates/files.py
@@ -89,7 +89,7 @@ class FileAttributeMatchTrigger(BaseTrigger):
         mode_op = self.mode_op.value(default_if_none='equals')
 
         skip_if_file_missing = self.skip_if_file_missing.value(default_if_none=True)
-        
+
         files = []
         if hasattr(context, 'data'):
             filedetails = context.data.get('filedetail')
@@ -98,7 +98,7 @@ class FileAttributeMatchTrigger(BaseTrigger):
         filedetail = filedetails.get(filename, None)
 
         if filedetail:
-            
+
             # checksum checks
 
             if checksum and checksum_op and checksum_algo:
@@ -114,10 +114,10 @@ class FileAttributeMatchTrigger(BaseTrigger):
                     return
 
             # mode checks
-                
+
             if mode and mode_op:
                 file_mode = filedetail.get('mode', 0)
-                
+
                 file_mode_cmp = oct(stat.S_IMODE(file_mode))
                 input_mode_cmp = oct(int(mode, 8))
 
@@ -132,14 +132,14 @@ class FileAttributeMatchTrigger(BaseTrigger):
             if skip_if_file_missing:
                 return
             fire_params['skip'] = "skip_missing=False"
-                
+
         if fire_params:
             msg = "filename={}".format(filename)
             for k in fire_params.keys():
                 msg += " and {}".format(fire_params[k])
-                
+
             self._fire(msg=msg)
-            
+
 class SuidCheckTrigger(BaseTrigger):
     __trigger_name__ = 'suid_or_guid_set'
     __description__ = 'Fires for each file found to have suid or sgid bit set.'
@@ -152,7 +152,7 @@ class SuidCheckTrigger(BaseTrigger):
         if not files:
             return
 
-        found = [x for x in list(files.items()) if (int(x[1].get('mode', 0)) & (stat.S_ISUID | stat.S_ISGID))]
+        found = [x for x in list(files.items()) if int(x[1].get('mode', 0)) & (stat.S_ISUID | stat.S_ISGID)]
         for path, entry in found:
             self._fire(msg='SUID or SGID found set on file {}. Mode: {}'.format(path, oct(entry.get('mode'))))
 

--- a/anchore_engine/services/policy_engine/engine/vulnerabilities.py
+++ b/anchore_engine/services/policy_engine/engine/vulnerabilities.py
@@ -90,7 +90,7 @@ def namespace_has_no_feed(name, version):
     """
     ns = DistroNamespace.as_namespace_name(name, version)
     found = ThreadLocalFeedGroupNameCache.lookup(ns) # Returns a tuple (name, enabled:bool)
-    return not found) or (not found[1]
+    return not found or not found[1]
 
 
 def get_namespace_related_names(distro, version, distro_mapped_names: list):

--- a/anchore_engine/services/policy_engine/engine/vulnerabilities.py
+++ b/anchore_engine/services/policy_engine/engine/vulnerabilities.py
@@ -90,7 +90,7 @@ def namespace_has_no_feed(name, version):
     """
     ns = DistroNamespace.as_namespace_name(name, version)
     found = ThreadLocalFeedGroupNameCache.lookup(ns) # Returns a tuple (name, enabled:bool)
-    return (not found) or (not found[1])
+    return not found) or (not found[1]
 
 
 def get_namespace_related_names(distro, version, distro_mapped_names: list):

--- a/anchore_engine/services/simplequeue/__init__.py
+++ b/anchore_engine/services/simplequeue/__init__.py
@@ -41,7 +41,7 @@ queues = {}
 def handle_metrics(*args, **kwargs):
 
     cycle_timer = kwargs['mythread']['cycle_timer']
-    while(True):
+    while True:
         try:
             for qname in anchore_engine.subsys.simplequeue.get_queuenames():
                 try:

--- a/anchore_engine/services/simplequeue/api/controllers/default_controller.py
+++ b/anchore_engine/services/simplequeue/api/controllers/default_controller.py
@@ -56,7 +56,7 @@ def is_inqueue(queuename, bodycontent):
         return_object = str(err)
         httpcode = 500
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
@@ -70,7 +70,7 @@ def qlen(queuename):
         return_object = str(err)
         httpcode = 500
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
@@ -83,7 +83,7 @@ def enqueue(queuename, bodycontent, forcefirst=None, qcount=0):
         return_object = str(err)
         httpcode = 500
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
@@ -98,7 +98,7 @@ def dequeue(queuename, wait_max_seconds=0, visibility_timeout=0):
         try:
             return_object = simplequeue.dequeue(queuename, visibility_timeout=visibility_timeout)
             if return_object:
-                return (return_object, 200)
+                return return_object, 200
             else:
 
                 # A very rough way to do long-polling, but occupies a thread during the wait
@@ -109,9 +109,9 @@ def dequeue(queuename, wait_max_seconds=0, visibility_timeout=0):
                     wait_expired = True
         except Exception as err:
             return_object = str(err)
-            return (return_object, 500)
+            return return_object, 500
 
-    return (return_object, 200)
+    return return_object, 200
 
 
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
@@ -134,7 +134,7 @@ def delete_message(queuename, receipt_handle):
         return_object = str(err)
         httpcode = 500
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
@@ -159,7 +159,7 @@ def update_message_visibility_timeout(queuename, receipt_handle, visibility_time
         return_object = str(err)
         httpcode = 500
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
@@ -173,7 +173,7 @@ def queues():
         return_object = str(err)
         httpcode = 500
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
@@ -187,7 +187,7 @@ def create_lease(lease_id):
         return_object = str(err)
         httpcode = 500
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
@@ -201,7 +201,7 @@ def list_leases():
         return_object = str(err)
         httpcode = 500
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
@@ -215,7 +215,7 @@ def describe_lease(lease_id):
         return_object = str(err)
         httpcode = 500
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
@@ -229,7 +229,7 @@ def acquire_lease(lease_id, client_id, ttl):
         return_object = str(err)
         httpcode = 500
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
@@ -243,7 +243,7 @@ def release_lease(lease_id, client_id, epoch):
         return_object = str(err)
         httpcode = 500
 
-    return (return_object, httpcode)
+    return return_object, httpcode
 
 
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
@@ -257,4 +257,4 @@ def refresh_lease(lease_id, client_id, ttl, epoch):
         return_object = str(err)
         httpcode = 500
 
-    return (return_object, httpcode)
+    return return_object, httpcode

--- a/anchore_engine/subsys/logger.py
+++ b/anchore_engine/subsys/logger.py
@@ -169,38 +169,38 @@ def safe_formatter(message, args):
 
 
 def spew(msg_string):
-    return (_msg(msg_string, msg_log_level='SPEW'))
+    return _msg(msg_string, msg_log_level='SPEW')
 
 
 @bootstrap_logger_intercept(logging.DEBUG)
 def debug(msg_string, *args):
     msg_string = safe_formatter(msg_string, args)
-    return (_msg(msg_string, msg_log_level='DEBUG'))
+    return _msg(msg_string, msg_log_level='DEBUG')
 
 
 @bootstrap_logger_intercept(logging.INFO)
 def info(msg_string, *args):
     msg_string = safe_formatter(msg_string, args)
-    return (_msg(msg_string, msg_log_level='INFO'))
+    return _msg(msg_string, msg_log_level='INFO')
 
 
 @bootstrap_logger_intercept(logging.WARN)
 def warn(msg_string, *args):
     msg_string = safe_formatter(msg_string, args)
-    return (_msg(msg_string, msg_log_level='WARN'))
+    return _msg(msg_string, msg_log_level='WARN')
 
 
 @bootstrap_logger_intercept(logging.ERROR)
 def error(msg_string, *args):
     msg_string = safe_formatter(msg_string, args)
-    return (_msg(msg_string, msg_log_level='ERROR'))
+    return _msg(msg_string, msg_log_level='ERROR')
 
 
 @bootstrap_logger_intercept('EXCEPTION')
 def exception(msg_string):
     import traceback
     traceback.print_exc()
-    return (_msg(msg_string, msg_log_level='ERROR'))
+    return _msg(msg_string, msg_log_level='ERROR')
 
 
 @bootstrap_logger_intercept('EXCEPTION')
@@ -215,12 +215,12 @@ def debug_exception(msg_string):
         import traceback
         traceback.print_exc()
 
-    return (_msg(msg_string, msg_log_level='ERROR'))
+    return _msg(msg_string, msg_log_level='ERROR')
 
 
 @bootstrap_logger_intercept(logging.FATAL)
 def fatal(msg_string):
-    return (_msg(msg_string, msg_log_level='FATAL'))
+    return _msg(msg_string, msg_log_level='FATAL')
 
 
 def set_log_level(new_log_level, log_to_stdout=False, log_to_db=False):

--- a/anchore_engine/subsys/metrics.py
+++ b/anchore_engine/subsys/metrics.py
@@ -114,7 +114,7 @@ def init_flask_metrics(flask_app, export_defaults=True, **kwargs):
 
     if not enabled:
         flask_metrics = disabled_flask_metrics()
-        return (True)
+        return True
 
     if not flask_metrics:
         flask_metrics = PrometheusMetrics(flask_app, export_defaults=export_defaults, group_by_endpoint=True)
@@ -124,26 +124,26 @@ def init_flask_metrics(flask_app, export_defaults=True, **kwargs):
 
         flask_metrics.info('anchore_service_info', "Anchore Service Static Information", version=version, **kwargs)
 
-    return (True)
+    return True
 
 
 def is_enabled():
     global enabled
-    return (enabled)
+    return enabled
 
 
 def get_flask_metrics_obj():
     global flask_metrics, enabled
     if not enabled:
-        return (None)
-    return (flask_metrics)
+        return None
+    return flask_metrics
 
 
 def get_summary_obj(name, description="", **kwargs):
     global metrics, enabled
 
     if not enabled:
-        return (None)
+        return None
 
     ret = None
     try:
@@ -153,14 +153,14 @@ def get_summary_obj(name, description="", **kwargs):
     except:
         logger.warn("could not create/get named metric (" + str(name) + ")")
 
-    return (ret)
+    return ret
 
 
 def summary_observe(name, observation, description="", **kwargs):
     global metrics, enabled
 
     if not enabled:
-        return (True)
+        return True
 
     try:
         if name not in metrics:
@@ -174,14 +174,14 @@ def summary_observe(name, observation, description="", **kwargs):
     except Exception as err:
         logger.warn("adding metric failed - exception: " + str(err))
 
-    return (True)
+    return True
 
 
 def histogram_observe(name, observation, description="", buckets=None, **kwargs):
     global metrics, enabled
 
     if not enabled:
-        return (True)
+        return True
 
     try:
         if name not in metrics:
@@ -198,14 +198,14 @@ def histogram_observe(name, observation, description="", buckets=None, **kwargs)
     except Exception as err:
         logger.warn("adding metric failed - exception: " + str(err))
 
-    return (True)
+    return True
 
 
 def gauge_set(name, observation, description="", **kwargs):
     global metrics
 
     if not enabled:
-        return (True)
+        return True
 
     try:
         if name not in metrics:
@@ -219,14 +219,14 @@ def gauge_set(name, observation, description="", **kwargs):
     except Exception as err:
         logger.warn("adding metric failed - exception: " + str(err))
 
-    return (True)
+    return True
 
 
 def counter_inc(name, step=1, description="", **kwargs):
     global metrics
 
     if not enabled:
-        return (True)
+        return True
 
     try:
         if name not in metrics:
@@ -240,4 +240,4 @@ def counter_inc(name, step=1, description="", **kwargs):
     except Exception as err:
         logger.warn("adding metric failed - exception: " + str(err))
 
-    return (True)
+    return True

--- a/anchore_engine/subsys/notifications.py
+++ b/anchore_engine/subsys/notifications.py
@@ -28,7 +28,7 @@ def queue_notification(userId, subscription_key, subscription_type, payload):
         logger.warn("failed to create/enqueue notification")
         raise err
 
-    return(rc)
+    return rc
 
 def make_notification(user_record, subscription_type, notification):
     ret = {}
@@ -44,7 +44,7 @@ def make_notification(user_record, subscription_type, notification):
     except Exception as err:
         raise Exception("cannot prepare notification - exception: " + str(err))
 
-    return(ret)
+    return ret
 
 def notify(user_record, notification):
     notification_modes = ['webhook']
@@ -54,7 +54,7 @@ def notify(user_record, notification):
         if notification_mode == 'webhook':
             rc = do_notify_webhook(user_record, notification)
 
-    return(True)
+    return True
 
 def do_notify_webhook(user_record, notification):
     #logger.spew("webhook notify user: " + json.dumps(user_record, indent=4))
@@ -103,10 +103,10 @@ def do_notify_webhook(user_record, notification):
                     headers = {'Content-Type': 'application/json'}
                     result = http.anchy_post(url, data=payload, auth=auth, timeout=2.0, verify=verify, headers=headers)
                     logger.debug("webhook response: " + str(result))
-                    return(True)
+                    return True
                 except Exception as err:
                     raise Exception("failed to post notification to webhook - exception: " + str(err))
             
     logger.debug("warning: notification generated, but no matching webhook could be found in config to send it to - dropping notification")
-    return(False)
+    return False
 

--- a/anchore_engine/subsys/object_store/drivers/filesystem.py
+++ b/anchore_engine/subsys/object_store/drivers/filesystem.py
@@ -125,7 +125,7 @@ class FilesystemObjectStorageDriver(ObjectStorageDriver):
             path = self._parse_uri(uri)
             content = self._load_content(path)
             ret = utils.ensure_bytes(content)
-            return (ret)
+            return ret
         except Exception as e:
             raise ObjectKeyNotFoundError(userId='', bucket='', key='', caused_by=e)
 

--- a/anchore_engine/subsys/object_store/drivers/s3.py
+++ b/anchore_engine/subsys/object_store/drivers/s3.py
@@ -111,7 +111,7 @@ class S3ObjectStorageDriver(ObjectStorageDriver):
             resp = self.s3_client.get_object(Bucket=bucket, Key=key)
             content = resp['Body'].read()
             ret = utils.ensure_bytes(content)
-            return(ret)
+            return ret
 
         except Exception as e:
             raise e

--- a/anchore_engine/subsys/object_store/drivers/swift.py
+++ b/anchore_engine/subsys/object_store/drivers/swift.py
@@ -104,7 +104,7 @@ class SwiftObjectStorageDriver(ObjectStorageDriver):
                 if 'contents' in obj and obj['action'] == 'download_object':
                     content = b''.join([x for x in obj['contents']])
                     ret = utils.ensure_bytes(content)     
-                    return (ret)
+                    return ret
                 elif obj['action'] == 'download_object' and not obj['success']:
                     raise ObjectKeyNotFoundError(bucket='', key='', userId='', caused_by=None)
                 raise Exception('Unexpected operation/action from swift: {}'.format(obj['action']))

--- a/anchore_engine/subsys/object_store/manager.py
+++ b/anchore_engine/subsys/object_store/manager.py
@@ -79,7 +79,7 @@ class ObjectStorageManager(object):
         my_schemas = set(my_schemas)
         supported = schemas.intersection(my_schemas)
         unsupported = schemas.difference(my_schemas)
-        return (supported, unsupported)
+        return supported, unsupported
 
     def get_document(self, userId: str, bucket: str, archiveId: str):
         """

--- a/anchore_engine/subsys/servicestatus.py
+++ b/anchore_engine/subsys/servicestatus.py
@@ -109,7 +109,7 @@ def handle_service_heartbeat(*args, **kwargs):
     except Exception as err:
         raise Exception("BUG: need to provide service name as first argument to function: " + str(args))
 
-    while (True):
+    while True:
         logger.debug("storing service status: " + str(servicename))
         try:
             logger.debug("local service record: %s", anchore_engine.subsys.servicestatus.get_my_service_record())

--- a/anchore_engine/subsys/simplequeue.py
+++ b/anchore_engine/subsys/simplequeue.py
@@ -13,7 +13,7 @@ def create_queue(name, max_outstanding_msgs=0, visibility_timeout=0):
     except Exception as err:
         raise err
             
-    return(True)
+    return True
 
 
 def get_queuenames():
@@ -25,14 +25,14 @@ def get_queuenames():
     except Exception as err:
         raise err
 
-    return(ret)
+    return ret
 
 
 def get_queue(name):
     try:
         with db.session_scope() as dbsession:
             ret = db_queue.get_queue(name, 'system', session=dbsession)
-            return(ret)
+            return ret
     except Exception as err:
         raise err
 
@@ -41,7 +41,7 @@ def qlen(name):
     queuenames = get_queuenames()
     
     if name not in queuenames:
-        return(0)
+        return 0
 
     try:
         with db.session_scope() as dbsession:
@@ -49,7 +49,7 @@ def qlen(name):
     except Exception as err:
         raise err
 
-    return(ret)
+    return ret
 
 
 def enqueue(name, inobj, qcount=0, forcefirst=False):
@@ -64,7 +64,7 @@ def enqueue(name, inobj, qcount=0, forcefirst=False):
         except Exception as err:
             raise err
 
-    return(ret)
+    return ret
 
 
 def dequeue(name, visibility_timeout=None):
@@ -76,12 +76,12 @@ def dequeue(name, visibility_timeout=None):
     ret = {}
     queue = get_queue(name)
     if queue is None:
-        return(None)
+        return None
         
     try:
         with db.session_scope() as dbsession:
             ret = db_queue.dequeue(name, 'system', visibility_timeout=visibility_timeout, session=dbsession)
-        return (ret)
+        return ret
     except Exception as err:
         raise err
 
@@ -99,12 +99,12 @@ def update_visibility_timeout(name, receipt_handle, visibility_timeout):
     ret = {}
     queue = get_queue(name)
     if queue is None:
-        return (None)
+        return None
 
     try:
         with db.session_scope() as dbsession:
             ret = db_queue.update_visibility_by_handle(name, 'system', receipt_handle, visibility_timeout, session=dbsession)
-        return (ret)
+        return ret
     except Exception as err:
         raise err
 
@@ -114,7 +114,7 @@ def delete_msg(name, receipt_handle):
     queue = get_queue(name)
 
     if not queue:
-        return(None)
+        return None
 
     try:
         with db.session_scope() as dbsession:
@@ -122,7 +122,7 @@ def delete_msg(name, receipt_handle):
     except Exception as err:
         raise err
 
-    return (ret)
+    return ret
 
 
 def is_inqueue(name, inobj):
@@ -130,7 +130,7 @@ def is_inqueue(name, inobj):
     queuenames = get_queuenames()
 
     if name not in queuenames:
-        return({})
+        return {}
 
     try:
         with db.session_scope() as dbsession:
@@ -138,4 +138,4 @@ def is_inqueue(name, inobj):
     except Exception as err:
         raise err
         
-    return(ret)
+    return ret

--- a/anchore_engine/subsys/taskstate.py
+++ b/anchore_engine/subsys/taskstate.py
@@ -67,40 +67,40 @@ state_graphs = {
 
 def init_state(state_type, current_state, reset=False):
     if reset:
-        return(reset_state(state_type))
+        return reset_state(state_type)
     else:
         if current_state == None:
-            return(base_state(state_type))
+            return base_state(state_type)
         else:
-            return(current_state)
+            return current_state
 
 def reset_state(state_type):
-    return(base_state(state_type))
+    return base_state(state_type)
 
 def base_state(state_type):
-    return(state_graphs[state_type]['base_state'])
+    return state_graphs[state_type]['base_state']
 
 def fault_state(state_type):
-    return(state_graphs[state_type]['fault_state'])
+    return state_graphs[state_type]['fault_state']
 
 def queued_state(state_type):
-    return(state_graphs[state_type]['queued_state'])
+    return state_graphs[state_type]['queued_state']
 
 def working_state(state_type):
-    return(state_graphs[state_type]['working_state'])
+    return state_graphs[state_type]['working_state']
 
 def next_state(state_type, current_state):
     if not current_state:
-        return(state_graphs[state_type]['transisitions']['init'])
+        return state_graphs[state_type]['transisitions']['init']
 
-    return(state_graphs[state_type]['transitions'][current_state])
+    return state_graphs[state_type]['transitions'][current_state]
 
 def complete_state(state_type):
-    return(state_graphs[state_type]['complete_state'])
+    return state_graphs[state_type]['complete_state']
 
 def orphaned_state(state_type):
     if 'orphaned_state' in state_graphs[state_type]:
         ret = state_graphs[state_type]['orphaned_state']
     else:
         ret = state_graphs[state_type]['fault_state']
-    return(ret)
+    return ret

--- a/anchore_engine/twisted.py
+++ b/anchore_engine/twisted.py
@@ -182,7 +182,7 @@ class WsgiApiServiceMaker(object):
 
             #logger.enable_bootstrap_logging(self.tapname)
 
-            assert (issubclass(self.service_cls, ApiService))
+            assert issubclass(self.service_cls, ApiService)
             self.anchore_service = self.service_cls(options=options)
             self.anchore_service.initialize(self.global_configuration)
 
@@ -308,7 +308,7 @@ class WsgiApiServiceMaker(object):
 
         ret_svc = StreamServerEndpointService(endpoint=endpoint, factory=site)
         ret_svc.setName(self.anchore_service.name)
-        
+
         return ret_svc
 
     def _default_version_rewrite(self, request):

--- a/anchore_engine/util/deb.py
+++ b/anchore_engine/util/deb.py
@@ -132,7 +132,7 @@ class DpkgVersion(object):
 
         for i in range(max(len(list_a), len(list_b))):
             first_diff = 0
-            while list_a and not list_a[0].isdigit() or (list_b and not list_b[0].isdigit()):
+            while (list_a and not list_a[0].isdigit() or list_b and not list_b[0].isdigit()):
                 ac = DpkgVersion._order(list_a[0] if list_a else None)
                 bc = DpkgVersion._order(list_b[0] if list_b else None)
 
@@ -149,7 +149,7 @@ class DpkgVersion(object):
             while list_b and list_b[0] == '0':
                 list_b.pop(0)
 
-            while list_a and list_a[0].isdigit()) and (list_b and list_b[0].isdigit():
+            while (list_a and list_a[0].isdigit()) and (list_b and list_b[0].isdigit()):
                 if not first_diff:
                     first_diff = ord(list_a[0]) - ord(list_b[0])
                 list_a.pop(0)

--- a/anchore_engine/util/deb.py
+++ b/anchore_engine/util/deb.py
@@ -132,7 +132,7 @@ class DpkgVersion(object):
 
         for i in range(max(len(list_a), len(list_b))):
             first_diff = 0
-            while (list_a and not list_a[0].isdigit() or (list_b and not list_b[0].isdigit())):
+            while list_a and not list_a[0].isdigit() or (list_b and not list_b[0].isdigit()):
                 ac = DpkgVersion._order(list_a[0] if list_a else None)
                 bc = DpkgVersion._order(list_b[0] if list_b else None)
 
@@ -149,7 +149,7 @@ class DpkgVersion(object):
             while list_b and list_b[0] == '0':
                 list_b.pop(0)
 
-            while (list_a and list_a[0].isdigit()) and (list_b and list_b[0].isdigit()):
+            while list_a and list_a[0].isdigit()) and (list_b and list_b[0].isdigit():
                 if not first_diff:
                     first_diff = ord(list_a[0]) - ord(list_b[0])
                 list_a.pop(0)

--- a/anchore_engine/util/docker.py
+++ b/anchore_engine/util/docker.py
@@ -133,4 +133,4 @@ def parse_dockerimage_string(instr):
     else:
         ret['pullstring'] = None
 
-    return(ret)
+    return ret

--- a/anchore_engine/util/langpack.py
+++ b/anchore_engine/util/langpack.py
@@ -134,7 +134,7 @@ def normalized_version_match(rawsemver, rawpkgver, language='python'):
     if inrange:
         versionmatch = True
 
-    return(versionmatch)
+    return versionmatch
 
 
 def compare_versions(rawsemver, rawpkgver, language='python'):
@@ -143,4 +143,4 @@ def compare_versions(rawsemver, rawpkgver, language='python'):
         raise Exception("empty version range passed as input")
     normal_semver = rawsemver
     ret = normalized_version_match(normal_semver, rawpkgver, language=language)
-    return(ret)
+    return ret

--- a/anchore_engine/util/packages.py
+++ b/anchore_engine/util/packages.py
@@ -23,7 +23,7 @@ def compare_package_versions(distro_flavor, pkg_a, ver_a, pkg_b, ver_b):
     fulla = '-'.join([str(pkg_a), str(ver_a)])
     fullb = '-'.join([str(pkg_b), str(ver_b)])
     if fulla == fullb:
-        return (0)
+        return 0
 
     if distro_flavor == "RHEL":
         if rpm_compare_versions(ver_a, ver_b) < 0:

--- a/anchore_engine/util/rpm.py
+++ b/anchore_engine/util/rpm.py
@@ -175,7 +175,7 @@ def rpm_ver_cmp(a, b):
         # different types: one numeric, the other alpha (i.e. empty)
         # numeric segments are always newer than alpha segments
         # XXX See patch #60884 (and details) from bugzilla #50977.
-        # if (two == str2) return (isnum ? 1 : -1);
+        # if (two == str2) return isnum ? 1 : -1;
         if l_b == b_seg:
             return 1 if is_num else -1
 

--- a/anchore_engine/utils.py
+++ b/anchore_engine/utils.py
@@ -192,11 +192,11 @@ def filter_record_keys(record_list, whitelist_keys):
 def run_sanitize(cmd_list):
     def shellcheck(x):
         if not re.search("[;&<>]", x):
-            return(x)
+            return x
         else:
             raise Exception("bad character in shell input")
 
-    return([x for x in cmd_list if shellcheck(x)])
+    return [x for x in cmd_list if shellcheck(x)]
 
 def run_command_list(cmd_list, env=None):
     """
@@ -222,7 +222,7 @@ def run_command_list(cmd_list, env=None):
     #sout = ensure_str(sout)
     #serr = ensure_str(serr)
 
-    return(rc, sout, serr)
+    return rc, sout, serr
 
 
 def run_command(cmdstr, env=None):
@@ -240,7 +240,7 @@ def manifest_to_digest(rawmanifest):
         ret = manifest_to_digest_shellout(rawmanifest)
 
     ret = ensure_str(ret)
-    return(ret)
+    return ret
 
 
 def get_threadbased_id(guarantee_uniq=False):
@@ -369,7 +369,7 @@ def parse_dockerimage_string(instr):
     else:
         ret['pullstring'] = None
 
-    return(ret)
+    return ret
 
 
 def ensure_bytes(obj):
@@ -408,7 +408,7 @@ def rfc3339str_to_datetime(rfc3339_str):
     if ret is None:
         raise Exception("could not convert input created_at value ({}) into datetime using formats in {}".format(rfc3339_str, rfc3339_date_input_fmts))
 
-    return(ret)
+    return ret
 
 def datetime_to_rfc3339(dt_obj):
     """

--- a/scripts/ci/make/pipeline_tasks
+++ b/scripts/ci/make/pipeline_tasks
@@ -39,8 +39,9 @@ lint() {
     hash pylint || "${PYTHON}" -m pip install -q pylint
 
     print_colorized WARN "linting project"
-    pylint anchore_engine
-    pylint anchore_manager
+    # This is specifically enabling checks because the output is too large to
+    # fix in one go. As cleanups are done, more checks can be enabled
+    pylint -s n --disable=all --enable=C0325 anchore_engine
 }
 
 unit_tests() {


### PR DESCRIPTION
**What this PR does / why we need it**: There is no need for parentheses on statements. For example this:

```python
    return(1)
```

Is the same as:

```python
    return 1
```

Although stylistic, the unnecessary parentheses can cause confusion, making a contributor double-check what is actually occurring (e.g. a tuple or a callable?). 

This PR also adds `make lint` to the CI config so that it prevents newer PRs from getting it in.


**Which issue this PR fixes** Partially fixes issue #https://github.com/anchore/anchore-engine/issues/364

**Special notes**: I *think* I managed to get this right, I double checked, but will need to rely on tests to ensure I didn't remove something that was actually needed


