### PR TITLE
Fix skipped filter with GET /images where image_status and fulltag parameter are both present

### DIFF
--- a/anchore_engine/db/db_catalog_image.py
+++ b/anchore_engine/db/db_catalog_image.py
@@ -159,7 +159,7 @@ def get_created_at(record):
         return record['created_at']
     return 0
 
-def get_byimagefilter(userId, image_type, dbfilter={}, onlylatest=False, session=None):
+def get_byimagefilter(userId, image_type, dbfilter={}, onlylatest=False, image_status='active', analysis_status=None, session=None):
     if not session:
         session = db.Session
 
@@ -173,11 +173,12 @@ def get_byimagefilter(userId, image_type, dbfilter={}, onlylatest=False, session
             imageDigest = result['imageDigest']
             dbobj = get(imageDigest, userId, session=session)
 
-            if not latest:
-                latest = dbobj
+            if (image_status is None or dbobj['image_status'] == image_status) and (analysis_status is None or dbobj['analysis_status'] == analysis_status):
+                if not latest:
+                    latest = dbobj
 
-            ret_results.append(dbobj)
-            
+                ret_results.append(dbobj)
+
     ret = []
     if not onlylatest:
         ret = ret_results

--- a/anchore_engine/services/catalog/catalog_impl.py
+++ b/anchore_engine/services/catalog/catalog_impl.py
@@ -242,9 +242,8 @@ def image(dbsession, request_inputs, bodycontent=None):
     if params and 'history' in params:
         history = params['history']
 
-    if params:
-        image_status = params.get('image_status')
-        analysis_status = params.get('analysis_status')
+    image_status = params.get('image_status') if params else None
+    analysis_status = params.get('analysis_status') if params else None
 
     httpcode = 500
     try:
@@ -255,7 +254,6 @@ def image(dbsession, request_inputs, bodycontent=None):
                     input_type = t
                     image_info = anchore_engine.common.images.get_image_info(userId, "docker", input_string, registry_lookup=False, registry_creds=(None, None))
                     break
-
 
         image_status_filter = image_status if image_status and image_status != 'all' else None
         analysis_status_filter = analysis_status if analysis_status and analysis_status != 'all' else None
@@ -301,16 +299,11 @@ def image(dbsession, request_inputs, bodycontent=None):
                             if k in image_info and image_info[k]:
                                 dbfilter[k] = image_info[k]
 
-                        if image_status_filter:
-                            dbfilter['image_status'] = image_status_filter
-                        if analysis_status_filter:
-                            dbfilter['analysis_status'] = analysis_status_filter
-
                         logger.debug("image DB lookup filter: " + json.dumps(dbfilter, indent=4))
                         if history:
-                            image_records = db_catalog_image.get_byimagefilter(userId, 'docker', dbfilter=dbfilter, session=dbsession)
+                            image_records = db_catalog_image.get_byimagefilter(userId, 'docker', dbfilter=dbfilter, image_status=image_status_filter, analysis_status=analysis_status_filter, session=dbsession)
                         else:
-                            image_records = db_catalog_image.get_byimagefilter(userId, 'docker', dbfilter=dbfilter,
+                            image_records = db_catalog_image.get_byimagefilter(userId, 'docker', dbfilter=dbfilter, image_status=image_status_filter, analysis_status=analysis_status_filter,
                                                                                onlylatest=True, session=dbsession)
 
                         if image_records:


### PR DESCRIPTION
Addresses a failure to filter results by state when the tag filter or other filters are provided.

Adds filtering to another db query with a default to 'active' only images.