### PR TITLE
conditionally update the last_sync on successful group downloads

### DIFF
--- a/anchore_engine/services/policy_engine/engine/feeds/feeds.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/feeds.py
@@ -248,7 +248,10 @@ class AnchoreServiceFeed(DataFeed):
 
             log.debug(log_msg_ctx(operation_id, group_download_result.feed, group_download_result.group, 'Updating last sync timestamp to {}'.format(download_started)))
             group_db_obj = self.group_by_name(group_download_result.group)
-            group_db_obj.last_sync = download_started
+            # There is potential failures that could happen when downloading,
+            # skipping updating the `last_sync` allows the system to retry
+            if group_download_result.status == 'complete':
+                group_db_obj.last_sync = download_started
             group_db_obj.count = self.record_count(group_db_obj.name, db)
             db.add(group_db_obj)
             db.commit()


### PR DESCRIPTION


**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes https://github.com/anchore/anchore-engine/issues/406

**Special notes**: I am not fully confident of the fix because I couldn't find a way to test this out. The issue explains well what should happen so given that context I think this should be good. 


