### PR TITLE
bulk deletion of images

### DIFF
--- a/anchore_engine/clients/services/catalog.py
+++ b/anchore_engine/clients/services/catalog.py
@@ -68,6 +68,9 @@ class CatalogClient(InternalServiceClient):
     def delete_image(self, imageDigest, force=False):
         return self.call_api(http.anchy_delete, 'images/{imageDigest}', path_params={'imageDigest': imageDigest}, query_params={'force': force})
 
+    def delete_images_async(self, imageDigests, force=False):
+        return self.call_api(http.anchy_delete, 'images', query_params={'force': force, 'imageDigests': ','.join(imageDigests)})
+
 #    def import_image(self, anchore_data):
 #        return self.call_api(http.anchy_post, 'import', body=json.dumps(anchore_data))
 

--- a/anchore_engine/services/apiext/swagger/swagger.yaml
+++ b/anchore_engine/services/apiext/swagger/swagger.yaml
@@ -429,6 +429,37 @@ paths:
           description: Internal Error
           schema:
             $ref: "#/definitions/ApiErrorResponse"
+    delete:
+      tags:
+      - Images
+      x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.images
+      operationId: delete_images_async
+      x-anchore-authz-action: deleteImage
+      summary: Bulk mark images for deletion
+      description: Delete analysis for image digests in the list asynchronously
+      parameters:
+      - name: imageDigests
+        in: query
+        required: true
+        x-nullable: false
+        type: array
+        items:
+          type: string
+        collectionFormat: csv
+      - name: force
+        in: query
+        required: false
+        type: boolean
+      - $ref: "#/parameters/AsAccountParameter"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/DeleteImagesResponseList"
+        500:
+          description: Internal Error
+          schema:
+            $ref: "#/definitions/ApiErrorResponse"
   /import/images:
     post:
       tags:
@@ -2864,6 +2895,29 @@ definitions:
         - id
       value:
         type: string
+  DeleteImagesResponse:
+    type: object
+    description: Image deletion response containing status and details
+    required:
+    - digest
+    - status
+    properties:
+      digest:
+        type: string
+      status:
+        type: string
+        description: Current status of the image deletion
+        enum:
+        - not_found
+        - deleting
+        - delete_failed
+      detail:
+        type: string
+  DeleteImagesResponseList:
+    type: array
+    description: A list of delete image responses
+    items:
+      $ref: "#/definitions/DeleteImagesResponse"
   Policy:
     type: object
     required:

--- a/anchore_engine/services/catalog/api/controllers/default_controller.py
+++ b/anchore_engine/services/catalog/api/controllers/default_controller.py
@@ -146,6 +146,21 @@ def delete_image(imageDigest, force=False):
     return return_object, httpcode
 
 
+@flask_metrics.do_not_track()
+@authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
+def delete_images_async(imageDigests, force=False):
+    try:
+        account_id = ApiRequestContextProxy.namespace()
+        with db.session_scope() as session:
+            return_object, httpcode = anchore_engine.services.catalog.catalog_impl.delete_images_async(account_id, session, imageDigests, force)
+
+    except Exception as err:
+        httpcode = 500
+        return_object = str(err)
+
+    return return_object, httpcode
+
+
 # @api.route('/registry_lookup', methods=['GET'])
 @flask_metrics.do_not_track()
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)

--- a/anchore_engine/services/catalog/swagger/swagger.yaml
+++ b/anchore_engine/services/catalog/swagger/swagger.yaml
@@ -189,6 +189,36 @@ paths:
           schema:
             type: object
       x-swagger-router-controller: "anchore_engine.services.catalog.api.controllers.default_controller"
+    delete:
+      tags:
+      - "catalog"
+      summary: "Bulk delete images from DB"
+      description: ""
+      operationId: "delete_images_async"
+      parameters:
+      - name: 'imageDigests'
+        in: query
+        required: true
+        x-nullable: false
+        type: array
+        items:
+          type: string
+        collectionFormat: csv
+      - name: 'force'
+        in: query
+        type: boolean
+        description: "force delete"
+        required: false
+      produces:
+      - "application/json"
+      responses:
+        200:
+          description: "success"
+          schema:
+            type: array
+            items:
+              type: object
+      x-swagger-router-controller: "anchore_engine.services.catalog.api.controllers.default_controller"
   /images/{imageDigest}:
     get:
       tags:


### PR DESCRIPTION
- synchronous checks to verify each image can be deleted
- response contains status of the delete op and a message when the checks fail and image can't be deleted
- actual deletion of image triggered in an async thread

Implements #502

Signed-off-by: Swathi Gangisetty <swathi@anchore.com>