### PR TITLE
Add keyword arguments so swagger can route the request to the api con…

### DIFF
--- a/anchore_engine/services/apiext/api/controllers/oauth.py
+++ b/anchore_engine/services/apiext/api/controllers/oauth.py
@@ -12,7 +12,7 @@ from anchore_engine.apis.exceptions import AccessDeniedError
 authorizer = get_authorizer()
 
 
-def get_oauth_token():
+def get_oauth_token(grant_type='password', username=None, password=None, client_id='anonymous'):
     """
     POST /oauth/token
 
@@ -21,6 +21,10 @@ def get_oauth_token():
     This is a bit of a mix of the ResourceOwnerPasswordGrant flow and the ImplicitGrant flow since
     this function will populate the necessary fields to perform a password grant if the Authorization
     header is set and no content body is provided
+
+    Note: the parameters above are embedded within the connexion request object, but must be specified in the
+    method signature in order for connexion to route the request to this method. So it may appear that they are unused,
+    but have no fear, they are!
 
     :return:
     """
@@ -38,7 +42,14 @@ def get_oauth_token():
             logger.debug('Handling converting empty body into form-based grant request')
 
             if not request.data and not request.form:
-                setattr(request, 'form', ImmutableMultiDict([('username', request.authorization.username), ('password', request.authorization.password), ('grant_type', 'password'), ('client_id', 'anonymous')]))
+                setattr(request,
+                        'form',
+                        ImmutableMultiDict([
+                            ('username', request.authorization.username),
+                            ('password', request.authorization.password),
+                            ('grant_type', 'password'),
+                            ('client_id', 'anonymous')])
+                        )
 
         resp = authz.create_token_response()
         logger.debug('Token resp: {}'.format(resp))

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ toastedmarshmallow==2.15.2.post1
 treelib==1.5.5
 Twisted[tls]==20.3.0
 typing==3.7.4.1
-urllib3==1.25.8
+urllib3==1.25.9
 watchdog==0.9.0
 Werkzeug==0.16.0
 yosai==0.3.2


### PR DESCRIPTION
…troller

Signed-off-by: Samuel Dacanay <sam.dacanay@anchore.com>

Fixes an intermittent issue that @nightfurys found w/ the oauth APIs


