### PR TITLE
bump urllib3 to prevent reported vulnerability with current version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ toastedmarshmallow==2.15.2.post1
 treelib==1.5.5
 Twisted[tls]==20.3.0
 typing==3.7.4.1
-urllib3==1.25.8
+urllib3==1.25.9
 watchdog==0.9.0
 Werkzeug==0.16.0
 yosai==0.3.2


### PR DESCRIPTION
Relevant changelog section in urllib3: https://github.com/urllib3/urllib3/blob/master/CHANGES.rst#1259-2020-04-16

Same fix in https://github.com/anchore/anchore-cli/pull/130

