### PR TITLE
python 3.8 support for deserialize

### DIFF
--- a/tests/unit/anchore_engine/services/policy_engine/api/test_util.py
+++ b/tests/unit/anchore_engine/services/policy_engine/api/test_util.py
@@ -1,0 +1,43 @@
+from datetime import datetime
+from typing import List
+from anchore_engine.services.policy_engine.api import util
+from anchore_engine.services.policy_engine.api.models import Tag, Image
+from anchore_engine.services.policy_engine.api.models import PolicyRule, PolicyRuleParams
+
+
+
+def test_deserialize_image():
+    dikt = {
+            'id': "1",
+            'digest': "111",
+            'user_id': "1",
+            'state': "initializing",
+            'distro_namespace': "namespace",
+            'created_at': str(datetime.now()),
+            'last_modified': str(datetime.now()),
+            'tags': ["tag1", "tag2"]
+        }
+
+
+    result = util.deserialize_model(dikt, Image)
+    assert isinstance(result, Image)
+
+
+class TestPolicyRule:
+
+    def test_with_params(self):
+        policy_rule_params = [
+            {'name': "rule1", 'value': "value1"},
+            {'name': "rule2", 'value': "value2"},
+        ]
+
+        dikt = {
+            'id': "1",
+            'gate': "1",
+            'trigger': "trigger",
+            'action': "GO",
+            'params': policy_rule_params
+        }
+        result = util.deserialize_model(dikt, PolicyRule)
+        assert result.id == "1"
+        assert len(result.params) == 2


### PR DESCRIPTION
<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**: Closes #611 : There is no `GenericMeta` in Python 3.8, which is used to check if the type is coming from a `List` or a `Dict`

There are no `Dict` type hints used at all, so this PR removes the deserialization for that. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #: Closes #611

**Special notes**: There wasn't any (apparent) need to check for nested list objects that weren't addressed by `deserialize_model()`.

These changes along with the `zope.interface` change in PR #610 made all functional (+ enterprise) tests pass


```
$ tox -e py38 tests/functional --result-json test-functional-report.json
GLOB sdist-make: /Users/alfredo/python/enterprise/setup.py
py38 inst-nodeps: /Users/alfredo/python/enterprise/.tox/.tmp/package/1/anchore_enterprise-2.4.0.zip
py38 installed: anchore-engine @ file:///Users/alfredo/python/enterprise/deps/anchore-engine,anchore-enterprise @ file:///Users/alfredo/python/enterprise/.tox/.tmp/package/1/anchore_enterprise-2.4.0.zip,argh==0.26.2,argon2-cffi==20.1.0,attrs==20.2.0,Authlib==0.12.1,Automat==20.2.0,bcrypt==3.2.0,boto3==1.11.6,botocore==1.14.17,cbor2==5.1.2,certifi==2020.6.20,cffi==1.14.2,chardet==3.0.4,Click==7.0,clickclick==1.2.2,connexion==2.5.1,constantly==15.1.0,cryptography==3.1,docker==4.3.1,docutils==0.15.2,Flask==1.1.1,hyperlink==20.0.1,idna==2.8,ijson==2.5.1,incremental==17.5.0,inflection==0.5.1,iniconfig==1.0.1,itsdangerous==1.1.0,Jinja2==2.11.2,jmespath==0.10.0,jsonschema==2.6.0,MarkupSafe==1.1.1,more-itertools==8.5.0,msgpack-python==0.5.6,openapi-spec-validator==0.2.9,packaging==20.4,passlib==1.7.2,pathlib==1.0.1,pathtools==0.1.2,pluggy==0.13.1,prettytable==0.7.2,prometheus-client==0.7.1,prometheus-flask-exporter==0.12.1,psutil==5.6.7,psycopg2-binary==2.8.4,py==1.9.0,pyasn1==0.4.8,pyasn1-modules==0.2.8,pycparser==2.20,pycryptodome==3.9.4,PyHamcrest==2.0.2,pyOpenSSL==19.1.0,pyparsing==2.4.7,Pypubsub==4.0.3,pytest==6.0.1,python-dateutil==2.8.1,python-rapidjson==0.9.1,python-swiftclient==3.8.1,pytz==2019.3,PyYAML==5.3.1,requests==2.22.0,retrying==1.3.3,s3transfer==0.3.3,semantic-version==2.6.0,service-identity==18.1.0,six==1.14.0,SQLAlchemy==1.3.12,swagger-spec-validator==2.4.3,toastedmarshmallow==2.15.2.post1,toml==0.10.1,treelib==1.5.5,Twisted==20.3.0,typing==3.7.4.1,urllib3==1.25.8,watchdog==0.9.0,websocket-client==0.57.0,Werkzeug==0.16.0,yosai==0.3.2,zope.component==4.6,zope.deferredimport==4.3.1,zope.deprecation==4.4.0,zope.event==4.4,zope.hookable==5.0.1,zope.interface==4.7.2,zope.proxy==4.3.5
py38 run-test-pre: PYTHONHASHSEED='1955152387'
py38 run-test: commands[0] | pytest --junitxml=.tox/results/tox/junit-py38.xml tests/functional
============================= test session starts ==============================
platform darwin -- Python 3.8.1, pytest-6.0.1, py-1.9.0, pluggy-0.13.1
cachedir: .tox/py38/.pytest_cache
rootdir: /Users/alfredo/python/enterprise, configfile: pytest.ini
collected 118 items

...
- generated xml file: /Users/alfredo/python/enterprise/.tox/results/tox/junit-py38.xml -
============ 108 passed, 10 skipped, 1 warning in 138.56s (0:02:18) ============
___________________________________________________________________________________________________________________________________ summary ____________________________________________________________________________________________________________________________________
  py38: commands succeeded
  congratulations :)
```





