### PR TITLE
add missing non-os package types from Github

### DIFF
--- a/anchore_engine/common/__init__.py
+++ b/anchore_engine/common/__init__.py
@@ -10,4 +10,4 @@ image_content_types = ['os', 'files', 'npm', 'gem', 'python', 'java']
 image_metadata_types = ['manifest', 'docker_history', 'dockerfile']
 image_vulnerability_types = ['os', 'non-os']
 os_package_types = ['rpm', 'dpkg', 'APKG']
-nonos_package_types = ['java', 'python', 'npm', 'gem', 'maven', 'js']
+nonos_package_types = ('java', 'python', 'npm', 'gem', 'maven', 'js', 'composer', 'nuget')


### PR DESCRIPTION

**What this PR does / why we need it**: This is a follow-up PR for issue #400 which was misreporting non-os packages. Github Advisories include other packages as well which are not present in `common.nonos_package_types`


**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #: Additional fix for #400 



