### PR TITLE
Updates to image deletion

### DIFF
--- a/anchore_engine/services/apiext/swagger/swagger.yaml
+++ b/anchore_engine/services/apiext/swagger/swagger.yaml
@@ -528,6 +528,8 @@ paths:
       responses:
         200:
           description: Image deletion success
+          schema:
+            $ref: "#/definitions/DeleteImagesResponse"
   /images/by_id/{imageId}:
     get:
       tags:
@@ -2914,7 +2916,7 @@ definitions:
         description: Current status of the image deletion
         enum:
         - not_found
-        - deleting
+        - delete_queued
         - delete_failed
       detail:
         type: string
@@ -3077,6 +3079,8 @@ definitions:
         type: integer
       tag_detected_at:
         type: integer
+      image_status:
+        type: string
   AnchoreImage:
     description: A unique image in the engine. May have multiple tags or references. Unique to an image content across registries or repositories.
     type: object

--- a/anchore_engine/subsys/taskstate.py
+++ b/anchore_engine/subsys/taskstate.py
@@ -30,12 +30,14 @@ state_graphs = {
     'image_status': {
         'base_state': 'active',
         'fault_state': 'inactive',
-        'queued_state': 'active',
-        'working_state': 'active',
+        'queued_state': 'delete_queued',
+        'working_state': 'deleting',
         'complete_state': 'active',
         'transitions': {
             'init': 'active',
-            'active':'active'
+            'active': 'delete_queued',
+            'delete_queued': 'deleting',
+            'deleting': 'deleted'
         }
     },
     'service_status': {

--- a/conf/default_config.yaml
+++ b/conf/default_config.yaml
@@ -147,6 +147,7 @@ services:
       policy_bundle_sync: 300
       repo_watcher: 60
       archive_tasks: 43200 # 12 hours between archive task run
+      image_gc: 60
     event_log:
       notification:
         enabled: ${ANCHORE_EVENTS_NOTIFICATIONS_ENABLED}


### PR DESCRIPTION
- persisted state transitions to schlep images through deletion workflow
- asynchronous processing for all image deletion requests, both single and bulk. synchronous path performs delete checks, updates the image state and returns a response with delete status
- new catalog handler to periodically garbage collect images marked for deletion

Resolves #502