### PR TITLE
Fix exception response handler and create dedicated exception for image conflict errors

### DIFF
--- a/anchore_engine/services/catalog/api/controllers/default_controller.py
+++ b/anchore_engine/services/catalog/api/controllers/default_controller.py
@@ -4,6 +4,7 @@ import anchore_engine.apis
 from anchore_engine import db
 import anchore_engine.services.catalog.catalog_impl
 import anchore_engine.common
+from anchore_engine.services.catalog.archiver import ImageConflict
 from anchore_engine.subsys import logger
 import anchore_engine.configuration.localconfig
 import anchore_engine.subsys.servicestatus
@@ -95,7 +96,9 @@ def add_image(image_metadata=None, tag=None, digest=None, created_at=None, from_
 
             with db.session_scope() as session:
                 return_object, httpcode = anchore_engine.services.catalog.catalog_impl.image(session, request_inputs, bodycontent=image_metadata)
-
+    except ImageConflict as img_err:
+        httpcode = 409
+        return_object = str(img_err)
     except Exception as err:
         logger.exception('Error processing image add')
         httpcode = 500


### PR DESCRIPTION
Signed-off-by: Samuel Dacanay <sam.dacanay@anchore.com>

<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**: Improves Engine's ability to parse errors into readable responses, and allows HTTP codes from catalog request to pass through to the API response should they be formatted correctly. Use a dedicated Exception for the case where there is an Image Conflict when a restore-from-archive operation happens


**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #592 

**Special notes**:


