### PR TITLE
Bump requests and Twisted dependencies

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,3 @@
 pytest
-requests==2.22.0
 Flask-Testing
 memory_profiler

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,18 +6,16 @@ Flask==1.1.1
 jsonschema==2.6.0
 passlib==1.7.2
 pathlib==1.0.1
-pg8000==1.10.6
 prettytable==0.7.2
 prometheus-client==0.7.1
 prometheus-flask-exporter==0.12.1
 psutil==5.6.7
 psycopg2-binary==2.8.4
 python-dateutil==2.8.1
-python-keystoneclient==3.22.0
 python-swiftclient==3.8.1
 pytz==2019.3
 PyYAML==5.3
-requests==2.22.0
+requests==2.23.0
 retrying==1.3.3
 semantic-version==2.6.0
 six==1.14.0
@@ -25,7 +23,7 @@ SQLAlchemy==1.3.12
 swagger-spec-validator==2.4.3
 toastedmarshmallow==2.15.2.post1
 treelib==1.5.5
-Twisted[tls]==19.10.0
+Twisted[tls]==20.3.0
 typing==3.7.4.1
 urllib3==1.25.8
 watchdog==0.9.0
@@ -34,3 +32,7 @@ yosai==0.3.2
 zope.component==4.6
 zope.interface==4.7.1
 ijson==2.5.1
+
+# Optional and third-party/integration dependencies
+python-keystoneclient==3.22.0
+pg8000==1.10.6


### PR DESCRIPTION

**What this PR does / why we need it**: Bumps Twisted that fixes two CVEs (CVE-2020-10108 and CVE-2020-10109) and requests to avoid the `idna<2.9` dependency that collides with Twisted's

It also moves optional dependencies down, under a commented block so that they are easier to identify as a group.
