### PR TITLE
Allow for analyzer output to optionally be json encoded

### DIFF
--- a/anchore_engine/common/helpers.py
+++ b/anchore_engine/common/helpers.py
@@ -105,7 +105,7 @@ def make_anchore_exception(err, input_message=None, input_httpcode=None, input_d
 
         if error_codes:
             ret.anchore_error_json['detail']['error_codes'].extend(error_codes)
-                                   
+
     return ret
 
 
@@ -369,9 +369,7 @@ def make_eval_record(userId, evalId, policyId, imageDigest, tag, final_action, e
 
 def safe_extract_json_value(value):
     # support the legacy serialized json string
-    if isinstance(value, str):
-        try:
-            value = json.loads(value)
-        except json.decoder.JSONDecodeError:
-            pass
-    return value
+    try:
+        return json.loads(value)
+    except (TypeError, json.decoder.JSONDecodeError):
+        return value

--- a/anchore_engine/common/helpers.py
+++ b/anchore_engine/common/helpers.py
@@ -204,7 +204,7 @@ def extract_files_content(image_data):
         if 'files.allinfo' in image_data['imagedata']['analysis_report']['file_list']:
             adata = image_data['imagedata']['analysis_report']['file_list']['files.allinfo']['base']
             for k in list(adata.keys()):
-                avalue = json.loads(adata[k])
+                avalue = safe_extract_json_value(adata[k])
                 if k in fcsums:
                     avalue['sha256'] = fcsums[k]
                 ret[k] = avalue
@@ -218,8 +218,7 @@ def extract_os_content(image_data):
     if 'pkgs.allinfo' in image_data['imagedata']['analysis_report']['package_list']:
         adata = image_data['imagedata']['analysis_report']['package_list']['pkgs.allinfo']['base']
         for k in list(adata.keys()):
-            avalue = json.loads(adata[k])
-            ret[k] = avalue
+            ret[k] = safe_extract_json_value(adata[k])
     return ret
 
 
@@ -228,8 +227,7 @@ def extract_npm_content(image_data):
     if 'pkgs.npms' in image_data['imagedata']['analysis_report']['package_list']:
         adata = image_data['imagedata']['analysis_report']['package_list']['pkgs.npms']['base']
         for k in list(adata.keys()):
-            avalue = json.loads(adata[k])
-            ret[k] = avalue
+            ret[k] = safe_extract_json_value(adata[k])
     return ret
 
 
@@ -238,8 +236,7 @@ def extract_gem_content(image_data):
     if 'pkgs.gems' in image_data['imagedata']['analysis_report']['package_list']:
         adata = image_data['imagedata']['analysis_report']['package_list']['pkgs.gems']['base']
         for k in list(adata.keys()):
-            avalue = json.loads(adata[k])
-            ret[k] = avalue
+            ret[k] = safe_extract_json_value(adata[k])
     return ret
 
 
@@ -248,8 +245,7 @@ def extract_python_content(image_data):
     if 'pkgs.python' in image_data['imagedata']['analysis_report']['package_list']:
         adata = image_data['imagedata']['analysis_report']['package_list']['pkgs.python']['base']
         for k in list(adata.keys()):
-            avalue = json.loads(adata[k])
-            ret[k] = avalue
+            ret[k] = safe_extract_json_value(adata[k])
     return ret
 
 
@@ -258,8 +254,7 @@ def extract_java_content(image_data):
     if 'pkgs.java' in image_data['imagedata']['analysis_report']['package_list']:
         adata = image_data['imagedata']['analysis_report']['package_list']['pkgs.java']['base']
         for k in list(adata.keys()):
-            avalue = json.loads(adata[k])
-            ret[k] = avalue
+            ret[k] = safe_extract_json_value(adata[k])
     return ret
 
 
@@ -268,8 +263,7 @@ def extract_pkg_content(image_data, content_type):
     ret = {}
     adata = image_data['imagedata']['analysis_report']['package_list']['pkgs.{}'.format(content_type)]['base']
     for k in list(adata.keys()):
-        avalue = json.loads(adata[k])
-        ret[k] = avalue
+        ret[k] = safe_extract_json_value(adata[k])
     return ret
 
 
@@ -280,7 +274,7 @@ def extract_malware_content(image_data):
     malware_scans = image_data['imagedata']['analysis_report'].get('malware', {}).get('malware', {}).get('base', {})
 
     for scanner_name, output in malware_scans.items():
-        finding = json.loads(output)
+        finding = safe_extract_json_value(output)
         ret.append(finding)
 
         # ret[scanner_name]
@@ -372,3 +366,12 @@ def make_eval_record(userId, evalId, policyId, imageDigest, tag, final_action, e
     payload["last_updated"] = payload['created_at']
 
     return payload
+
+def safe_extract_json_value(value):
+    # support the legacy serialized json string
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.decoder.JSONDecodeError:
+            pass
+    return value

--- a/tests/unit/anchore_engine/common/test_helpers.py
+++ b/tests/unit/anchore_engine/common/test_helpers.py
@@ -1,0 +1,17 @@
+import pytest
+from anchore_engine.common import helpers
+
+
+values = [
+    pytest.param("{}", {}, id="'{}'"),
+    pytest.param({}, {}, id="{}"),
+    pytest.param("a string", "a string", id="'a string'"),
+]
+
+
+class TestSafeExtractJsonValue:
+
+    @pytest.mark.parametrize("value, expected", values)
+    def test_inputs(self, value, expected):
+        result = helpers.safe_extract_json_value(value)
+        assert result == expected


### PR DESCRIPTION
**What this PR does / why we need it**:
Today the analyzers have several stages of encoding and decoding --as part of the 3.0 work we will be removing some of these stages. This specific change allows for the json decoding step to be optional, enabling use of the existing analyzers mixed with the new analyzers (from syft). This will help in testing the swap out of the analyzers and remove extra encoding/decoding steps from the analysis path.



