### PR TITLE
Remove never-released 'advisory_data' field from external api

### DIFF
--- a/anchore_engine/services/apiext/api/controllers/images.py
+++ b/anchore_engine/services/apiext/api/controllers/images.py
@@ -334,7 +334,6 @@ def make_response_vulnerability(vulnerability_type, vulnerability_data):
                     all_data = json.loads(row[header.index('CVES')])  # {'nvd_data': [], 'vendor_data': []}
                     el['nvd_data'] = make_cvss_scores(all_data.get('nvd_data', []))
                     el['vendor_data'] = make_cvss_scores(all_data.get('vendor_data', []))
-                    el['advisory_data'] = all_data.get('advisory_data', {})
                     for nvd_el in el['nvd_data']:
                         id_cves_map[nvd_el.get('id')] = el.get('vuln')
 

--- a/anchore_engine/services/policy_engine/api/controllers/synchronous_operations.py
+++ b/anchore_engine/services/policy_engine/api/controllers/synchronous_operations.py
@@ -654,10 +654,7 @@ def get_image_vulnerabilities(user_id, image_id, force_refresh=False, vendor_onl
                 # rennovation this for new CVSS references
                 cves = ''
                 nvd_list = []
-                all_data = {'nvd_data': nvd_list, 'vendor_data': [], 'advisory_data': {'cves': []}}
-
-                if vuln.vulnerability.additional_metadata:
-                    all_data['advisory_data']['cves'] = vuln.vulnerability.additional_metadata.get('CVE', [])
+                all_data = {'nvd_data': nvd_list, 'vendor_data': []}
 
                 for nvd_record in nvd_records:
                     nvd_list.extend(nvd_record.get_cvss_data_nvd())


### PR DESCRIPTION
The merging of CVEs is handled during the NVD metadata merge in the API handling. The only condition this doesn't cover is if a user has no nvdv2:cve feed data but does have github:* advisory data from the feed service, but that is not considered an expected use-case and is not the default state.