### PR TITLE
Deduplicate multiple copies of parse_dockerimage_string

### DIFF
--- a/anchore_engine/services/policy_engine/engine/policy/bundles.py
+++ b/anchore_engine/services/policy_engine/engine/policy/bundles.py
@@ -696,7 +696,7 @@ class MappingRule(object):
         if not tag:
             raise ValueError('Tag cannot be empty or null for matching evaluation')
         else:
-            match_target = parse_dockerimage_string(tag)
+            match_target = parse_dockerimage_string(tag, strict=False)
 
         # Must match registry and repo first
         if not (self._registry_match(match_target.get('registry')) and self._repository_match(match_target.get('repo'))):

--- a/anchore_engine/utils.py
+++ b/anchore_engine/utils.py
@@ -20,6 +20,7 @@ from ijson.backends import python as ijpython
 
 
 from anchore_engine.subsys import logger
+from anchore_engine.util.docker import parse_dockerimage_string
 
 
 K_BYTES = 1024
@@ -257,120 +258,6 @@ class AnchoreException(Exception):
 
     def to_dict(self):
         return {self.__class__.__name__: dict((key, value) for key, value in vars(self).items() if not key.startswith('_'))}
-
-def parse_dockerimage_string(instr):
-    host = None
-    port = None
-    repo = None
-    tag = None
-    registry = None
-    repotag = None
-    fulltag = None
-    fulldigest = None
-    digest = None
-    imageId = None
-
-    logger.debug("input string to parse: {}".format(instr))
-    instr = instr.strip()
-    bad_chars = re.findall(r"[^a-zA-Z0-9@:/_\.\-]", instr)
-    if bad_chars:
-        raise ValueError("bad character(s) {} in dockerimage string input ({})".format(bad_chars, instr))
-
-    if re.match("^sha256:.*", instr):
-        registry = 'docker.io'
-        digest = instr
-
-    elif len(instr) == 64 and not re.findall("[^0-9a-fA-F]+",instr):
-        imageId = instr
-    else:
-
-        # get the host/port
-        patt = re.match("(.*?)/(.*)", instr)
-        if patt:
-            a = patt.group(1)
-            remain = patt.group(2)
-            patt = re.match("(.*?):(.*)", a)
-            if patt:
-                host = patt.group(1)
-                port = patt.group(2)
-            elif a == 'docker.io':
-                host = 'docker.io'
-                port = None
-            elif a in ['localhost', 'localhost.localdomain', 'localbuild']:
-                host = a
-                port = None
-            else:
-                patt = re.match(r".*\..*", a)
-                if patt:
-                    host = a
-                else:
-                    host = 'docker.io'
-                    remain = instr
-                port = None
-
-        else:
-            host = 'docker.io'
-            port = None
-            remain = instr
-
-        # get the repo/tag
-        patt = re.match("(.*)@(.*)", remain)
-        if patt:
-            repo = patt.group(1)
-            digest = patt.group(2)
-        else:
-            patt = re.match("(.*):(.*)", remain)
-            if patt:
-                repo = patt.group(1)
-                tag = patt.group(2)
-            else:
-                repo = remain
-                tag = "latest"
-
-        if not tag:
-            tag = "latest"
-
-        if port:
-            registry = ':'.join([host, port])
-        else:
-            registry = host
-
-        if digest:
-            repotag = '@'.join([repo, digest])
-        else:
-            repotag = ':'.join([repo, tag])
-
-        fulltag = '/'.join([registry, repotag])
-
-        if not digest:
-            digest = None
-        else:
-            fulldigest = registry + '/' + repo + '@' + digest
-            tag = None
-            fulltag = None
-            repotag = None
-
-    ret = {}
-    ret['host'] = host
-    ret['port'] = port
-    ret['repo'] = repo
-    ret['tag'] = tag
-    ret['registry'] = registry
-    ret['repotag'] = repotag
-    ret['fulltag'] = fulltag
-    ret['digest'] = digest
-    ret['fulldigest'] = fulldigest
-    ret['imageId'] = imageId
-
-    if ret['fulldigest']:
-        ret['pullstring'] = ret['fulldigest']
-    elif ret['fulltag']:
-        ret['pullstring'] = ret['fulltag']
-    else:
-        ret['pullstring'] = None
-
-    return ret
-
 
 def ensure_bytes(obj):
     return obj.encode('utf-8') if type(obj) != bytes else obj


### PR DESCRIPTION
Rather than maintaining two slightly-out-of-sync copies of the same function that work slightly differently, just pull in one of the copies into the other module's namespace, and make it able to handle both use cases.

This adds the kwarg `strict` to `parse_dockerimage_string`, which if set to `False`, will NOT throw exceptions on invalid input characters (i.e., so the "shape checking" use case of the policy engine can use it)

Also provide some code cleanups, e.g., using raw-strings for regex, tuples instead of lists, etc.