### PR TITLE
add checks to determine if a package name and version are the same st…

### DIFF
--- a/anchore_engine/services/apiext/api/controllers/images.py
+++ b/anchore_engine/services/apiext/api/controllers/images.py
@@ -365,7 +365,12 @@ def make_response_vulnerability(vulnerability_type, vulnerability_data):
         for k in list(keymap.keys()):
             el[k] = vuln[keymap[k]]
 
-        el['package'] = "{}-{}".format(vuln['name'], vuln['version'])
+        if vuln['name'] != vuln['version']:
+            pkg_final = "{}-{}".format(vuln['name'], vuln['version'])
+        else:
+            pkg_final = vuln['name']
+
+        el['package'] = pkg_final
 
         # get nvd scores
         el['nvd_data'] = []

--- a/anchore_engine/services/policy_engine/api/controllers/synchronous_operations.py
+++ b/anchore_engine/services/policy_engine/api/controllers/synchronous_operations.py
@@ -661,11 +661,16 @@ def get_image_vulnerabilities(user_id, image_id, force_refresh=False, vendor_onl
 
                 cves = json.dumps(all_data)
 
+                if vuln.pkg_name != vuln.package.fullversion:
+                    pkg_final = "{}-{}".format(vuln.pkg_name, vuln.package.fullversion)
+                else:
+                    pkg_final = vuln.pkg_name
+                    
                 rows.append([
                     vuln.vulnerability_id,
                     vuln.vulnerability.severity,
                     1,
-                    vuln.pkg_name + '-' + vuln.package.fullversion,
+                    pkg_final,
                     str(vuln.fixed_in()),
                     vuln.pkg_image_id,
                     'None', # Always empty this for now


### PR DESCRIPTION
…ring, which can happen under some generic package handling in the analyzer, to avoid unusual API output for the "package" field in API responses.  Fixes #423

Signed-off-by: Daniel Nurmi <nurmi@anchore.com>

