### PR TITLE
Fixed centos->rhel vuln data upgrade process

### DIFF
--- a/test/unit/anchore_engine/services/policy_engine/engine/test_vulnerabilities.py
+++ b/test/unit/anchore_engine/services/policy_engine/engine/test_vulnerabilities.py
@@ -27,6 +27,12 @@ def test_namespace_has_no_feed():
 
 
 def test_get_namespace_related_names():
+    """
+    Tests the older enable-filtering behavior of the namespace selector for which image/distros to update during a given
+    feed sync
+
+    :return:
+    """
     assert vulnerabilities.namespace_has_no_feed('debian', '8')
 
     # State pre 0.7.0 upgrade


### PR DESCRIPTION
Handles case where rhel feed data is already present and automatically converts image matches correctly.