### PR TITLE
Dont allow admin account disablement fix 522

### DIFF
--- a/anchore_engine/db/db_accounts.py
+++ b/anchore_engine/db/db_accounts.py
@@ -70,7 +70,7 @@ def update_state(name, new_state, session=None):
     if accnt.state == AccountStates.deleting or (accnt.state == AccountStates.enabled and new_state == AccountStates.deleting):
         raise InvalidStateError(accnt.state, new_state)
 
-    # Both Account Name and Type should be admin, but just to be safe...
+    # Both Account Name and Type should be equal to "admin" for the Admin Account, but just to be safe...
     if (accnt.name == 'admin' or accnt.type == 'admin') and new_state != AccountStates.enabled:
         raise DisableAdminAccountError()
 

--- a/anchore_engine/db/db_accounts.py
+++ b/anchore_engine/db/db_accounts.py
@@ -3,6 +3,7 @@ Interface to the accounts table. Data format is dicts, not objects.
 """
 from anchore_engine.db import Account, AccountTypes, AccountStates
 from anchore_engine.db.entities.common import anchore_now
+from anchore_engine.configuration.localconfig import ADMIN_ACCOUNT_NAME
 
 
 class AccountNotFoundError(Exception):
@@ -71,7 +72,7 @@ def update_state(name, new_state, session=None):
         raise InvalidStateError(accnt.state, new_state)
 
     # Both Account Name and Type should be equal to "admin" for the Admin Account, but just to be safe...
-    if (accnt.name == 'admin' or accnt.type == 'admin') and new_state != AccountStates.enabled:
+    if (accnt.name == ADMIN_ACCOUNT_NAME or accnt.type == AccountTypes.admin) and new_state != AccountStates.enabled:
         raise DisableAdminAccountError()
 
     accnt.state = new_state

--- a/anchore_engine/services/apiext/api/controllers/accounts.py
+++ b/anchore_engine/services/apiext/api/controllers/accounts.py
@@ -307,9 +307,7 @@ def update_account_state(accountname, desired_state):
                 return account_db_to_status_msg(result), 200
             else:
                 return make_response_error('Error updating account state'), 500
-    except InvalidStateError as ex:
-        return make_response_error(str(ex), in_httpcode=400), 400
-    except DisableAdminAccountError as ex:
+    except (InvalidStateError, DisableAdminAccountError) as ex:
         return make_response_error(str(ex), in_httpcode=400), 400
     except AccountNotFoundError as ex:
         return make_response_error('Account not found', in_httpcode=404), 404


### PR DESCRIPTION
Signed-off-by: Samuel Dacanay <samjdacanay@gmail.com>

**What this PR does / why we need it**:
This PR addresses the issue where it is technically possible to disable the admin account, yet hard to re-enable afterwards

**Which issue this PR fixes**: fixes  #522

**Special notes**:
Verified fix works locally, with following result:
```zsh
samdacanay@samsanchorembp forks % anchore-cli account disable admin
Error: Cannot disable the admin account
HTTP Code: 400
Detail: {u'error_codes': []}
```

