### PR TITLE
Add initialization of policy engine structures for the db upgrade from 0.0.12 -> 0.0.13

### DIFF
--- a/anchore_engine/db/entities/upgrade.py
+++ b/anchore_engine/db/entities/upgrade.py
@@ -1174,6 +1174,9 @@ def db_upgrade_012_013():
 
     :return:
     """
+    # Setup some policy engine stuff to support feed ops
+    from anchore_engine.services.policy_engine import process_preflight
+    process_preflight()
 
     upgrade_feed_groups_013()
     upgrade_distro_mappings_rhel_013()


### PR DESCRIPTION
Turns out this only affects upgrades from 0.6.x to 0.7.1 directly. 0.7.0 is unaffected because the KeyError was generated from a new feed registry lookup, not the db lookup.