### PR TITLE
Fixes bad error handling in bundle validation path

### DIFF
--- a/anchore_engine/services/policy_engine/api/controllers/synchronous_operations.py
+++ b/anchore_engine/services/policy_engine/api/controllers/synchronous_operations.py
@@ -229,8 +229,10 @@ def problem_from_exception(eval_exception, severity=None):
     # If there is a details() function, call that
     if hasattr(eval_exception, 'details') and callable(eval_exception.details):
         prob.details = eval_exception.details()
-    else:
+    elif hasattr(eval_exception, 'message'):
         prob.details = eval_exception.message
+    else:
+        prob.details = str(eval_exception)
 
     prob.problem_type = eval_exception.__class__.__name__
     if hasattr(eval_exception, 'severity') and eval_exception.severity:

--- a/anchore_engine/services/policy_engine/engine/policy/bundles.py
+++ b/anchore_engine/services/policy_engine/engine/policy/bundles.py
@@ -1111,9 +1111,9 @@ class ExecutableBundle(VersionedEntityMixin):
 
                     for policy_id in rule.policy_ids:
                         if len(policies[policy_id]) > 1:
-                            raise DuplicateIdentifierFoundError(identifier=rule.policy_id, identifier_type='policy')
+                            raise DuplicateIdentifierFoundError(identifier=policy_id, identifier_type='policy')
                         if not policies[policy_id]:
-                            raise ReferencedObjectNotFoundError(reference_id=rule.policy_id, reference_type='policy')
+                            raise ReferencedObjectNotFoundError(reference_id=policy_id, reference_type='policy')
 
                         self.policies[policy_id] = ExecutablePolicy(policies[policy_id][0], strict_validation=strict_validation)
 

--- a/anchore_engine/services/policy_engine/engine/policy/exceptions.py
+++ b/anchore_engine/services/policy_engine/engine/policy/exceptions.py
@@ -126,7 +126,7 @@ class ValidationError(PolicyError):
 
 class ReferencedObjectNotFoundError(ValidationError):
     def __init__(self, reference_type, reference_id):
-        super().__init__('Referenced bundle object not found')
+        super().__init__('Referenced object not found')
         self.reference_type = reference_type
         self.reference_id = reference_id
 


### PR DESCRIPTION
Fixes #634

* Fix for catching validation exceptions that do not have a 'message'
attribute, uses generic string representation as fallback
* Fix to bundle validation when mappings have policy_id references that
do not exist in the bundle
* Better message for ReferencedObjectNotFoundError

Signed-off-by: Zach Hill <zach@anchore.com>
