### PR TITLE
Add capabilities for passing in cmdline arguments to clamscan and freshclam

### DIFF
--- a/anchore_engine/analyzers/malware.py
+++ b/anchore_engine/analyzers/malware.py
@@ -5,7 +5,7 @@ import subprocess
 config_path = os.getenv('ANCHORE_FRESHCLAM_CONFIG_FILE', '/home/anchore/clamav/freshclam.conf')
 dbdir = os.getenv('ANCHORE_CLAMAV_DB_DIR', '/home/anchore/clamav/db')
 
-CLAMAV_CMD = "clamscan --suppress-ok-results --infected --recursive --allmatch --archive-verbose --tempdir={tempdir} --database={database}"
+CLAMAV_CMD = "clamscan --suppress-ok-results --infected --recursive --allmatch --archive-verbose --tempdir={tempdir} --database={database} --max-filesize=4000m --max-scansize=4000m"
 REFRESH_CMD = "freshclam --stdout --datadir={database} --config-file={configfile}"
 CLAMAV_FINDING_EXITCODE = 1
 CLAMAV_NO_FINDING_EXITCODE = 0
@@ -19,7 +19,7 @@ class RefreshFailedException(Exception):
     pass
 
 
-def run_clamav(path_to_scan: str, tempdir: str, dbdir: str) -> str:
+def run_clamav(path_to_scan: str, tempdir: str, dbdir: str, cmdline_args: list) -> str:
     """
     Run the scan
 
@@ -33,17 +33,64 @@ def run_clamav(path_to_scan: str, tempdir: str, dbdir: str) -> str:
     :param dbdir: str path to clamav virus db
     :return:
     """
+    clamscan_cmd = "{} {}".format(append_cmdline_args(CLAMAV_CMD.format(tempdir=tempdir, database=dbdir), cmdline_args),
+                                  path_to_scan)
+    if not is_squashed_tar_valid_for_scan(path_to_scan, clamscan_cmd):
+        print("Squashed tar {} is larger than configured clamscan parameters for filesize or scansize".format(path_to_scan))
+        return ''
 
-    cmd = CLAMAV_CMD.format(tempdir=tempdir, database=dbdir) + " " + path_to_scan
-    print('Running command {}'.format(cmd))
-    status, output = subprocess.getstatusoutput(cmd)
+    print('Running command {}'.format(clamscan_cmd))
+    status, output = subprocess.getstatusoutput(clamscan_cmd)
     if status in [CLAMAV_FINDING_EXITCODE, CLAMAV_NO_FINDING_EXITCODE]:
         return output
     else:
         raise ScanFailedException('clamav execution failed. returned exit code {}. Output = {}'.format(status, output))
 
 
-def refresh_clamavdb(databasedir: str, configfile: str) -> str:
+def is_squashed_tar_valid_for_scan(path_to_scan: str, clamscan_cmd: str) -> bool:
+    """
+    if value from max-filesize=<value> or max-scansize=<value> is smaller than the actual squashed tar,
+    we should not attempt the scan
+    """
+    squashed_tar_size_bytes = os.path.getsize(path_to_scan)
+
+    cmd_filesize = get_bytes_from_cmd_for_key(clamscan_cmd, 'max-filesize')
+    cmd_scansize = get_bytes_from_cmd_for_key(clamscan_cmd, 'max-scansize')
+
+    return squashed_tar_size_bytes < cmd_filesize and squashed_tar_size_bytes < cmd_scansize
+
+
+def get_bytes_from_cmd_for_key(clamscan_cmd: str, param_key: str) -> int:
+    regex = r"{}=(.*?)(\s|$)".format(param_key)
+    capture_group = re.search(regex, clamscan_cmd).group(1)
+
+    # result is in megabytes
+    if capture_group.endswith("M") or capture_group.endswith("m"):
+        bytes_value = int(capture_group[:-1])
+        bytes_value *= 1000000
+    else:
+        # result is in kb
+        bytes_value = int(capture_group)
+        bytes_value *= 1000
+    return bytes_value
+
+
+def append_cmdline_args(cmd: str, cmdline_args: list) -> str:
+    command = cmd
+    # append or replace command line args
+    for arg in cmdline_args:
+        # If the arg format is x=y, then we will either replace the value if the key (x) exists or we will append
+        # NOTE: If the arg format is just a key, we will always append
+        arg_parts = arg.split("=")
+        if len(arg_parts) > 1 and arg_parts[0] in command:
+            replace_expr = r"{}=.*?(\s|$)".format(arg_parts[0])
+            command = re.sub(replace_expr, "{} ".format(arg), command)
+        else:
+            command += " --{}".format(arg)
+    return command.strip()
+
+
+def refresh_clamavdb(databasedir: str, configfile: str, cmdline_args: list) -> str:
     """
     Run the refresh and return the output str
 
@@ -53,7 +100,7 @@ def refresh_clamavdb(databasedir: str, configfile: str) -> str:
     """
 
     print('Refreshing ClamAV DB')
-    cmd = REFRESH_CMD.format(database=databasedir, configfile=configfile)
+    cmd = append_cmdline_args(REFRESH_CMD.format(database=databasedir, configfile=configfile), cmdline_args)
     print('Running command {}'.format(cmd))
     status, output = subprocess.getstatusoutput(cmd)
     if status == 0:
@@ -195,9 +242,18 @@ class MalwareScanner:
         """
         self.config = config
         self.tar_path = squashed_tar_path
-        self.enabled = self.config.get(self.name, {}).get('enabled', False) if self.config is not None and self.config.get(self.name) is not None and self.tar_path is not None else False
-        self.refresh_enabled = self.config.get(self.name, {}).get('db_update_enabled', True) if self.config is not None and self.config.get(self.name) is not None else True
         self.tempdir = tempdir
+
+        if self.config is not None and self.config.get(self.name) is not None:
+            self.enabled = self.config.get(self.name, {}).get('enabled', False) if self.tar_path is not None else False
+            self.refresh_enabled = self.config.get(self.name, {}).get('db_update_enabled', True)
+            self.clamscan_args = self.config.get(self.name, {}).get('clamscan_args', [])
+            self.freshclam_args = self.config.get(self.name, {}).get('freshclam_args', [])
+        else:
+            self.enabled = False
+            self.refresh_enabled = True
+            self.clamscan_args = []
+            self.freshclam_args = []
 
     def run(self) -> ScanResult:
         raise NotImplementedError
@@ -212,8 +268,10 @@ class ClamAVRunner(MalwareScanner):
 
         :return:
         """
-        tmpdir = self.tempdir
-        output = run_clamav(self.tar_path, tempdir=tmpdir, dbdir=dbdir)
+        output = run_clamav(self.tar_path, tempdir=self.tempdir, dbdir=dbdir, cmdline_args=self.clamscan_args)
+        if not output:
+            return []
+
         print("Raw ClamAV stdout: " + output)
         return parse_clamscan(self.tar_path, output)
 
@@ -222,9 +280,8 @@ class ClamAVRunner(MalwareScanner):
         Update the signature db, and return the versions
         :return: version dict
         """
-        refresh_output = refresh_clamavdb(databasedir=dbdir, configfile=config_path)
+        refresh_output = refresh_clamavdb(databasedir=dbdir, configfile=config_path, cmdline_args=self.freshclam_args)
         return parse_refresh_output(refresh_output)
-
 
     def run(self):
         print("running clamav scan")

--- a/tests/unit/anchore_engine/analyzers/test_malware_analyzer.py
+++ b/tests/unit/anchore_engine/analyzers/test_malware_analyzer.py
@@ -4,6 +4,7 @@ Unit tests for the malware analyzer
 import pytest
 
 from anchore_engine.analyzers import malware
+from anchore_engine.analyzers.malware import CLAMAV_CMD
 
 test_sig = "Unix.Trojan.MSShellcode-40"
 scanned_file = "/analysis_scratch/a5346cac-802a-4cb9-a0c5-756b9b51858b/squashed.tar"
@@ -111,3 +112,21 @@ def test_disabled(config):
     out = t.run()
     assert out is not None
     assert out.findings is None
+
+
+replace_append_case = {
+    "expected": "clamscan --suppress-ok-results --infected --recursive --allmatch --archive-verbose --tempdir={tempdir} --database={database} --max-filesize=3000m --max-scansize=2000m",
+    "cmd": CLAMAV_CMD,
+    "args": ["max-filesize=3000m", "max-scansize=2000m"]
+}
+
+
+@pytest.mark.parametrize("param", [pytest.param(replace_append_case, id="replace_existing_append")])
+def test_append_cmdline_args(param):
+    assert malware.append_cmdline_args(param["cmd"], param["args"]) == param["expected"]
+
+
+@pytest.mark.parametrize("param", ['max-filesize', 'max-scansize'])
+def test_get_bytes_from_cmd_for_key(param):
+    assert malware.get_bytes_from_cmd_for_key(CLAMAV_CMD, param) == 4000000000
+


### PR DESCRIPTION
Signed-off-by: Samuel Dacanay <sam.dacanay@anchore.com>

<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**: We need to make the clamscan command more configurable in case people need to process images larger than 25mb. 


**Which issue this PR fixes**: fixes #615

**Special notes**:


