### PR TITLE
bump zope.interface to 4.7.2 which addresses incompatible changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ watchdog==0.9.0
 Werkzeug==0.16.0
 yosai==0.3.2
 zope.component==4.6
-zope.interface==4.7.1
+zope.interface==4.7.2
 ijson==2.5.1
 
 # Optional and third-party/integration dependencies


### PR DESCRIPTION
Specifically, 4.7.1 no longer works with Python 3.8, install fails.

Reference issue: https://github.com/zopefoundation/zope.interface/issues/30

Signed-off-by: Alfredo Deza <adeza@anchore.com>

<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**: Closes https://github.com/anchore/anchore-engine/issues/609


**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #:

**Special notes**:


