### PR TITLE
Add parsing failsafe when a path is not able to be found, with de-duplicated signatures

### DIFF
--- a/anchore_engine/analyzers/malware.py
+++ b/anchore_engine/analyzers/malware.py
@@ -9,6 +9,7 @@ CLAMAV_CMD = "clamscan --suppress-ok-results --infected --recursive --allmatch -
 REFRESH_CMD = "freshclam --stdout --datadir={database} --config-file={configfile}"
 CLAMAV_FINDING_EXITCODE = 1
 CLAMAV_NO_FINDING_EXITCODE = 0
+UNKNOWN = 'unknown'
 
 
 class ScanFailedException(Exception):
@@ -171,6 +172,13 @@ def parse_clamscan_output_line(scanned_file: str, line: str) -> tuple:
 
         return path, signature
 
+    # This is a failsafe if clamscan returns findings with an unexpected output
+    # I.E. eicar.com image that is plaintext and not executable.
+    regex = r'{}:\s+(.+)\s+FOUND$'.format(re.escape(scanned_file))
+    line_match = re.match(regex, line)
+    if line_match is not None:
+        return UNKNOWN, line_match.groups()[-1]
+
     return tuple()
 
 
@@ -201,6 +209,8 @@ def parse_clamscan(scanned_file: str, raw_output: str) -> list:
     summary_regex = re.compile('-+ SUMMARY -+')
     results = []
 
+    undefined_path_signatures = set()
+    defined_path_signatures = set()
     for line in raw_output.splitlines():
         if summary_regex.match(line):
             # Output complete
@@ -208,8 +218,18 @@ def parse_clamscan(scanned_file: str, raw_output: str) -> list:
 
         result = parse_clamscan_output_line(scanned_file, line)
         if result:
-            # Prefix each with "/" since it came from a tar file that is the rootfs
-            results.append({"path": result[0], "signature": result[1]})
+            path = result[0]
+            signature = result[1]
+            # Ensure that we have a unique set of signatures when the path is undefined (see parse_clamscan_output_line)
+            if path == UNKNOWN and signature not in undefined_path_signatures:
+                undefined_path_signatures.add(signature)
+            elif path != UNKNOWN:
+                results.append({"path": path, "signature": signature})
+                defined_path_signatures.add(signature)
+
+    # For each signature that doesn't have a defined path, append it.
+    for signature in undefined_path_signatures.difference(defined_path_signatures):
+        results.append({"path": UNKNOWN, "signature": signature})
     return results
 
 

--- a/tests/unit/anchore_engine/analyzers/test_malware_analyzer.py
+++ b/tests/unit/anchore_engine/analyzers/test_malware_analyzer.py
@@ -4,7 +4,7 @@ Unit tests for the malware analyzer
 import pytest
 
 from anchore_engine.analyzers import malware
-from anchore_engine.analyzers.malware import CLAMAV_CMD
+from anchore_engine.analyzers.malware import CLAMAV_CMD, UNKNOWN
 
 test_sig = "Unix.Trojan.MSShellcode-40"
 scanned_file = "/analysis_scratch/a5346cac-802a-4cb9-a0c5-756b9b51858b/squashed.tar"
@@ -12,14 +12,58 @@ scanned_file = "/analysis_scratch/a5346cac-802a-4cb9-a0c5-756b9b51858b/squashed.
 malware_matches = [
     ("/analysis_scratch/a5346cac-802a-4cb9-a0c5-756b9b51858b/squashed.tar!POSIX_TAR:bin/busybox!...!(7)POSIX_TAR:elf_payload1: Unix.Trojan.MSShellcode-40 FOUND", ("/elf_payload1", test_sig)),
     ("/analysis_scratch/a5346cac-802a-4cb9-a0c5-756b9b51858b/squashed.tar!POSIX_TAR:bin/busybox!...!(7)POSIX_TAR:somedir/somepath/elf_payload1: Unix.Trojan.MSShellcode-40 FOUND", ("/somedir/somepath/elf_payload1", test_sig)),
-    ("/analysis_scratch/a5346cac-802a-4cb9-a0c5-756b9b51858b/squashed.tar: Unix.Trojan.MSShellcode-40 FOUND", ())
+    ("/analysis_scratch/a5346cac-802a-4cb9-a0c5-756b9b51858b/squashed.tar: Unix.Trojan.MSShellcode-40 FOUND", (UNKNOWN, test_sig))
 ]
+
+clamscan_full_output_with_duplicates = """/analysis_scratch/a5346cac-802a-4cb9-a0c5-756b9b51858b/squashed.tar: Unix.Trojan.MSShellcode-40 FOUND
+/analysis_scratch/a5346cac-802a-4cb9-a0c5-756b9b51858b/squashed.tar: Unix.Malware.Agent-7153843-0 FOUND
+/analysis_scratch/a5346cac-802a-4cb9-a0c5-756b9b51858b/squashed.tar: Unix.Trojan.MSShellcode-40 FOUND
+/analysis_scratch/a5346cac-802a-4cb9-a0c5-756b9b51858b/squashed.tar!POSIX_TAR:bin/busybox!POSIX_TAR:etc/ssl/ct_log_list.cnf.dist!POSIX_TAR:etc/ssl/openssl.cnf.dist!...!(7)POSIX_TAR:elf_payload1: Unix.Trojan.MSShellcode-40 FOUND
+
+----------- SCAN SUMMARY -----------
+Known viruses: 8923276
+Engine version: 0.102.4
+Scanned directories: 0
+Scanned files: 1
+Infected files: 1
+Data scanned: 12.28 MB
+Data read: 6.07 MB (ratio 2.02:1)
+Time: 23.835 sec (0 m 23 s)
+"""
+clamscan_full_output_no_duplicates = """/analysis_scratch/a5346cac-802a-4cb9-a0c5-756b9b51858b/squashed.tar: Unix.Malware.Agent-7153843-0 FOUND
+/analysis_scratch/a5346cac-802a-4cb9-a0c5-756b9b51858b/squashed.tar!POSIX_TAR:bin/busybox!POSIX_TAR:etc/ssl/ct_log_list.cnf.dist!POSIX_TAR:etc/ssl/openssl.cnf.dist!...!(7)POSIX_TAR:elf_payload1: Unix.Trojan.MSShellcode-40 FOUND
+
+----------- SCAN SUMMARY -----------
+Known viruses: 8923276
+Engine version: 0.102.4
+Scanned directories: 0
+Scanned files: 1
+Infected files: 1
+Data scanned: 12.28 MB
+Data read: 6.07 MB (ratio 2.02:1)
+Time: 23.835 sec (0 m 23 s)
+"""
+clamscan_output = [("/analysis_scratch/a5346cac-802a-4cb9-a0c5-756b9b51858b/squashed.tar",
+                    clamscan_full_output_with_duplicates,
+                    [{'path': '/elf_payload1', 'signature': 'Unix.Trojan.MSShellcode-40'},
+                     {'path': 'unknown', 'signature': 'Unix.Malware.Agent-7153843-0'}]),
+                   ("/analysis_scratch/a5346cac-802a-4cb9-a0c5-756b9b51858b/squashed.tar",
+                    clamscan_full_output_no_duplicates,
+                    [{'path': '/elf_payload1', 'signature': 'Unix.Trojan.MSShellcode-40'},
+                     {'path': 'unknown', 'signature': 'Unix.Malware.Agent-7153843-0'}])
+                   ]
 
 
 @pytest.mark.parametrize(["line", "expected"], malware_matches)
 def test_clamav_lineparser(line, expected):
         parsed = malware.parse_clamscan_output_line(scanned_file, line)
         assert parsed == expected
+
+
+@pytest.mark.parametrize(["file", "output", "expected"], clamscan_output)
+def test_parse_clamscan(file, output, expected):
+    parsed = malware.parse_clamscan(file, output)
+    assert parsed == expected
 
 
 def test_freshclam_parser():


### PR DESCRIPTION
Signed-off-by: Samuel Dacanay <sam.dacanay@anchore.com>

<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**: Makes it so that even when malware is detected by clamav, but we cannot locate a path, that we still return the found signature to flag an issue (better to know that the issue is there than not at all, even if we can't tell you where it is)


**Which issue this PR fixes** Fixes #615

**Special notes**:


