### PR TITLE
Fix missing marshalling call causing 500 response on feed delete

### DIFF
--- a/anchore_engine/services/policy_engine/api/controllers/feeds.py
+++ b/anchore_engine/services/policy_engine/api/controllers/feeds.py
@@ -169,7 +169,7 @@ def delete_feed(feed):
     try:
         f = sync.DataFeeds.delete_feed(feed)
         if f:
-            return jsonify(f), 200
+            return jsonify(_marshall_feed_response(f)), 200
         else:
             raise ResourceNotFound(feed, detail={})
     except KeyError as e:


### PR DESCRIPTION
Fixes bug that caused 500 response due to marshalling issue even though op succeeded.