### PR TITLE
tests: do not require a specific path to execute tests

### DIFF
--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -1,0 +1,64 @@
+import json
+import os
+from os.path import dirname, realpath
+import pytest
+
+
+dir_path = dirname(realpath(__file__))
+top_dir = dirname(dir_path)
+test_data_env = os.path.join(top_dir, 'data/test_data_env')
+
+
+@pytest.fixture(scope="session")
+def monkeysession(request):
+    """
+    This is an unfortunate kludge needed to force the monkeypatch fixture to
+    allow a specific scope (the whole test session in this case).
+
+    Without this, Pytest would raise an error explaining this is not possible.
+
+    See: https://github.com/pytest-dev/pytest/issues/363
+
+    If this ever stops working, then the `monkeypatch` needs to be done on
+    every test method *or* the scope needs to be removed, causing these to be
+    set for every test.
+    """
+    from _pytest.monkeypatch import MonkeyPatch
+    mpatch = MonkeyPatch()
+    yield mpatch
+    mpatch.undo()
+
+
+@pytest.fixture(autouse=True)
+def set_env_vars(monkeysession):
+    env_vars = (
+        ("ANCHORE_TEST_S3_ACCESS_KEY", "9EB92C7W61YPFQ6QLDOU"),
+        ("ANCHORE_TEST_S3_SECRET_KEY", "TuHo2UbBx+amD3YiCeidy+R3q82MPTPiyd+dlW+s"),
+        ("ANCHORE_TEST_S3_URL", "http://localhost:9000"),
+        ("ANCHORE_TEST_S3_BUCKET", "testarchivebucket"),
+        ("ANCHORE_TEST_SWIFT_AUTH_URL", "http://localhost:8080/auth/v1.0"),
+        ("ANCHORE_TEST_SWIFT_KEY", "testing"),
+        ("ANCHORE_TEST_SWIFT_USER", "test:tester"),
+        ("ANCHORE_TEST_SWIFT_CONTAINER", "testarchive"),
+        ("ANCHORE_TEST_DB_URL", "postgresql://postgres:postgres@localhost:5432/postgres"),
+        ("ANCHORE_TEST_DB_USER", "postgres"),
+        ("ANCHORE_TEST_DB_PASS", "postgres"),
+        ("ANCHORE_TEST_DATA_ENV_DIR", test_data_env),
+    )
+    for environ, value in env_vars:
+        monkeysession.setenv(environ, value)
+
+
+@pytest.fixture
+def test_data_path():
+    return os.path.join(top_dir, 'data')
+
+
+@pytest.fixture
+def bundle():
+    def find(bundle_name='bundle-large_whitelist.json'):
+        data_dir = os.path.join(top_dir, 'data')
+        bundle_path = os.path.join(data_dir, bundle_name)
+        with open(bundle_path) as f:
+            return json.load(f)
+    return find

--- a/test/integration/services/policy_engine/feeds/test_feeds.py
+++ b/test/integration/services/policy_engine/feeds/test_feeds.py
@@ -1,3 +1,4 @@
+import os
 import time
 import pytest
 
@@ -67,8 +68,9 @@ def test_group_lookups(test_data_env):
     assert df.group_by_name('alpine:3.6'), 'Should have found group alpine:3.6'
 
 
-def test_sync_repo(test_data_env):
-    repo = LocalFeedDataRepo.from_disk('test/data/feeds_repo')
+def test_sync_repo(test_data_env, test_data_path):
+    feeds_repo_path = os.path.join(test_data_path, 'feeds_repo')
+    repo = LocalFeedDataRepo.from_disk(feeds_repo_path)
     assert repo.has_metadata(), 'Repo should have metadata'
     assert repo.has_root(), 'Repo should have root dir already'
     with pytest.raises(Exception):

--- a/test/integration/setup_deps.sh
+++ b/test/integration/setup_deps.sh
@@ -3,19 +3,3 @@
 echo "Setting up integration test dependencies"
 
 docker-compose -f deps/docker-compose.yaml up -d
-
-# These are from deps/minio/config/config.json, not real S3 creds. They should match the ones set in that config or tests will fail.
-export ANCHORE_TEST_S3_ACCESS_KEY="9EB92C7W61YPFQ6QLDOU"
-export ANCHORE_TEST_S3_SECRET_KEY="TuHo2UbBx+amD3YiCeidy+R3q82MPTPiyd+dlW+s"
-export ANCHORE_TEST_S3_URL="http://localhost:9000"
-export ANCHORE_TEST_S3_BUCKET="testarchivebucket"
-
-export ANCHORE_TEST_SWIFT_AUTH_URL="http://localhost:8080/auth/v1.0"
-export ANCHORE_TEST_SWIFT_KEY="testing"
-export ANCHORE_TEST_SWIFT_USER="test:tester"
-export ANCHORE_TEST_SWIFT_CONTAINER="testarchive"
-
-export ANCHORE_TEST_DB_URL="postgresql://postgres:postgres@localhost:5432/postgres"
-export ANCHORE_TEST_DB_USER="postgres"
-export ANCHORE_TEST_DB_PASS="postgres"
-export ANCHORE_TEST_DATA_ENV_DIR="${PWD}/../data/test_data_env"


### PR DESCRIPTION

**What this PR does / why we need it**: allows to set the environment variables for the test run only and automatically regardless of the path. At the end of the test run the environment variables are removed.


**Which issue this PR fixes** fixes issue #382 


