### PR TITLE
Make the feed registry explicit instead of using metaclass

### DIFF
--- a/anchore_engine/services/policy_engine/__init__.py
+++ b/anchore_engine/services/policy_engine/__init__.py
@@ -15,7 +15,7 @@ from anchore_engine.configuration import localconfig
 from anchore_engine.clients.services import simplequeue, internal_client_for
 from anchore_engine.clients.services.simplequeue import SimpleQueueClient
 from anchore_engine.service import ApiService, LifeCycleStages
-
+from anchore_engine.services.policy_engine.engine.feeds.feeds import VulnerabilityFeed, NvdV2Feed, PackagesFeed, VulnDBFeed, GithubFeed, feed_registry
 # from anchore_engine.subsys.logger import enable_bootstrap_logging
 # enable_bootstrap_logging()
 
@@ -96,7 +96,7 @@ def process_preflight():
     :return:
     """
 
-    preflight_check_functions = [_init_db_content]
+    preflight_check_functions = [init_db_content, init_feed_registry]
 
     for fn in preflight_check_functions:
         try:
@@ -144,13 +144,19 @@ def _init_distro_mappings():
     return True
 
 
-def _init_db_content():
+def init_db_content():
     """
     Initialize the policy engine db with any data necessary at startup.
 
     :return:
     """
     return _init_distro_mappings()
+
+
+def init_feed_registry():
+    for cls in [NvdV2Feed, VulnDBFeed, VulnerabilityFeed, PackagesFeed, GithubFeed]:
+        logger.info('Registering feed handler {}'.format(cls.__feed_name__))
+        feed_registry.register(cls)
 
 
 def do_feed_sync(msg):

--- a/scripts/ci/make/pipeline_tasks
+++ b/scripts/ci/make/pipeline_tasks
@@ -22,7 +22,7 @@ build() {
         anchore_cli_commit="$(git -c 'versionsort.suffix=-' ls-remote --exit-code --tags --refs --sort="v:refname" git://github.com/anchore/anchore-cli.git 'v*' | tail -n1 | sed 's/.*\///')"
     else
         # Get commit sha from HEAD of master anchore-cli remote
-        anchore_cli_commit="$(git ls-remote git://github.com/anchore/anchore-cli.git | head -n1 | awk '{print $1}')"
+        anchore_cli_commit="$(git ls-remote git://github.com/anchore/anchore-cli.git master | cut -f 1)"
     fi
 
     print_colorized WARN "building image ${TEST_IMAGE_NAME} - installing anchore-cli from git@${anchore_cli_commit}"

--- a/test/integration/services/policy_engine/conftest.py
+++ b/test/integration/services/policy_engine/conftest.py
@@ -6,8 +6,10 @@ from test.integration.services.policy_engine.utils import LocalTestDataEnvironme
 from anchore_engine.services.policy_engine.engine.tasks import ImageLoadTask
 from anchore_engine.db import end_session
 from test.fixtures import anchore_db, cls_anchore_db
+from anchore_engine.services.policy_engine import init_feed_registry
 
 def _init_te(init_feeds=True):
+    init_feed_registry()
     t = LocalTestDataEnvironment(os.getenv('ANCHORE_TEST_DATA_ENV_DIR', 'test/data/test_data_env'))
     if init_feeds:
         t.init_feeds()

--- a/test/integration/services/policy_engine/test_vulnerabilities.py
+++ b/test/integration/services/policy_engine/test_vulnerabilities.py
@@ -8,7 +8,7 @@ from anchore_engine.db import get_thread_scoped_session, end_session, Image, Dis
 from anchore_engine.services.policy_engine.engine.tasks import ImageLoadTask, FeedsUpdateTask, rescan_image
 from anchore_engine.services.policy_engine.engine.feeds.sync import DataFeeds
 from test.integration.services.policy_engine.utils import reset_feed_sync_time
-from anchore_engine.services.policy_engine import _init_distro_mappings
+from anchore_engine.services.policy_engine import _init_distro_mappings, init_feed_registry
 
 
 logger.enable_test_logging()
@@ -180,6 +180,7 @@ def test_have_vulnerabilities_for(test_data_env):
 
 
 def test_distromappings(anchore_db):
+    init_feed_registry()
     _init_distro_mappings()
 
     c7 = DistroNamespace(name='centos', version='7', like_distro='centos')

--- a/test/unit/anchore_engine/services/policy_engine/engine/feeds/test_sync.py
+++ b/test/unit/anchore_engine/services/policy_engine/engine/feeds/test_sync.py
@@ -1,13 +1,14 @@
 import pytest
 import datetime
-from anchore_engine.services.policy_engine.engine.feeds.feeds import DataFeed
+from anchore_engine.services.policy_engine.engine.feeds.feeds import feed_registry
 from anchore_engine.services.policy_engine.engine.feeds.sync import get_selected_feeds_to_sync, get_feeds_config, DataFeeds, FeedMetadata, VulnDBFeed, VulnerabilityFeed, NvdV2Feed, PackagesFeed
-
+from anchore_engine.services.policy_engine import init_feed_registry
 
 @pytest.fixture
 def feed_db_records():
+    init_feed_registry()
     recs = {}
-    for r in DataFeed.registered_feed_names():
+    for r in feed_registry.registered_feed_names():
         recs[r] = FeedMetadata()
         recs[r].name = r
         recs[r].last_update = datetime.datetime.utcnow()


### PR DESCRIPTION
Allows for more flexible control of feed registration and testing without relying on the class load order or import paths