### PR TITLE
Parse partial MANIFEST.MF files in java packages

### DIFF
--- a/anchore_engine/analyzers/modules/32_java_packages.py
+++ b/anchore_engine/analyzers/modules/32_java_packages.py
@@ -83,8 +83,6 @@ def process_java_archive(prefix, filename, inZFH=None):
             'name': name
         }
 
-        sname = sversion = svendor = iname = iversion = ivendor = None
-
         filenames = ZFH.namelist()
 
         if 'META-INF/MANIFEST.MF' in filenames:
@@ -93,22 +91,15 @@ def process_java_archive(prefix, filename, inZFH=None):
                     top_el['metadata']['MANIFEST.MF'] = anchore_engine.utils.ensure_str(MFH.read())
 
                 manifest = java_util.parse_manifest(top_el['metadata']['MANIFEST.MF'].splitlines())
-                sname = manifest['Specification-Title']
-                sversion = manifest['Specification-Version']
-                svendor = manifest['Specification-Vendor']
-                iname = manifest['Implementation-Title']
-                iversion = manifest['Implementation-Version']
-                ivendor = manifest['Implementation-Vendor']
+                if 'Specification-Version' in manifest:
+                    top_el['specification-version'] = manifest['Specification-Version']
+                if 'Implementation-Version' in manifest:
+                    top_el['implementation-version'] = manifest['Implementation-Version']
 
-                if sversion:
-                    top_el['specification-version'] = sversion
-                if iversion:
-                    top_el['implementation-version'] = iversion
-
-                if svendor:
-                    top_el['origin'] = svendor
-                elif ivendor:
-                    top_el['origin'] = ivendor
+                if 'Specification-Vendor' in manifest:
+                    top_el['origin'] = manifest['Specification-Vendor']
+                elif 'Implementation-Vendor' in manifest:
+                    top_el['origin'] = manifest['Implementation-Vendor']
 
             except:
                 # no manifest could be parsed out, leave the el values unset

--- a/anchore_engine/analyzers/modules/32_java_packages.py
+++ b/anchore_engine/analyzers/modules/32_java_packages.py
@@ -91,11 +91,8 @@ def process_java_archive(prefix, filename, inZFH=None):
                     top_el['metadata']['MANIFEST.MF'] = anchore_engine.utils.ensure_str(MFH.read())
 
                 manifest = java_util.parse_manifest(top_el['metadata']['MANIFEST.MF'].splitlines())
-                if 'Specification-Version' in manifest:
-                    top_el['specification-version'] = manifest['Specification-Version']
-                if 'Implementation-Version' in manifest:
-                    top_el['implementation-version'] = manifest['Implementation-Version']
-
+                top_el['specification-version'] = manifest.get('Specification-Version', 'N/A')
+                top_el['implementation-version'] = manifest.get('Implementation-Version', 'N/A')
                 if 'Specification-Vendor' in manifest:
                     top_el['origin'] = manifest['Specification-Vendor']
                 elif 'Implementation-Vendor' in manifest:


### PR DESCRIPTION
**What this PR does / why we need it**:
If we detect a META-INF/MANIFEST.MF file in a java packages attempt
to pull the values that are present and use them for component
detection

**Which issue this PR fixes** 
fixes #524
