### PR TITLE
Restore content hints functionality for removed analyzer modules

### DIFF
--- a/anchore_engine/analyzers/syft/__init__.py
+++ b/anchore_engine/analyzers/syft/__init__.py
@@ -38,3 +38,9 @@ def catalog_image(image):
 
     return defaultdict_to_dict(findings)
 
+
+def content_hints(hints_pkg):
+    """Content hints will provide the handlers with a means of inserting new data from
+    the user.
+    """
+    pass

--- a/anchore_engine/analyzers/syft/__init__.py
+++ b/anchore_engine/analyzers/syft/__init__.py
@@ -1,15 +1,15 @@
 import collections
 
-from anchore_engine.analyzers.utils import defaultdict_to_dict, get_hintsfile
+from anchore_engine.analyzers.utils import defaultdict_to_dict, content_hints
 from anchore_engine.clients.syft_wrapper import run_syft
-from .handlers import handlers_by_artifact_type
+from .handlers import handlers_by_artifact_type, handlers_by_engine_type
 
 
 def filter_artifacts(artifact):
     return artifact['type'] in handlers_by_artifact_type
 
 
-def catalog_image(image):
+def catalog_image(image, unpackdir):
     """
     Catalog the given image with syft, keeping only select artifacts in the returned results.
     """
@@ -34,6 +34,13 @@ def catalog_image(image):
     # document
     for artifact in filter(filter_artifacts, all_results['artifacts']):
         handler = handlers_by_artifact_type[artifact['type']]
-        handler(findings, artifact)
+        handler.translate_and_save_entry(findings, artifact)
+
+    # apply content hints, overriding values that are there
+    for engine_entry in content_hints(unpackdir=unpackdir):
+        pkg_type = engine_entry.get("type")
+        if pkg_type:
+            handler = handlers_by_engine_type[pkg_type]
+            handler.save_entry(findings, engine_entry)
 
     return defaultdict_to_dict(findings)

--- a/anchore_engine/analyzers/syft/__init__.py
+++ b/anchore_engine/analyzers/syft/__init__.py
@@ -1,13 +1,13 @@
-import os
 import collections
 
-from anchore_engine.analyzers.utils import defaultdict_to_dict
+from anchore_engine.analyzers.utils import defaultdict_to_dict, get_hintsfile
 from anchore_engine.clients.syft_wrapper import run_syft
 from .handlers import handlers_by_artifact_type
 
 
 def filter_artifacts(artifact):
     return artifact['type'] in handlers_by_artifact_type
+
 
 def catalog_image(image):
     """
@@ -37,10 +37,3 @@ def catalog_image(image):
         handler(findings, artifact)
 
     return defaultdict_to_dict(findings)
-
-
-def content_hints(hints_pkg):
-    """Content hints will provide the handlers with a means of inserting new data from
-    the user.
-    """
-    pass

--- a/anchore_engine/analyzers/syft/handlers/__init__.py
+++ b/anchore_engine/analyzers/syft/handlers/__init__.py
@@ -8,12 +8,27 @@ from . import debian
 
 # this is a mapping of syft artifact types to handler functions to transform syft output into engine-compliant output
 handlers_by_artifact_type = {
-    'gem': gem.handler,
-    'python': python.handler,
-    'npm': npm.handler,
-    'java-archive': java.handler,
-    'jenkins-plugin': java.handler,
-    'apk': alpine.handler,
-    'rpm': rpm.handler,
-    'deb': debian.handler,
+    'gem': gem,
+    'python': python,
+    'npm': npm,
+    'java-archive': java,
+    'jenkins-plugin': java,
+    'apk': alpine,
+    'rpm': rpm,
+    'deb': debian,
+}
+
+# this is a mapping of engine artifact types to handler functions to transform syft output into engine-compliant output
+handlers_by_engine_type = {
+    'gem': gem,
+    'python': python,
+    'npm': npm,
+    'java-jar': java,
+    'java-ear': java,
+    'java-war': java,
+    'java-jpi': java,
+    'java-hpi': java,
+    'APKG': alpine,
+    'rpm': rpm,
+    'dpkg': debian,
 }

--- a/anchore_engine/analyzers/syft/handlers/alpine.py
+++ b/anchore_engine/analyzers/syft/handlers/alpine.py
@@ -1,9 +1,14 @@
 import re
 
-from anchore_engine.analyzers.utils import dig, content_hints
+from anchore_engine.analyzers.utils import dig
 
+def save_entry(findings, engine_entry, pkg_key=None):
+    if not pkg_key:
+        pkg_key = engine_entry.get('name', "")
 
-def handler(findings, artifact):
+    findings['package_list']['pkgs.allinfo']['base'][pkg_key] = engine_entry
+
+def translate_and_save_entry(findings, artifact):
     """
     Handler function to map syft results for an alpine package type into the engine "raw" document format.
     """
@@ -36,12 +41,8 @@ def _all_package_info(findings, artifact):
         'files': [f.get('path') for f in dig(artifact, 'metadata', 'files', default=[])]
     }
 
-    pkg_updates = content_hints(pkg_type="apkg")
-    pkg_update = pkg_updates.get(name)
-    if pkg_update:
-        pkg_value.update(pkg_update)
-
-    findings['package_list']['pkgs.allinfo']['base'][name] = pkg_value
+    # inject the artifact document into the "raw" analyzer document
+    save_entry(findings, pkg_value, name)
 
 
 def _all_packages_plus_source(findings, artifact):

--- a/anchore_engine/analyzers/syft/handlers/alpine.py
+++ b/anchore_engine/analyzers/syft/handlers/alpine.py
@@ -1,6 +1,6 @@
 import re
 
-from anchore_engine.analyzers.utils import dig
+from anchore_engine.analyzers.utils import dig, content_hints
 
 
 def handler(findings, artifact):
@@ -11,6 +11,7 @@ def handler(findings, artifact):
     _all_packages(findings, artifact)
     _all_packages_plus_source(findings, artifact)
     _all_package_info(findings, artifact)
+
 
 def _all_package_info(findings, artifact):
     name = artifact['name']
@@ -35,7 +36,13 @@ def _all_package_info(findings, artifact):
         'files': [f.get('path') for f in dig(artifact, 'metadata', 'files', default=[])]
     }
 
+    pkg_updates = content_hints(pkg_type="apkg")
+    pkg_update = pkg_updates.get(name)
+    if pkg_update:
+        pkg_value.update(pkg_update)
+
     findings['package_list']['pkgs.allinfo']['base'][name] = pkg_value
+
 
 def _all_packages_plus_source(findings, artifact):
     name = artifact['name']
@@ -47,18 +54,21 @@ def _all_packages_plus_source(findings, artifact):
     if origin_package:
         findings['package_list']['pkgs_plus_source.all']['base'][origin_package] = version
 
+
 def _all_packages(findings, artifact):
     name = artifact['name']
     version = artifact["version"]
     if name and version:
         findings['package_list']['pkgs.all']['base'][name] = version
 
+
 def _all_package_files(findings, artifact):
     for file in dig(artifact, 'metadata', 'files', default=[]):
         original_path = file.get('path')
         if not original_path.startswith("/"):
-            # the 'alpine-baselayout' package is installed relative to root, however, syft reports this as an absolute path
+            # the 'alpine-baselayout' package is installed relative to root,
+            # however, syft reports this as an absolute path
             original_path = "/" + original_path
-        
+
         # anchore-engine considers all parent paths to also be a registered apkg path (except root)
         findings['package_list']['pkgfiles.all']['base'][original_path] = "APKFILE"

--- a/anchore_engine/analyzers/syft/handlers/debian.py
+++ b/anchore_engine/analyzers/syft/handlers/debian.py
@@ -38,7 +38,7 @@ def _all_package_info(findings, artifact):
     else:
         source = "N/A"
 
-    license = dig(artifact, 'licenses')
+    license = dig(artifact, 'licenses') or dig(artifact, 'license')
     if license:
         license = " ".join(license)
     else:
@@ -54,9 +54,9 @@ def _all_package_info(findings, artifact):
         'license': license,
         'type': "dpkg",
     }
-
     pkg_updates = content_hints(pkg_type="dpkg")
     pkg_update = pkg_updates.get(name)
+
     if pkg_update:
         pkg_value.update(pkg_update)
 
@@ -73,18 +73,21 @@ def _all_packages_plus_source(findings, artifact):
     if origin_package:
         findings['package_list']['pkgs_plus_source.all']['base'][origin_package] = version
 
+
 def _all_packages(findings, artifact):
     name = artifact['name']
     version = artifact["version"]
     if name and version:
         findings['package_list']['pkgs.all']['base'][name] = version
 
+
 def _all_package_files(findings, artifact):
     for file in dig(artifact, 'metadata', 'files', default=[]):
         original_path = file.get('path')
         if not original_path.startswith("/"):
-            # the 'alpine-baselayout' package is installed relative to root, however, syft reports this as an absolute path
+            # the 'alpine-baselayout' package is installed relative to root,
+            # however, syft reports this as an absolute path
             original_path = "/" + original_path
-        
+
         # anchore-engine considers all parent paths to also be a registered apkg path (except root)
         findings['package_list']['pkgfiles.all']['base'][original_path] = "DPKGFILE"

--- a/anchore_engine/analyzers/syft/handlers/debian.py
+++ b/anchore_engine/analyzers/syft/handlers/debian.py
@@ -1,9 +1,15 @@
 import re
 
-from anchore_engine.analyzers.utils import dig, content_hints
+from anchore_engine.analyzers.utils import dig
 
 
-def handler(findings, artifact):
+def save_entry(findings, engine_entry, pkg_key=None):
+    if not pkg_key:
+        pkg_key = engine_entry.get('name', "")
+
+    findings['package_list']['pkgs.allinfo']['base'][pkg_key] = engine_entry
+
+def translate_and_save_entry(findings, artifact):
     """
     Handler function to map syft results for an debian package type into the engine "raw" document format.
     """
@@ -11,7 +17,6 @@ def handler(findings, artifact):
     _all_packages(findings, artifact)
     _all_packages_plus_source(findings, artifact)
     _all_package_info(findings, artifact)
-
 
 def _all_package_info(findings, artifact):
     name = artifact['name']
@@ -54,14 +59,8 @@ def _all_package_info(findings, artifact):
         'license': license,
         'type': "dpkg",
     }
-    pkg_updates = content_hints(pkg_type="dpkg")
-    pkg_update = pkg_updates.get(name)
 
-    if pkg_update:
-        pkg_value.update(pkg_update)
-
-    findings['package_list']['pkgs.allinfo']['base'][name] = pkg_value
-
+    save_entry(findings, pkg_value, name)
 
 def _all_packages_plus_source(findings, artifact):
     name = artifact['name']

--- a/anchore_engine/analyzers/syft/handlers/debian.py
+++ b/anchore_engine/analyzers/syft/handlers/debian.py
@@ -1,6 +1,6 @@
 import re
 
-from anchore_engine.analyzers.utils import dig
+from anchore_engine.analyzers.utils import dig, content_hints
 
 
 def handler(findings, artifact):
@@ -11,6 +11,7 @@ def handler(findings, artifact):
     _all_packages(findings, artifact)
     _all_packages_plus_source(findings, artifact)
     _all_package_info(findings, artifact)
+
 
 def _all_package_info(findings, artifact):
     name = artifact['name']
@@ -54,7 +55,13 @@ def _all_package_info(findings, artifact):
         'type': "dpkg",
     }
 
+    pkg_updates = content_hints(pkg_type="dpkg")
+    pkg_update = pkg_updates.get(name)
+    if pkg_update:
+        pkg_value.update(pkg_update)
+
     findings['package_list']['pkgs.allinfo']['base'][name] = pkg_value
+
 
 def _all_packages_plus_source(findings, artifact):
     name = artifact['name']

--- a/anchore_engine/analyzers/syft/handlers/gem.py
+++ b/anchore_engine/analyzers/syft/handlers/gem.py
@@ -1,22 +1,30 @@
-from anchore_engine.analyzers.utils import dig
+from anchore_engine.analyzers.utils import dig, content_hints
 
 
 def handler(findings, artifact):
     """
-    Handler function to map syft results for the gem package type into the engine "raw" document format.
+    Handler function to map syft results for the gem package type into the
+    engine "raw" document format.
     """
     pkg_key = artifact['locations'][0]['path']
+    name = artifact['name']
+    versions = [artifact['version']]
 
     # craft the artifact document
     pkg_value = {
-            'name': artifact['name'],
-            'versions': [artifact['version']],
-            'latest': artifact['version'],
-            'sourcepkg': artifact['metadata'].get('homepage', ''),
-            'files': artifact['metadata'].get('files', []),
-            'origins': artifact['metadata'].get('authors', []),
-            'lics': artifact['metadata'].get('licenses', []),
+            'name': name,
+            'versions': versions,
+            'latest': dig(artifact, 'version', default=""),
+            'sourcepkg': dig(artifact, 'metadata', 'homepage', default=""),
+            'files': dig(artifact, 'metadata', 'files', default=[]),
+            'origins': dig(artifact, 'metadata', 'authors', default=[]),
+            'lics': dig(artifact, 'metadata', 'licenses', default=[]),
         }
+
+    pkg_updates = content_hints(pkg_type="gem")
+    pkg_update = pkg_updates.get(name)
+    if pkg_update:
+        pkg_value.update(pkg_update)
 
     # inject the artifact document into the "raw" analyzer document
     findings['package_list']['pkgs.gems']['base'][pkg_key] = pkg_value

--- a/anchore_engine/analyzers/syft/handlers/gem.py
+++ b/anchore_engine/analyzers/syft/handlers/gem.py
@@ -1,7 +1,22 @@
-from anchore_engine.analyzers.utils import dig, content_hints
+from anchore_engine.analyzers.utils import dig
 
 
-def handler(findings, artifact):
+def save_entry(findings, engine_entry, pkg_key=None):
+    if not pkg_key:
+        pkg_location = engine_entry.get('location', "")
+        if pkg_location:
+            # derive the key from the entries 'location' value
+            pkg_key = pkg_location
+        else:
+            # derive the key from a 'virtual' location
+            pkg_name = engine_entry.get('name', "")
+            pkg_version = engine_entry.get('version', engine_entry.get('latest', "")) # rethink this... ensure it's right
+            pkg_key = "/virtual/gempkg/{}-{}".format(pkg_name, pkg_version)
+
+    findings['package_list']['pkgs.gems']['base'][pkg_key] = engine_entry
+
+
+def translate_and_save_entry(findings, artifact):
     """
     Handler function to map syft results for the gem package type into the
     engine "raw" document format.
@@ -21,10 +36,4 @@ def handler(findings, artifact):
             'lics': dig(artifact, 'metadata', 'licenses', default=[]),
         }
 
-    pkg_updates = content_hints(pkg_type="gem")
-    pkg_update = pkg_updates.get(name)
-    if pkg_update:
-        pkg_value.update(pkg_update)
-
-    # inject the artifact document into the "raw" analyzer document
-    findings['package_list']['pkgs.gems']['base'][pkg_key] = pkg_value
+    save_entry(findings, pkg_value, pkg_key)

--- a/anchore_engine/analyzers/syft/handlers/java.py
+++ b/anchore_engine/analyzers/syft/handlers/java.py
@@ -1,7 +1,16 @@
-from anchore_engine.analyzers.utils import dig, content_hints
+from anchore_engine.analyzers.utils import dig
 
 
-def handler(findings, artifact):
+def save_entry(findings, engine_entry, pkg_key=None):
+    if not pkg_key:
+        pkg_name = engine_entry.get('name', "")
+        pkg_version = engine_entry.get('version', engine_entry.get('latest', "")) # rethink this... ensure it's right
+        pkg_key = engine_entry.get('location', "/virtual/javapkg/{}-{}.jar".format(pkg_name, pkg_version))
+
+    findings['package_list']['pkgs.java']['base'][pkg_key] = engine_entry
+
+
+def translate_and_save_entry(findings, artifact):
     """
     Handler function to map syft results for java-archive and jenkins-plugin types into the engine "raw" document format.
     """
@@ -50,11 +59,5 @@ def handler(findings, artifact):
         'type': "java-" + java_ext,
     }
 
-    pkg_updates = content_hints(pkg_type="java")
-    pkg_update = pkg_updates.get(name)
-    if pkg_update:
-        pkg_value.update(pkg_update)
-
     # inject the artifact document into the "raw" analyzer document
-    findings['package_list']['pkgs.java']['base'][pkg_key] = pkg_value
-
+    save_entry(findings, pkg_value, pkg_key)

--- a/anchore_engine/analyzers/syft/handlers/java.py
+++ b/anchore_engine/analyzers/syft/handlers/java.py
@@ -1,5 +1,5 @@
+from anchore_engine.analyzers.utils import dig, content_hints
 
-from anchore_engine.analyzers.utils import dig
 
 def handler(findings, artifact):
     """
@@ -12,13 +12,14 @@ def handler(findings, artifact):
         # there may be an extension in the virtual path, use it
         java_ext = virtualElements[-1].split(".")[-1]
     else:
-        # the last field is probably a package name, use the second to last virtual path element and extract the extension
+        # the last field is probably a package name, use the second to last virtual path element and extract the
+        # extension
         java_ext = virtualElements[-2].split(".")[-1]
 
     # per the manifest specification https://docs.oracle.com/en/java/javase/11/docs/specs/jar/jar.html#jar-manifest
     # these fields SHOULD be in the main section, however, there are multiple java packages found
     # where this information is thrown into named subsections.
-    
+
     # Today anchore-engine reads key-value pairs in all sections into one large map --this behavior is replicated here.
 
     values = {}
@@ -34,7 +35,7 @@ def handler(findings, artifact):
     origin = values.get('Specification-Vendor')
     if not origin:
         origin = values.get('Implementation-Vendor')
-    
+
     # use pom properties over manifest info (if available)
     if group_id:
         origin = group_id
@@ -48,6 +49,11 @@ def handler(findings, artifact):
         'location': pkg_key, # this should be related to full path
         'type': "java-" + java_ext,
     }
+
+    pkg_updates = content_hints(pkg_type="java")
+    pkg_update = pkg_updates.get(name)
+    if pkg_update:
+        pkg_value.update(pkg_update)
 
     # inject the artifact document into the "raw" analyzer document
     findings['package_list']['pkgs.java']['base'][pkg_key] = pkg_value

--- a/anchore_engine/analyzers/syft/handlers/npm.py
+++ b/anchore_engine/analyzers/syft/handlers/npm.py
@@ -1,7 +1,22 @@
-from anchore_engine.analyzers.utils import dig, content_hints
+from anchore_engine.analyzers.utils import dig
 
 
-def handler(findings, artifact):
+def save_entry(findings, engine_entry, pkg_key=None):
+    if not pkg_key:
+        pkg_location = engine_entry.get('location', "")
+        if pkg_location:
+            # derive the key from the entries 'location' value
+            pkg_key = pkg_location
+        else:
+            # derive the key from a 'virtual' location
+            pkg_name = engine_entry.get('name', "")
+            pkg_version = engine_entry.get('version', engine_entry.get('latest', "")) # rethink this... ensure it's right
+            pkg_key = "/virtual/npmpkg/{}-{}".format(pkg_name, pkg_version)
+
+    findings['package_list']['pkgs.npms']['base'][pkg_key] = engine_entry
+
+
+def translate_and_save_entry(findings, artifact):
     """
     Handler function to map syft results for npm package type into the engine "raw" document format.
     """
@@ -21,11 +36,6 @@ def handler(findings, artifact):
             'origins': origins,
             'lics': dig(artifact, 'metadata', 'licenses', default=[]),
         }
-    pkg_updates = content_hints(pkg_type="npm")
-    pkg_update = pkg_updates.get(name)
-    if pkg_update:
-        pkg_value.update(pkg_update)
 
     # inject the artifact document into the "raw" analyzer document
-    findings['package_list']['pkgs.npms']['base'][pkg_key] = pkg_value
-
+    save_entry(findings, pkg_value, pkg_key)

--- a/anchore_engine/analyzers/syft/handlers/npm.py
+++ b/anchore_engine/analyzers/syft/handlers/npm.py
@@ -21,7 +21,6 @@ def handler(findings, artifact):
             'origins': origins,
             'lics': dig(artifact, 'metadata', 'licenses', default=[]),
         }
-
     pkg_updates = content_hints(pkg_type="npm")
     pkg_update = pkg_updates.get(name)
     if pkg_update:

--- a/anchore_engine/analyzers/syft/handlers/npm.py
+++ b/anchore_engine/analyzers/syft/handlers/npm.py
@@ -1,24 +1,31 @@
-from anchore_engine.analyzers.utils import dig
+from anchore_engine.analyzers.utils import dig, content_hints
+
 
 def handler(findings, artifact):
     """
     Handler function to map syft results for npm package type into the engine "raw" document format.
     """
     pkg_key = artifact['locations'][0]['path']
-    homepage = artifact['metadata'].get('homepage', '')
-    author = artifact['metadata'].get('author')
-    authors = artifact['metadata'].get('authors', [])
+    name = artifact['name']
+    homepage = dig(artifact, 'metadata', 'homepage', default="")
+    author = dig(artifact, 'metadata', 'author', default="")
+    authors = dig(artifact, 'metadata', 'authors', default=[])
     origins = [] if not author else [author]
     origins.extend(authors)
 
     pkg_value = {
-            'name': artifact['name'],
+            'name': name,
             'versions': [artifact['version']],
             'latest': artifact['version'],
-            'sourcepkg': artifact['metadata'].get('url', homepage),
+            'sourcepkg': dig(artifact, 'metadata', 'url', default=homepage),
             'origins': origins,
-            'lics': artifact['metadata'].get('licenses', []),
+            'lics': dig(artifact, 'metadata', 'licenses', default=[]),
         }
+
+    pkg_updates = content_hints(pkg_type="npm")
+    pkg_update = pkg_updates.get(name)
+    if pkg_update:
+        pkg_value.update(pkg_update)
 
     # inject the artifact document into the "raw" analyzer document
     findings['package_list']['pkgs.npms']['base'][pkg_key] = pkg_value

--- a/anchore_engine/analyzers/syft/handlers/python.py
+++ b/anchore_engine/analyzers/syft/handlers/python.py
@@ -1,6 +1,6 @@
 import os
 
-from anchore_engine.analyzers.utils import dig
+from anchore_engine.analyzers.utils import dig, content_hints
 
 
 def handler(findings, artifact):
@@ -12,35 +12,41 @@ def handler(findings, artifact):
         return
 
     site_pkg_root = artifact['metadata']['sitePackagesRootPath']
+    name = artifact['name']
 
     # anchore engine always uses the name, however, the name may not be a top-level package
     # instead default to the first top-level package unless the name is listed among the
     # top level packages explicitly defined in the metadata
     pkg_key_name = artifact['metadata']['topLevelPackages'][0]
-    if artifact['name'] in artifact['metadata']['topLevelPackages']:
-        pkg_key_name = artifact['name']
+    if name in artifact['metadata']['topLevelPackages']:
+        pkg_key_name = name
 
     pkg_key = os.path.join(site_pkg_root, pkg_key_name)
-    origin = artifact['metadata'].get('author', "")
-    email = artifact['metadata'].get('authorEmail', None)
+    origin = dig(artifact, 'metadata', 'author', default="")
+    email = dig(artifact, 'metadata', 'authorEmail', default=None)
     if email:
         origin += " <%s>" % email
 
     files = []
-    for file in artifact['metadata'].get('files', []):
+    for file in dig(artifact, 'metadata', 'files', default=[]):
         files.append(os.path.join(site_pkg_root, file['path']))
 
     # craft the artifact document
     pkg_value = {
-            'name': artifact['name'],
+            'name': name,
             'version': artifact['version'],
             'latest': artifact['version'],
             'files': files,
             'origin': origin,
-            'license': artifact['metadata'].get('license', ""),
+            'license': dig(artifact, 'metadata', 'license', default=""),
             'location': site_pkg_root,
             'type': 'python',
         }
+
+    pkg_updates = content_hints(pkg_type="python")
+    pkg_update = pkg_updates.get(name)
+    if pkg_update:
+        pkg_value.update(pkg_update)
 
     # inject the artifact document into the "raw" analyzer document
     findings['package_list']['pkgs.python']['base'][pkg_key] = pkg_value

--- a/anchore_engine/analyzers/syft/handlers/rpm.py
+++ b/anchore_engine/analyzers/syft/handlers/rpm.py
@@ -31,12 +31,13 @@ def _all_package_info(findings, artifact):
         'size': str(dig(artifact, 'metadata', 'size', default="N/A")),
         'license': dig(artifact, 'metadata', 'license', default="N/A"),
     }
-
     if pkg_value['arch'] == 'amd64':
         pkg_value['arch'] = 'x86_64'
 
-    pkg_update = content_hints(pkg_type="rpm")
-    if pkg_update and pkg_update['name'] == name:
+    pkg_updates = content_hints(pkg_type="rpm")
+    pkg_update = pkg_updates.get(name)
+
+    if pkg_update:
         pkg_value.update(pkg_update)
 
     findings['package_list']['pkgs.allinfo']['base'][name] = pkg_value

--- a/anchore_engine/analyzers/syft/handlers/rpm.py
+++ b/anchore_engine/analyzers/syft/handlers/rpm.py
@@ -1,6 +1,6 @@
 import re
 
-from anchore_engine.analyzers.utils import dig
+from anchore_engine.analyzers.utils import dig, content_hints
 
 
 def handler(findings, artifact):
@@ -31,9 +31,13 @@ def _all_package_info(findings, artifact):
         'size': str(dig(artifact, 'metadata', 'size', default="N/A")),
         'license': dig(artifact, 'metadata', 'license', default="N/A"),
     }
-           
+
     if pkg_value['arch'] == 'amd64':
         pkg_value['arch'] = 'x86_64'
+
+    pkg_update = content_hints(pkg_type="rpm")
+    if pkg_update and pkg_update['name'] == name:
+        pkg_value.update(pkg_update)
 
     findings['package_list']['pkgs.allinfo']['base'][name] = pkg_value
 

--- a/anchore_engine/analyzers/syft/handlers/rpm.py
+++ b/anchore_engine/analyzers/syft/handlers/rpm.py
@@ -1,9 +1,16 @@
 import re
 
-from anchore_engine.analyzers.utils import dig, content_hints
+from anchore_engine.analyzers.utils import dig
 
 
-def handler(findings, artifact):
+def save_entry(findings, engine_entry, pkg_key=None):
+    if not pkg_key:
+        pkg_key = engine_entry.get('name', "")
+
+    findings['package_list']['pkgs.allinfo']['base'][pkg_key] = engine_entry
+
+
+def translate_and_save_entry(findings, artifact):
     """
     Handler function to map syft results for an alpine package type into the engine "raw" document format.
     """
@@ -34,14 +41,7 @@ def _all_package_info(findings, artifact):
     if pkg_value['arch'] == 'amd64':
         pkg_value['arch'] = 'x86_64'
 
-    pkg_updates = content_hints(pkg_type="rpm")
-    pkg_update = pkg_updates.get(name)
-
-    if pkg_update:
-        pkg_value.update(pkg_update)
-
-    findings['package_list']['pkgs.allinfo']['base'][name] = pkg_value
-
+    save_entry(findings, pkg_value, name)
 
 def _all_packages(findings, artifact):
     name = artifact['name']

--- a/anchore_engine/analyzers/utils.py
+++ b/anchore_engine/analyzers/utils.py
@@ -1,19 +1,18 @@
+from functools import lru_cache
+import logging
 import os
-import shutil
 import re
-import subprocess
 import hashlib
 import yaml
-import traceback
 import random
 import json
 import tarfile
-import copy
 import collections
 
 import anchore_engine.utils
 
-from stat import *
+logger = logging.getLogger(__name__)
+
 
 def init_analyzer_cmdline(argv, name):
     ret = {}
@@ -74,12 +73,14 @@ def init_analyzer_cmdline(argv, name):
 
     return ret
 
+
 def _default_member_function(tfl, member, a, t=None):
     print ("{} {} - {}".format(a, t, member.name))
 
+
 def run_tarfile_member_function(tarfilename, *args, member_regexp=None, func=_default_member_function, **kwargs):
     if not os.path.exists(tarfilename):
-        raise ValueError("input tarfile {} not found - exception: {}".format(tarfilename, err))
+        raise ValueError("input tarfile not found: {}".format(tarfilename))
 
     if member_regexp:
         memberpatt = re.compile(member_regexp)
@@ -90,7 +91,6 @@ def run_tarfile_member_function(tarfilename, *args, member_regexp=None, func=_de
     with tarfile.open(tarfilename, mode='r', format=tarfile.PAX_FORMAT) as tfl:
         memberhash = get_memberhash(tfl)
         kwargs['memberhash'] = memberhash
-        #for member in tfl.getmembers():
         for member in list(memberhash.values()):
             if not memberpatt or memberpatt.match(member.name):
                 if ret.get(member.name):
@@ -100,16 +100,18 @@ def run_tarfile_member_function(tarfilename, *args, member_regexp=None, func=_de
 
     return ret
 
+
 def run_tarfile_function(tarfile, func=None, *args, **kwargs):
 
     if not os.path.exists(tarfile):
-        raise ValueError("input tarfile not found - exception: {}".format(err))
+        raise ValueError("input tarfile not found: {}".format(tarfile))
 
     ret = None
     with tarfile.open(tarfile, mode='r', format=tarfile.PAX_FORMAT) as tfl:
         ret = func(tfl, *args, **kwargs)
 
     return ret
+
 
 def _search_tarfilenames_for_file(tarfilenames, searchfile):
     ret = None
@@ -593,169 +595,8 @@ def get_files_from_squashtar(squashtar, unpackdir=None):
 
 ### Package helpers
 
-def rpm_get_all_packages_from_squashtar(unpackdir, squashtar):
-    rpms = {}
-
-    rpm_db_base_dir = rpm_prepdb_from_squashtar(unpackdir, squashtar)
-    rpmdbdir = os.path.join(rpm_db_base_dir, "var", "lib", "rpm")
-
-    try:
-        sout = subprocess.check_output(['rpm', '--dbpath='+rpmdbdir, '--queryformat', '%{NAME} %{VERSION} %{RELEASE} %{ARCH}\n', '-qa'], stderr=subprocess.STDOUT)
-        for l in sout.splitlines():
-            l = l.strip()
-            l = str(l, 'utf-8')
-            #l = l.decode('utf8')
-            (name, vers, rel, arch) = re.match(r'(\S*)\s*(\S*)\s*(\S*)\s*(.*)', l).group(1, 2, 3, 4)
-            rpms[name] = {'version':vers, 'release':rel, 'arch':arch}
-    except Exception as err:
-        print(err.output)
-        raise ValueError("could not get package list from RPM database: " + str(err))
-
-    return rpms, rpmdbdir
-
-def rpm_get_all_pkgfiles(unpackdir):
-    rpmfiles = {}
-    rpmdbdir = unpackdir
-
-    try:
-        sout = subprocess.check_output(['rpm', '--dbpath='+rpmdbdir, '-qal'])
-        for l in sout.splitlines():
-            l = l.strip()
-            l = str(l, 'utf-8')
-            #l = l.decode('utf8')
-            rpmfiles[l] = True
-    except Exception as err:
-        raise ValueError("could not get file list from RPM database: " + str(err))
-
-    return rpmfiles
-
-def rpm_get_all_packages_detail_from_squashtar(unpackdir, squashtar):
-    rpms = {}
-
-    rpm_db_base_dir = rpm_prepdb_from_squashtar(unpackdir, squashtar)
-    rpmdbdir = os.path.join(rpm_db_base_dir, "var", "lib", "rpm")
-
-    try:
-        sout = subprocess.check_output(['rpm', '--dbpath='+rpmdbdir, '--queryformat', '%{NAME}|ANCHORETOK|%{VERSION}|ANCHORETOK|%{RELEASE}|ANCHORETOK|%{ARCH}|ANCHORETOK|%{SIZE}|ANCHORETOK|%{LICENSE}|ANCHORETOK|%{SOURCERPM}|ANCHORETOK|%{VENDOR}\n', '-qa'])
-        for l in sout.splitlines():
-            l = l.strip()
-            l = str(l, 'utf-8')
-            (name, vers, rel, arch, rawsize, lic, source, vendor) = l.split("|ANCHORETOK|")
-
-            try:
-                size = str(int(rawsize))
-            except:
-                size = str(0)
-
-            vendor = vendor + " (vendor)"
-            rpms[name] = {'version':vers, 'release':rel, 'arch':arch, 'size':size, 'license':lic, 'sourcepkg':source, 'origin':vendor, 'type':'rpm'}
-    except Exception as err:
-        raise ValueError("could not get package list from RPM database: " + str(err))
-
-    try:
-        hints = get_hintsfile(unpackdir, squashtar)
-        for pkg in hints.get('packages', []):
-            if pkg.get('type', "").lower() == 'rpm':
-                try:
-                    el = _hints_to_rpm(pkg)
-                    rpms.update(el)                    
-                except Exception as err:
-                    print ("WARN: could not convert hints package to valid RPM analyzer output - exception: {}".format(err))
-    except Exception as err:
-        print ("WARN: problem honoring hints file - exception: {}".format(err))                                
-
-                    
-    return rpms, rpmdbdir
-
-
-def _hints_to_rpm(pkg):
-    pkg_type = 'rpm'
-    pkg_name = anchore_engine.utils.ensure_str(pkg.get('name', ""))
-    pkg_version = anchore_engine.utils.ensure_str(pkg.get('version', ""))
-    pkg_arch = anchore_engine.utils.ensure_str(pkg.get('arch', 'x86_64'))
-    pkg_release = anchore_engine.utils.ensure_str(pkg.get('release', ""))
-    pkg_source = anchore_engine.utils.ensure_str(pkg.get('source', ""))
-    pkg_origin = anchore_engine.utils.ensure_str(pkg.get('origin', ""))
-    pkg_license = anchore_engine.utils.ensure_str(pkg.get('license', ""))
-    pkg_size = anchore_engine.utils.ensure_str(str(pkg.get('size', "0")))
-
-    if not pkg_name or not pkg_version or not pkg_type:
-        raise Exception("bad hints record, all hints records must supply at least a name, version and type")
-    if not pkg_release or not pkg_source:
-        from anchore_engine.util.rpm import split_rpm_filename
-        p_name, p_parsed_version, p_release, p_epoch, p_arch = split_rpm_filename("{}-{}.{}.rpm".format(pkg_name, pkg_version, pkg_arch))
-        if pkg_name == p_parsed_version:
-            raise Exception("hints package version for hints package ({}) is not valid for RPM package type".format(pkg_name))
-    
-        pkg_version = p_parsed_version
-
-        if p_epoch:
-            pkg_version = "{}:{}".format(p_epoch, p_parsed_version)
-
-        pkg_release = p_release
-
-        if p_arch:
-            pkg_arch = p_arch
-
-        if pkg_source:
-            pkg_source = "{}-{}.{}.rpm".format(pkg_source, pkg_version, 'src')
-        else:
-            pkg_source = "{}-{}-{}.{}.rpm".format(pkg_name, pkg_version, pkg_release, 'src')            
-
-    pkg_type = 'rpm'
-    if pkg_arch == 'amd64':
-        pkg_arch = 'x86_64'
-
-    el = {
-        pkg_name: {
-            'version': pkg_version,
-            'release': pkg_release,
-            'arch': pkg_arch,
-            'size': pkg_size,
-            'license': pkg_license,
-            'sourcepkg': pkg_source,
-            'origin': pkg_origin,
-            'type': 'rpm',                                                
-        }
-    }
-    return el
-
-def _hints_to_python(pkg):
-    pkg_type = anchore_engine.utils.ensure_str(pkg.get('type', "python")).lower()    
-    pkg_name = anchore_engine.utils.ensure_str(pkg.get('name', ""))
-    pkg_version = anchore_engine.utils.ensure_str(pkg.get('version', ""))
-    pkg_location = anchore_engine.utils.ensure_str(pkg.get('location', ""))
-    pkg_license = anchore_engine.utils.ensure_str(pkg.get('license', ""))
-    pkg_origin = anchore_engine.utils.ensure_str(pkg.get('origin', ""))
-    pkg_files = pkg.get('files', [])
-    pkg_metadata = json.dumps(pkg.get('metadata', {}))
-    
-    if not pkg_name or not pkg_version or not pkg_type:
-        raise Exception("bad hints record, all hints records must supply at least a name, version and type")
-    for inp in [pkg_files]:
-        if type(inp) is not list:
-            raise Exception("bad hints record ({}), versions, licenses, origins, and files if specified must be list types".format(pkg_name))
-        
-    if not pkg_location:
-        pkg_location = "/virtual/pypkg/site-packages"
-        pkg_key = "{}/{}-{}".format(pkg_location, pkg_name, pkg_version)
-    else:
-        pkg_key = "{}/{}".format(pkg_location, pkg_name)
-
-    el = {
-        'name': pkg_name,
-        'version': pkg_version,
-        'origin': pkg_origin,
-        'license': pkg_license,
-        'location': pkg_location,
-        'metadata': pkg_metadata,
-        'files': pkg_files,
-        'type': pkg_type
-    }
-    return pkg_key, el
-
 def _hints_to_go(pkg):
-    pkg_type = anchore_engine.utils.ensure_str(pkg.get('type', "go")).lower()    
+    pkg_type = anchore_engine.utils.ensure_str(pkg.get('type', "go")).lower()
     pkg_name = anchore_engine.utils.ensure_str(pkg.get('name', ""))
     pkg_version = anchore_engine.utils.ensure_str(pkg.get('version', ""))
     pkg_location = anchore_engine.utils.ensure_str(pkg.get('location', "/virtual/gopkg/{}-{}".format(pkg_name, pkg_version)))
@@ -768,7 +609,7 @@ def _hints_to_go(pkg):
 
     if not pkg_name or not pkg_version or not pkg_type:
         raise Exception("bad hints record, all hints records must supply at least a name, version and type")
-    
+
     el = {
         'name': pkg_name,
         'version': pkg_version,
@@ -782,10 +623,10 @@ def _hints_to_go(pkg):
         'type': pkg_type
     }
 
-    return pkg_location, el    
-    
+    return pkg_location, el
+
 def _hints_to_binary(pkg):
-    pkg_type = anchore_engine.utils.ensure_str(pkg.get('type', "binary")).lower()    
+    pkg_type = anchore_engine.utils.ensure_str(pkg.get('type', "binary")).lower()
     pkg_name = anchore_engine.utils.ensure_str(pkg.get('name', ""))
     pkg_version = anchore_engine.utils.ensure_str(pkg.get('version', ""))
     pkg_location = anchore_engine.utils.ensure_str(pkg.get('location', "/virtual/binarypkg/{}-{}".format(pkg_name, pkg_version)))
@@ -812,15 +653,42 @@ def _hints_to_binary(pkg):
 
     return pkg_location, el
 
-def get_hintsfile(unpackdir, squashtar):
+
+def get_hintsfile(unpackdir=None, squashtar=None):
+    """
+    Retrieve the hintsfile from the current unpackdir or from the container
+    (within the squashed tarfile), following that order of precedence.
+
+    This function makes the `unpackdir` and the `squashtar` arguments fully
+    optional, falling back to retrieving the actual value of the `unpackdir`
+    from the `ANCHORE_ANALYZERS_UNPACKDIR` environment variable.
+
+    Finally, this function uses a caching closure , for up to 24 different
+    calls. The Syft handlers will consume this hints function without passing
+    any arguments at all for every package but relying on a unique path still,
+    which is why it is useful to have the hints file contents cached.
+    """
+    if unpackdir is None:
+        unpackdir = os.environ["ANCHORE_ANALYZERS_UNPACKDIR"]
+        squashtar = os.path.join(unpackdir, "squashed.tar")
     ret = {}
-    if os.path.exists(os.path.join(unpackdir, "anchore_hints.json")):
-        with open(os.path.join(unpackdir, "anchore_hints.json"), 'r') as FH:
+
+    @lru_cache(maxsize=24)
+    def read_hints(path):
+        """
+        Cached function to retrieve the contents of the hints file. Prevents
+        reading the file for every package in a container
+        """
+        with open(path, 'r') as FH:
             try:
-                ret = json.loads(FH.read())
+                return json.loads(FH.read())
             except Exception as err:
-                print ("WARN: hintsfile found unpacked, but cannot be read - exception: {}".format(err))
-                ret = {}
+                print("WARN: hintsfile found unpacked, but cannot be read - exception: {}".format(err))
+                return {}
+
+    anchore_hints_path =  os.path.join(unpackdir, "anchore_hints.json")
+    if os.path.exists(anchore_hints_path):
+        ret = read_hints(anchore_hints_path)
     else:
         with tarfile.open(squashtar, mode='r', format=tarfile.PAX_FORMAT) as tfl:
             memberhash = anchore_engine.analyzers.utils.get_memberhash(tfl)
@@ -834,7 +702,7 @@ def get_hintsfile(unpackdir, squashtar):
                     with tfl.extractfile(hints_member) as FH:
                         ret = json.loads(FH.read())
                 except Exception as err:
-                    print ("WARN: hintsfile found in squashtar, but cannot be read - exception: {}".format(err))
+                    print("WARN: hintsfile found in squashtar, but cannot be read - exception: {}".format(err))
                     ret = {}
             else:
                 ret = {}
@@ -842,8 +710,13 @@ def get_hintsfile(unpackdir, squashtar):
     if ret and not os.path.exists(os.path.join(unpackdir, "anchore_hints.json")):
         with open(os.path.join(unpackdir, "anchore_hints.json"), 'w') as OFH:
             OFH.write(json.dumps(ret))
-            
+
+    for pkg_type in ret.get("packages", []):
+        if not all((pkg_type.get("name"), pkg_type.get("version"), pkg_type.get("type"))):
+            logger.error("bad hints record, all hints records must supply at least a name, version and type")
+
     return ret
+
 
 def make_anchoretmpdir(tmproot):
     tmpdir = '/'.join([tmproot, str(random.randint(0, 9999999)) + ".anchoretmp"])
@@ -852,1137 +725,6 @@ def make_anchoretmpdir(tmproot):
         return tmpdir
     except:
         return False
-
-    
-def java_prepdb_from_squashtar(unpackdir, squashtar, java_file_regexp):
-    javatmpdir = os.path.join(unpackdir, "javatmp")
-    if not os.path.exists(javatmpdir):
-        try:
-            os.makedirs(javatmpdir)
-        except Exception as err:
-            raise err
-
-    ret = os.path.join(javatmpdir, "rootfs")
-    javafilepatt = re.compile(java_file_regexp)
-
-    if not os.path.exists(os.path.join(ret)):
-        with tarfile.open(squashtar, mode='r', format=tarfile.PAX_FORMAT) as tfl:
-            javamembers = []
-            for member in tfl.getmembers():
-                filename = member.name
-                if javafilepatt.match(filename): #re.match(java_file_regexp, filename):
-                    if member.mode == 0:
-                        member.mode = 0o755
-                    javamembers.append(member)
-
-            tfl.extractall(path=os.path.join(javatmpdir, "rootfs"), members=javamembers)
-        ret = os.path.join(javatmpdir, "rootfs")
-
-    return ret
-
-def python_prepdb_from_squashtar(unpackdir, squashtar, py_file_regexp):
-    pytmpdir = os.path.join(unpackdir, "pytmp")
-    if not os.path.exists(pytmpdir):
-        try:
-            os.makedirs(pytmpdir)
-        except Exception as err:
-            raise err
-
-    ret = os.path.join(pytmpdir, "rootfs")
-
-    pyfilepatt = re.compile(py_file_regexp)
-
-    if not os.path.exists(os.path.join(ret)):
-        candidates = {}
-        with tarfile.open(squashtar, mode='r', format=tarfile.PAX_FORMAT) as tfl:
-            pymembers = []
-            for filename in tfl.getnames():
-                if pyfilepatt.match(filename):
-                    candidate = os.path.dirname(filename)
-                    if candidate not in candidates:
-                        candidates[candidate] = True
-
-            for member in tfl.getmembers():
-                if member.isfile() or member.isdir():
-                    filename = member.name
-                    for candidate in candidates.keys():
-                        if filename == candidate or filename.startswith(candidate):
-                            if member.mode == 0:
-                                member.mode = 0o755                            
-                            pymembers.append(member)
-                            break
-
-            tfl.extractall(path=os.path.join(pytmpdir, "rootfs"), members=pymembers)
-        ret = os.path.join(pytmpdir, "rootfs")
-
-    return ret
-
-def apk_prepdb_from_squashtar(unpackdir, squashtar):
-    apktmpdir = os.path.join(unpackdir, "apktmp")
-    if not os.path.exists(apktmpdir):
-        try:
-            os.makedirs(apktmpdir)
-        except Exception as err:
-            raise err
-
-    ret = os.path.join(apktmpdir, "rootfs")
-
-    if not os.path.exists(os.path.join(ret, 'lib', 'apk', 'db', 'installed')):
-        with tarfile.open(squashtar, mode='r', format=tarfile.PAX_FORMAT) as tfl:
-            tarfilenames = tfl.getnames()
-            apkdbfile = _search_tarfilenames_for_file(tarfilenames, "lib/apk/db/installed")
-
-            apkmembers = []
-
-            member = tfl.getmember(apkdbfile)
-            if member.mode == 0:
-                member.mode = 0o755            
-            apkmembers.append(member)
-            
-            tfl.extractall(path=os.path.join(apktmpdir, "rootfs"), members=apkmembers)
-        ret = os.path.join(apktmpdir, "rootfs")
-
-    return ret
-
-def dpkg_prepdb_from_squashtar(unpackdir, squashtar):
-    dpkgtmpdir = os.path.join(unpackdir, "dpkgtmp")
-    if not os.path.exists(dpkgtmpdir):
-        try:
-            os.makedirs(dpkgtmpdir)
-        except Exception as err:
-            raise err
-
-    ret = os.path.join(dpkgtmpdir, "rootfs")
-
-    if not os.path.exists(os.path.join(ret, "var", "lib", "dpkg")):
-
-        with tarfile.open(squashtar, mode='r', format=tarfile.PAX_FORMAT) as tfl:
-            dpkgmembers = []
-            for member in tfl.getmembers():
-                filename = member.name
-                filename = re.sub(r"^\./|^/", "", filename)
-                if filename.startswith("var/lib/dpkg") or filename.startswith("usr/share/doc"):
-                    if member.mode == 0:
-                        member.mode = 0o755                                                
-                    dpkgmembers.append(member)
-            tfl.extractall(path=os.path.join(dpkgtmpdir, "rootfs"), members=dpkgmembers)
-
-        ret = os.path.join(dpkgtmpdir, "rootfs")
-
-    return ret
-
-def rpm_prepdb_from_squashtar(unpackdir, squashtar):
-    rpmtmpdir = os.path.join(unpackdir, "rpmtmp")
-    if not os.path.exists(rpmtmpdir):
-        try:
-            os.makedirs(rpmtmpdir)
-        except Exception as err:
-            raise err
-
-    ret = os.path.join(rpmtmpdir, "rpmdbfinal")
-
-    if not os.path.exists(os.path.join(ret, "var", "lib", "rpm")):
-        with tarfile.open(squashtar, mode='r', format=tarfile.PAX_FORMAT) as tfl:
-            rpmmembers = []
-            for member in tfl.getmembers():
-                filename = member.name
-                filename = re.sub(r"^\./|^/", "", filename)
-                if filename.startswith("var/lib/rpm"):
-                    if member.mode == 0:
-                        member.mode = 0o755                                                
-                    rpmmembers.append(member)
-
-            tfl.extractall(path=os.path.join(rpmtmpdir, "rootfs"), members=rpmmembers)
-
-        rc = rpm_prepdb(rpmtmpdir)
-        ret = os.path.join(rpmtmpdir, "rpmdbfinal") #, "var", "lib", "rpm")
-
-    return ret
-
-def rpm_prepdb(unpackdir):
-    origrpmdir = os.path.join(unpackdir, 'rootfs', 'var', 'lib', 'rpm')
-    ret = origrpmdir
-
-    print ("prepping rpmdb {}".format(origrpmdir))
-
-    if os.path.exists(origrpmdir):
-        newrpmdirbase = os.path.join(unpackdir, "rpmdbfinal")
-        if not os.path.exists(newrpmdirbase):
-            os.makedirs(newrpmdirbase)
-        newrpmdir = os.path.join(newrpmdirbase, 'var', 'lib', 'rpm')
-        try:
-            shutil.copytree(origrpmdir, newrpmdir)
-            sout = subprocess.check_output(['rpmdb', '--root='+newrpmdirbase, '--dbpath=/var/lib/rpm', '--rebuilddb'])
-            ret = newrpmdir
-        except:
-            pass
-
-    return ret
-
-def dpkg_get_all_pkgfiles_from_squashtar(unpackdir, squashtar):
-    allfiles = {}
-
-    try:
-        (allpkgs, allpkgs_simple, actpkgs, othpkgs, dpkgdbdir) = dpkg_get_all_packages_detail_from_squashtar(unpackdir, squashtar)
-        cmd = ["dpkg-query", "--admindir={}".format(os.path.join(unpackdir)), "-L"] + list(actpkgs.keys())
-        sout = subprocess.check_output(cmd)
-        for l in sout.splitlines():
-            l = l.strip()
-            l = str(l, 'utf-8')
-            #l = l.decode('utf8')
-            allfiles[l] = True
-
-    except Exception as err:
-        print("Could not run command: " + str(' '.join(cmd)))
-        print("Exception: " + str(err))
-        print("Please ensure the command 'dpkg' is available and try again")
-        raise err
-
-    return allfiles
-
-def dpkg_get_all_packages_detail_from_squashtar(unpackdir, squashtar):
-    all_packages = {}
-    actual_packages = {}
-    all_packages_simple = {}
-    other_packages = {}
-
-    dpkg_db_base_dir = dpkg_prepdb_from_squashtar(unpackdir, squashtar)
-    dpkgdbdir = os.path.join(dpkg_db_base_dir, "var", "lib", "dpkg")
-    dpkgdocsdir = os.path.join(dpkg_db_base_dir, "usr", "share", "doc")
-    dpkgstatusddir = os.path.join(dpkg_db_base_dir, "var", "lib", "dpkg", "status.d")
-
-    package_tuples = {}
-
-    cmd = ["dpkg-query", "--admindir={}".format(dpkgdbdir), "-W", "-f="+"${Package}|ANCHORETOK|${Version}|ANCHORETOK|${Architecture}|ANCHORETOK|${Installed-Size}|ANCHORETOK|${source:Package}|ANCHORETOK|${source:Version}|ANCHORETOK|${Maintainer}|ANCHORETOK|${db:Status-Abbrev}\\n"]
-    try:
-        sout = subprocess.check_output(cmd)
-        for l in sout.splitlines(True):
-            l = l.strip()
-            l = str(l, 'utf-8')
-            (p, v, arch, rawsize, sp, sv, vendor, status) = l.split("|ANCHORETOK|")
-
-            if status and not status.startswith("ii"):
-                # skip this package if the status is returned, and is not reporting as explicitly installed (ii*)
-                continue
-            if p not in package_tuples:
-                package_tuples[p] = (p,v,arch,rawsize,sp,sv,vendor,status)
-
-    except Exception as err:
-        print("Could not run command: {} - exception: {}".format(str(cmd), err))
-
-    try:
-        # inspect presence and contents of the status.d directory,
-        # which is where distroless container images store information
-        # about dpkg software that is installed
-
-        if os.path.exists(dpkgstatusddir):
-            for f in os.listdir(dpkgstatusddir):
-                with open(os.path.join(dpkgstatusddir, f), 'r') as FH:
-                    p = v = vendor = arch = size = sp = sv = status = None
-                    for line in FH.readlines():
-                        line = line.strip()
-                        try:
-                            (pk, pv) = line.split(":", 1)
-                        except:
-                            pk = pv = None
-
-                        if pk == 'Package':
-                            p = pv.strip()
-                        elif pk == 'Version':
-                            v = pv.strip()
-                        elif pk == 'Maintainer':
-                            vendor = pv.strip()
-                        elif pk == 'Architecture':
-                            arch = pv.strip()
-                        elif pk == 'Installed-Size':
-                            rawsize = pv.strip()
-                        elif pk == 'Source':
-                            sp = pv.strip()
-                    if sp and v:
-                        sv = v
-
-                    if p not in package_tuples:
-                        package_tuples[p] = (p,v,arch,rawsize,sp,sv,vendor,status)
-
-    except Exception as err:
-        print ("Could not parse package metadata from {} - exception: {}".format(dpkgstatusddir, err))
-
-    for package_key in package_tuples.keys():
-        (p, v, arch, rawsize, sp, sv, vendor, status) = package_tuples[package_key]
-
-        if sp and sv:
-            source = "{}-{}".format(sp, sv)
-        else:
-            source = ""
-
-        try:
-            size = str(int(rawsize) * 1000)
-        except:
-            size = str(0)
-
-        sp = str(sp)
-        sv = str(sv)
-        vendor = str(vendor) + " (maintainer)"
-        arch = str(arch)
-        source = str(source)
-
-        try:
-            licfile = os.path.join(dpkgdocsdir, p, 'copyright')
-            if not os.path.exists(licfile):
-                lic = "Unknown"
-            else:
-                lics = deb_copyright_getlics(licfile)
-                if len(list(lics.keys())) > 0:
-                    lic = ' '.join(lics)
-                else:
-                    lic = "Unknown"
-        except:
-            lic = "Unknown"
-
-        all_packages[p] = {'version':v, 'release':'N/A', 'arch':arch, 'size':size, 'origin':vendor, 'license':lic, 'sourcepkg':source, 'type':'dpkg'}
-        
-        if p and v:
-            if p not in actual_packages:
-                actual_packages[p] = {'version':v, 'arch':arch}
-            if p not in all_packages_simple:
-                all_packages_simple[p] = {'version':v, 'arch':arch}
-        if sp and sv:
-            if sp not in all_packages_simple:
-                all_packages_simple[sp] = {'version':sv, 'arch':arch}
-        if p and v and sp and sv:
-            if p == sp and v != sv:
-                other_packages[p] = [{'version':sv, 'arch':arch}]
-    try:
-        hints = get_hintsfile(unpackdir, squashtar)
-        for pkg in hints.get('packages', []):
-            if pkg.get('type', "").lower() == 'dpkg':
-                try:
-                    el = _hints_to_dpkg(pkg)
-                    all_packages.update(el)
-                except Exception as err:
-                    print ("WARN: could not convert hints package to valid DPKG analyzer output - exception: {}".format(err))
-    except Exception as err:
-        print ("WARN: problem honoring hints file - exception: {}".format(err))                                
-                
-    return all_packages, all_packages_simple, actual_packages, other_packages, dpkgdbdir
-
-
-def _hints_to_dpkg(pkg):
-    pkg_type = 'dpkg'    
-    pkg_name = anchore_engine.utils.ensure_str(pkg.get('name'))
-    pkg_version = anchore_engine.utils.ensure_str(pkg.get('version'))
-    pkg_arch = anchore_engine.utils.ensure_str(pkg.get('arch', 'amd64'))
-    pkg_release = anchore_engine.utils.ensure_str(pkg.get('release', ""))
-    pkg_source = anchore_engine.utils.ensure_str(pkg.get('source', ""))
-    pkg_origin = anchore_engine.utils.ensure_str(pkg.get('origin', ""))
-    pkg_license = anchore_engine.utils.ensure_str(pkg.get('license', ""))
-    pkg_size = anchore_engine.utils.ensure_str(str(pkg.get('size', "0")))
-
-    if not pkg_name or not pkg_version or not pkg_type:
-        raise Exception("bad hints record, all hints records must supply at least a name, version and type")
-    
-    if not pkg_source:
-        pkg_source = "{}-{}".format(pkg_name, pkg_version)
-
-    pkg_release = 'N/A'
-
-    el = {
-        pkg_name: {
-            'version': pkg_version,
-            'release': pkg_release,
-            'arch': pkg_arch,
-            'size': pkg_size,
-            'license': pkg_license,
-            'sourcepkg': pkg_source,
-            'origin': pkg_origin,
-            'type': 'dpkg',                             
-        }
-    }
-    return el
-
-
-def deb_copyright_getlics(licfile):
-    ret = {}
-
-    if os.path.exists(licfile):
-        found=False
-        FH=open(licfile, 'r')
-        lictext = FH.read()
-        for l in lictext.splitlines():
-            l = l.strip()
-            m = re.match(r"License: (\S*)", l)
-            if m:
-                lic = m.group(1)
-                if lic:
-                    ret[lic] = True
-                    found=True
-        FH.close()
-    return ret
-
-def apkg_parse_apkdb(apkdbfh):
-    apkgs = {}
-    apkg = {
-        'version':"N/A",
-        'sourcepkg':"N/A",
-        'release':"N/A",
-        'origin':"N/A",
-        'arch':"N/A",
-        'license':"N/A",
-        'size':"N/A"
-    }
-    thename = ""
-    thepath = ""
-    thefiles = list()
-    allfiles = list()
-
-    if True:
-        for l in apkdbfh.readlines():
-            l = anchore_engine.utils.ensure_str(l)
-            l = l.strip()
-
-            if not l:
-                apkgs[thename] = apkg
-                if thepath:
-                    flist = list()
-                    for x in thefiles:
-                        flist.append(os.path.join(thepath, x))
-                    flist.append(os.path.join(thepath))
-                    allfiles = allfiles + flist
-                apkgs[thename]['files'] = allfiles
-                apkg = {
-                    'version':"N/A",
-                    'sourcepkg':"N/A",
-                    'release':"N/A",
-                    'origin':"N/A",
-                    'arch':"N/A",
-                    'license':"N/A",
-                    'size':"N/A",
-                    'type':"APKG"
-                }
-                allfiles = list()
-                thefiles = list()
-                thepath = ""
-
-            patt = re.match(r"(\S):(.*)", l)
-            if patt:
-                (k, v) = patt.group(1,2)
-                apkg['type'] = "APKG"
-                if k == 'P':
-                    thename = v
-                    apkg['name'] = v
-                elif k == 'V':
-                    vpatt = re.match(r"(\S*)-(\S*)", v)
-                    if vpatt:
-                        (vers, rel) = vpatt.group(1, 2)
-                    else:
-                        vers = v
-                        rel = "N/A"
-                    apkg['version'] = vers
-                    apkg['release'] = rel
-                elif k == 'm':
-                    apkg['origin'] = v
-                elif k == 'I':
-                    apkg['size'] = v
-                elif k == 'L' and v:
-                    apkg['license'] = v
-                elif k == 'o':
-                    apkg['sourcepkg'] = v
-                elif k == 'A':
-                    apkg['arch'] = v
-                elif k == 'F':
-                    if thepath:
-                        flist = list()
-                        for x in thefiles:
-                            flist.append(os.path.join(thepath, x))
-                        flist.append(os.path.join(thepath))
-                        allfiles = allfiles + flist
-
-                    thepath = "/" + v
-                    thefiles = list()
-                elif k == 'R':
-                    thefiles.append(v)
-
-    return apkgs
-
-def apkg_get_all_pkgfiles_from_squashtar(unpackdir, squashtar):
-    ret = {}
-    with tarfile.open(squashtar, mode='r', format=tarfile.PAX_FORMAT) as tfl:
-        try:
-            tarfilenames = tfl.getnames()
-            apkdbfile = _search_tarfilenames_for_file(tarfilenames, "lib/apk/db/installed")
-            member = tfl.getmember(apkdbfile)
-            memberfd = tfl.extractfile(member)
-            ret = apkg_parse_apkdb(memberfd)
-        except Exception as err:
-            raise ValueError("cannot locate APK installed DB in squashed.tar - exception: {}".format(err))
-    try:
-        hints = get_hintsfile(unpackdir, squashtar)
-        for pkg in hints.get('packages', []):
-            if pkg.get('type', "").lower() == 'apkg':
-                try:
-                    el = _hints_to_apkg(pkg)
-                    ret.update(el)
-                except Exception as err:
-                    print ("WARN: could not convert hints package to valid APK analyzer output - exception: {}".format(err))
-    except Exception as err:
-        print ("WARN: problem honoring hints file - exception: {}".format(err))
-        
-    return ret
-
-def _hints_to_apkg(pkg):
-    pkg_type = 'apkg'        
-    pkg_name = anchore_engine.utils.ensure_str(pkg.get('name', ""))
-    pkg_version = anchore_engine.utils.ensure_str(pkg.get('version', ""))
-    pkg_arch = anchore_engine.utils.ensure_str(pkg.get('arch', 'x86_64'))
-    pkg_release = anchore_engine.utils.ensure_str(pkg.get('release', ""))
-    pkg_source = anchore_engine.utils.ensure_str(pkg.get('source', ""))
-    pkg_origin = anchore_engine.utils.ensure_str(pkg.get('origin', ""))
-    pkg_license = anchore_engine.utils.ensure_str(pkg.get('license', ""))
-    pkg_size = anchore_engine.utils.ensure_str(str(pkg.get('size', "0")))
-    pkg_files = pkg.get('files', [])
-
-    if not pkg_name or not pkg_version or not pkg_type:
-        raise Exception("bad hints record, all hints records must supply at least a name, version and type")
-    for inp in [pkg_files]:
-        if type(inp) is not list:
-            raise Exception("bad hints record ({}), versions, licenses, origins, and files if specified must be list types".format(pkg_name))    
-    
-    if not pkg_release:
-        try:
-            (v, r) = pkg_version.split('-', 2)
-        except:
-            raise Exception("hints package version for hints package ({}) is not valid for APKG package type".format(pkg_name))            
-
-        pkg_release = r
-        pkg_version = v
-
-    if not pkg_source:
-        pkg_source = pkg_name
-
-    el = {
-        pkg_name: {
-            'name': pkg_name,
-            'version': pkg_version,
-            'release': pkg_release,
-            'arch': pkg_arch,
-            'size': pkg_size,
-            'license': pkg_license,
-            'sourcepkg': pkg_source,
-            'origin': pkg_origin,
-            'files': pkg_files,
-            'type': 'APKG',
-        }
-    }
-    return el    
-
-def apkg_get_all_pkgfiles(unpackdir):
-    apkdb = '/'.join([unpackdir, 'rootfs/lib/apk/db/installed'])
-
-    if not os.path.exists(apkdb):
-        raise ValueError("cannot locate APK installed DB '"+str(apkdb)+"'")
-
-    ret = {}
-    with open(apkdb, 'r') as FH:
-        ret = apkg_parse_apkdb(FH)
-
-    return ret
-
-def gem_parse_meta(gem):
-    ret = {}
-
-    name = None
-    versions = []
-    lics = []
-    latest = None
-    origins = []
-    sourcepkg = None
-    rfiles = []
-
-    try:
-        for line in gem.splitlines():
-            line = line.strip()
-            line = re.sub(r"\.freeze", "", line)
-
-            # look for the unicode \u{} format and try to convert to something python can use
-            try:
-                replline = line
-                mat = "\\\\u{.*?}"
-                patt = re.match(r".*("+mat+").*", replline)
-                while patt:
-                    replstr = ""
-                    subpatt = re.match("\\\\u{(.*)}", patt.group(1))
-                    if subpatt:
-                        chars = subpatt.group(1).split()
-                        for char in chars:
-                            replstr += chr(int(char, 16))
-
-                    if replstr:
-                        replline = re.sub(re.escape(patt.group(1)), replstr, replline, 1)
-
-                    patt = re.match(r".*("+mat+").*", replline)
-                    line = replline
-            except Exception as err:
-                pass
-
-            patt = re.match(r".*\.name *= *(.*) *", line)
-            if patt:
-                name = json.loads(patt.group(1))
-
-            patt = re.match(r".*\.homepage *= *(.*) *", line)
-            if patt:
-                sourcepkg = json.loads(patt.group(1))
-
-            patt = re.match(r".*\.version *= *(.*) *", line)
-            if patt:
-                v = json.loads(patt.group(1))
-                latest = v
-                versions.append(latest)
-
-            patt = re.match(r".*\.licenses *= *(.*) *", line)
-            if patt:
-                lstr = re.sub(r"^\[|\]$", "", patt.group(1)).split(',')
-                for thestr in lstr:
-                    thestr = re.sub(' *" *', "", thestr)
-                    lics.append(thestr)
-
-            patt = re.match(r".*\.authors *= *(.*) *", line)
-            if patt:
-                lstr = re.sub(r"^\[|\]$", "", patt.group(1)).split(',')
-                for thestr in lstr:
-                    thestr = re.sub(' *" *', "", thestr)
-                    origins.append(thestr)
-
-            patt = re.match(r".*\.files *= *(.*) *", line)
-            if patt:
-                lstr = re.sub(r"^\[|\]$", "", patt.group(1)).split(',')
-                for thestr in lstr:
-                    thestr = re.sub(' *" *', "", thestr)
-                    rfiles.append(thestr)
-
-    except Exception as err:
-        print("WARN could not fully parse gemspec file: " + str(name) + ": exception: " + str(err))
-        return {}
-
-    if name:
-        ret[name] = {'name':name, 'lics':lics, 'versions':versions, 'latest':latest, 'origins':origins, 'sourcepkg':sourcepkg, 'files':rfiles}
-
-    return ret
-
-def _hints_to_gem(pkg):
-    pkg_type = anchore_engine.utils.ensure_str(pkg.get('type', "gem")).lower()    
-    pkg_name = anchore_engine.utils.ensure_str(pkg.get('name', ""))
-    pkg_version = anchore_engine.utils.ensure_str(pkg.get('version', ""))
-    pkg_versions = pkg.get('versions', [])    
-    pkg_location = anchore_engine.utils.ensure_str(pkg.get('location', ""))
-    pkg_license = anchore_engine.utils.ensure_str(pkg.get('license', ""))
-    pkg_licenses = pkg.get('licenses', [])
-    pkg_files = pkg.get('files', [])
-    pkg_origin = anchore_engine.utils.ensure_str(pkg.get('origin', ""))
-    pkg_origins = pkg.get('origins', [])
-    pkg_source = anchore_engine.utils.ensure_str(pkg.get('source', pkg_name))
-
-    if not pkg_name or not (pkg_version or pkg_versions) or not pkg_type:
-        raise Exception("bad hints record, all hints records must supply at least a name, version and type")
-
-    for inp in [pkg_versions, pkg_licenses, pkg_origins, pkg_files]:
-        if type(inp) is not list:
-            raise Exception("bad hints record ({}), versions, licenses, origins, and files if specified must be list types".format(pkg_name))
-    
-    if pkg_license and not pkg_licenses:
-        pkg_licenses = [pkg_license]
-
-    if pkg_version and not pkg_versions:
-        pkg_versions = [pkg_version]
-
-    if pkg_origin and not pkg_origins:
-        pkg_origins = [pkg_origin]
-
-    pkg_latest = pkg_versions[0]
-
-    if not pkg_location:
-        pkg_location = "/virtual/gempkg/{}-{}".format(pkg_name, pkg_latest)
-
-    pkg_key = pkg_location
-
-    el = {
-        'name': pkg_name,
-        'versions': pkg_versions,
-        'latest': pkg_latest,
-        'sourcepkg': pkg_source,
-        'files': pkg_files,
-        'origins': pkg_origins,
-        'lics': pkg_licenses,
-        'type': pkg_type
-    }    
-    return pkg_key, el
-
-def npm_parse_meta(npm):
-
-    record = {}
-
-    name = npm.pop('name', None)
-    if not name:
-        return record
-
-    lics = list()
-    versions = list()
-    latest = None
-    origins = list()
-    sourcepkg = None
-
-    npmtime = npm.pop('time', None)
-    npmdesc = npm.pop('description', None)
-    npmdisttags = npm.pop('dist-tags', None)
-    npmkeywords = npm.pop('keywords', None)
-
-
-    npmlicense = npm.pop('license', None)
-    npmversions = npm.pop('versions', None)
-    npmversion = npm.pop('version', None)
-    npmauthor = npm.pop('author', None)
-    npmmaintainers = npm.pop('maintainers', None)
-    npmrepository = npm.pop('repository', None)
-    npmhomepage= npm.pop('homepage', None)
-
-    if npmlicense:
-        if isinstance(npmlicense, str):
-            lics.append(npmlicense)
-        elif isinstance(npmlicense, dict):
-            for ktype in ['type', 'name', 'license', 'sourceType']:
-                lic = npmlicense.pop(ktype, None)
-                if lic:
-                    lics.append(lic)
-        elif isinstance(npmlicense, list):
-            for lentry in npmlicense:
-                if isinstance(lentry, str):
-                    lics.append(lentry)
-                elif isinstance(lentry, dict):
-                    for ktype in ['type', 'name', 'license', 'sourceType']:
-                        lic = lentry.pop(ktype, None)
-                        if lic:
-                            lics.append(lic)
-        else:
-            print("unknown type (" + str(name) + "): " + str(type(npmlicense)))
-
-
-    if npmversions:
-        if isinstance(npmversions, dict):
-            versions = list(npmversions.keys())
-            for v in npmversions:
-                if npmversions[v] == 'latest':
-                    latest = v
-        elif isinstance(npmversions, list):
-            versions = npmversions
-    elif npmversion:
-        versions.append(npmversion)
-
-    astring = None
-    if npmauthor:
-        if isinstance(npmauthor, str):
-            astring = npmauthor
-        elif isinstance(npmauthor, dict):
-            aname = npmauthor.pop('name', None)
-            aurl = npmauthor.pop('url', None)
-            if aname:
-                astring = aname
-                if aurl:
-                    astring += " ("+aurl+")"
-        else:
-            print("unknown type (" + str(name) + "): "+ str(type(npmauthor)))
-
-    elif npmmaintainers:
-        for m in npmmaintainers:
-            aname = m.pop('name', None)
-            aemail = m.pop('email', None)
-            if aname:
-                astring = aname
-                if aemail:
-                    astring += " ("+aemail+")"
-
-    if astring:
-        origins.append(astring)
-
-    if npmrepository:
-        if isinstance(npmrepository, dict):
-            sourcepkg = npmrepository.pop('url', None)
-        elif isinstance(npmrepository, str):
-            sourcepkg = npmrepository
-        else:
-            print("unknown type (" + str(name) + "): " + str(type(npmrepository)))
-
-    elif npmhomepage:
-        if isinstance(npmhomepage, str):
-            sourcepkg = npmhomepage
-
-    if not lics:
-        print("WARN: ("+name+") no lics: " + str(npm))
-    if not versions:
-        print("WARN: ("+name+") no versions: " + str(npm))
-    if not origins:
-        print("WARN: ("+name+") no origins: " + str(npm))
-    if not sourcepkg:
-        print("WARN: ("+name+") no sourcepkg: " + str(npm))
-
-    if name:
-        record[name] = {'name':name, 'lics':lics, 'versions':versions, 'latest':latest, 'origins':origins, 'sourcepkg':sourcepkg}
-
-    return record
-
-def _hints_to_npm(pkg):
-    pkg_type = anchore_engine.utils.ensure_str(pkg.get('type', "npm")).lower()    
-    pkg_name = anchore_engine.utils.ensure_str(pkg.get('name', ""))
-    pkg_version = anchore_engine.utils.ensure_str(pkg.get('version', ""))
-    pkg_versions = pkg.get('versions', [])    
-    pkg_location = anchore_engine.utils.ensure_str(pkg.get('location', ""))
-    pkg_license = anchore_engine.utils.ensure_str(pkg.get('license', ""))
-    pkg_licenses = pkg.get('licenses', [])
-    pkg_files = pkg.get('files', [])
-    pkg_origin = anchore_engine.utils.ensure_str(pkg.get('origin', ""))
-    pkg_origins = pkg.get('origins', [])    
-    pkg_source = anchore_engine.utils.ensure_str(pkg.get('source', pkg_name))
-
-    if not pkg_name or not (pkg_version or pkg_versions) or not pkg_type:
-        raise Exception("bad hints record, all hints records must supply at least a name, version and type")
-    for inp in [pkg_versions, pkg_licenses, pkg_origins, pkg_files]:
-        if type(inp) is not list:
-            raise Exception("bad hints record ({}), versions, licenses, origins, and files if specified must be list types".format(pkg_name))
-        
-    if pkg_license and not pkg_licenses:
-        pkg_licenses = [pkg_license]
-
-    if pkg_version and not pkg_versions:
-        pkg_versions = [pkg_version]
-
-    if pkg_origin and not pkg_origins:
-        pkg_origins = [pkg_origin]
-
-    pkg_latest = pkg_versions[0]
-
-    if not pkg_location:
-        pkg_location = "/virtual/npmpkg/{}-{}".format(pkg_name, pkg_latest)
-
-    pkg_key = pkg_location
-    
-    el = {
-        'name': pkg_name,
-        'versions': pkg_versions,
-        'latest': pkg_latest,
-        'sourcepkg': pkg_source,
-        'files': pkg_files,
-        'origins': pkg_origins,
-        'lics': pkg_licenses,
-        'type': pkg_type
-    }    
-    return pkg_key, el
-
-def _hints_to_java(pkg):
-    pkg_type = anchore_engine.utils.ensure_str(pkg.get('type', "java")).lower()
-    pkg_jtype = '{}-jar'.format(pkg_type)
-    
-    pkg_name = anchore_engine.utils.ensure_str(pkg.get('name', ""))
-    pkg_version = anchore_engine.utils.ensure_str(pkg.get('version', ""))
-    pkg_location = anchore_engine.utils.ensure_str(pkg.get('location', "/virtual/javapkg/{}-{}.jar".format(pkg_name, pkg_version)))
-    pkg_origin = anchore_engine.utils.ensure_str(pkg.get('origin', ""))
-    pkg_metadata = pkg.get('metadata', {})
-
-    if not pkg_name or not pkg_version or not pkg_type:
-        raise Exception("bad hints record, all hints records must supply at least a name, version and type")
-    
-    pkg_key = pkg_location
-    
-    el = {
-        'metadata': pkg_metadata,
-        'specification-version': pkg_version,
-        'implementation-version': pkg_version,
-        'maven-version': pkg_version,
-        'origin': pkg_origin,
-        'location': pkg_location,
-        'type': pkg_jtype,
-        'name': pkg_name
-    }
-
-    return pkg_key, el
-def rpm_get_file_package_metadata_from_squashtar(unpackdir, squashtar):
-    # derived from rpm source code rpmpgp.h
-    rpm_digest_algo_map = {
-        1: 'md5',
-        2: 'sha1',
-        3: 'ripemd160',
-        5: 'md2',
-        6: 'tiger192',
-        7: 'haval5160',
-        8: 'sha256',
-        9: 'sha384',
-        10: 'sha512',
-        11: 'sha224'
-    }
-
-    record_template = {'digest': None, 'digestalgo': None, 'mode': None, 'group': None, 'user': None, 'size': None, 'package': None, 'conffile': False}
-
-    result = {}
-
-    rpm_db_base_dir = rpm_prepdb_from_squashtar(unpackdir, squashtar)
-    rpmdbdir = os.path.join(rpm_db_base_dir, "var", "lib", "rpm")
-
-    cmdstr = 'rpm --dbpath='+rpmdbdir+' -qa --queryformat [%{FILENAMES}|ANCHORETOK|%{FILEDIGESTS}|ANCHORETOK|%{FILEMODES:octal}|ANCHORETOK|%{FILEGROUPNAME}|ANCHORETOK|%{FILEUSERNAME}|ANCHORETOK|%{FILESIZES}|ANCHORETOK|%{=NAME}|ANCHORETOK|%{FILEFLAGS:fflags}|ANCHORETOK|%{=FILEDIGESTALGO}\\n]'
-    cmd = cmdstr.split()
-    print ("{} - {}".format(rpmdbdir, cmd))
-    try:
-        pipes = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        o, e = pipes.communicate()
-        exitcode = pipes.returncode
-        soutput = o
-        serror = e
-
-        if exitcode == 0:
-            for l in soutput.splitlines():
-                l = str(l.strip(), 'utf8')
-                if l:
-                    try:
-                        (fname, fdigest, fmode, fgroup, fuser, fsize, fpackage, fflags, fdigestalgonum)= l.split("|ANCHORETOK|")
-                        fname = re.sub('""', '', fname)
-                        cfile = False
-                        if 'c' in str(fflags):
-                            cfile = True
-
-                        try:
-                            fdigestalgo = rpm_digest_algo_map[int(fdigestalgonum)]
-                        except:
-                            fdigestalgo = 'unknown'
-
-                        if fname not in result:
-                            result[fname] = []
-
-                        el = copy.deepcopy(record_template)
-                        el.update({'digest': fdigest or None, 'digestalgo': fdigestalgo or None, 'mode': fmode or None, 'group': fgroup or None, 'user': fuser or None, 'size': fsize or None, 'package': fpackage or None, 'conffile': cfile})
-                        result[fname].append(el)
-                    except Exception as err:
-                        print("WARN: unparsable output line - exception: " + str(err))
-                        raise err
-        else:
-            raise Exception("rpm file metadata command failed with exitcode ("+str(exitcode)+") - stdoutput: " + str(soutput) + " : stderr: " + str(serror))
-
-    except Exception as err:
-        raise Exception("WARN: distro package metadata gathering failed - exception: " + str(err))
-
-    return result
-
-def dpkg_get_file_package_metadata_from_squashtar(unpackdir, squashtar):
-
-    result = {}
-    record_template = {'digest': None, 'digestalgo': None, 'mode': None, 'group': None, 'user': None, 'size': None, 'package': None, 'conffile': False}
-
-    conffile_csums = {}
-
-    dpkg_db_base_dir = dpkg_prepdb_from_squashtar(unpackdir, squashtar)
-    dpkgdbdir = os.path.join(dpkg_db_base_dir, "var", "lib", "dpkg")
-    dpkgdocsdir = os.path.join(dpkg_db_base_dir, "usr", "share", "doc")
-    statuspath = os.path.join(dpkg_db_base_dir, "var", "lib", "dpkg", "status")
-
-    try:
-        if os.path.exists(statuspath):
-            buf = None
-            try:
-                with open(statuspath, 'r') as FH:
-                    buf = FH.read()
-            except Exception as err:
-                buf = None
-                print("WARN: cannot read status file - exception: " + str(err))
-
-            if buf:
-                for line in buf.splitlines():
-                    #line = str(line.strip(), 'utf8')
-                    line = line.strip()
-                    if re.match("^Conffiles:.*", line):
-                        fmode = True
-                    elif re.match("^.*:.*", line):
-                        fmode = False
-                    else:
-                        if fmode:
-                            try:
-                                (fname, csum) = line.split()
-                                conffile_csums[fname] = csum
-                            except Exception as err:
-                                print("WARN: bad line in status for conffile line - exception: " + str(err))
-
-    except Exception as err:
-        import traceback
-        traceback.print_exc()
-        raise Exception("WARN: could not parse dpkg status file, looking for conffiles checksums - exception: " + str(err))
-
-    metafiles = {}
-    conffiles = {}
-    metapath = os.path.join(dpkg_db_base_dir, "var", "lib", "dpkg", "info")
-    try:
-        if os.path.exists(metapath):
-            for f in os.listdir(metapath):
-                patt = re.match(r"(.*)\.md5sums", f)
-                if patt:
-                    pkgraw = patt.group(1)
-                    patt = re.match("(.*):.*", pkgraw)
-                    if patt:
-                        pkg = patt.group(1)
-                    else:
-                        pkg = pkgraw
-
-                    metafiles[pkg] = os.path.join(metapath, f)
-
-                patt = re.match(r"(.*)\.conffiles", f)
-                if patt:
-                    pkgraw = patt.group(1)
-                    patt = re.match("(.*):.*", pkgraw)
-                    if patt:
-                        pkg = patt.group(1)
-                    else:
-                        pkg = pkgraw
-
-                    conffiles[pkg] = os.path.join(metapath, f)
-        else:
-            raise Exception("no dpkg info path found in image: " + str(metapath))
-
-        for pkg in list(metafiles.keys()):
-            dinfo = None
-            try:
-                with open(metafiles[pkg], 'r') as FH:
-                    dinfo = FH.read()
-            except Exception as err:
-                print("WARN: could not open/read metafile - exception: " + str(err))
-
-            if dinfo:
-                for line in dinfo.splitlines():
-                    #line = str(line.strip(), 'utf8')
-                    line = line.strip()
-                    try:
-                        (csum, fname) = line.split()
-                        fname = '/' + fname
-                        fname = re.sub(r"\/\/", r"\/", fname)
-
-                        if fname not in result:
-                            result[fname] = []
-
-                        el = copy.deepcopy(record_template)
-                        el.update({"package": pkg or None, "digest": csum or None, "digestalgo": "md5", "conffile": False})
-                        result[fname].append(el)
-                    except Exception as err:
-                        print("WARN: problem parsing line from dpkg info file - exception: " + str(err))
-
-        for pkg in list(conffiles.keys()):
-            cinfo = None
-            try:
-                with open(conffiles[pkg], 'r') as FH:
-                    cinfo = FH.read()
-            except Exception as err:
-                cinfo = None
-                print("WARN: could not open/read conffile - exception: " + str(err))
-
-            if cinfo:
-                for line in cinfo.splitlines():
-                    #line = str(line.strip(), 'utf8')
-                    line = line.strip()
-                    try:
-                        fname = line
-                        if fname in conffile_csums:
-                            csum = conffile_csums[fname]
-                            if fname not in result:
-                                result[fname] = []
-                            el = copy.deepcopy(record_template)
-                            el.update({"package": pkg or None, "digest": csum or None, "digestalgo": "md5", "conffile": True})
-                            result[fname].append(el)
-                    except Exception as err:
-                        print("WARN: problem parsing line from dpkg conffile file - exception: " + str(err))
-
-    except Exception as err:
-        import traceback
-        traceback.print_exc()
-        raise Exception("WARN: could not find/parse dpkg info metadata files - exception: " + str(err))
-
-    return result
-
-def apk_get_file_package_metadata_from_squashtar(unpackdir, squashtar):
-    # derived from alpine apk checksum logic
-    #
-    # a = "Q1XxRCAhhQ6eotekmwp6K9/4+DLwM="
-    # sha1sum = a[2:].decode('base64').encode('hex')
-    #
-
-    result = {}
-    record_template = {'digest': None, 'digestalgo': None, 'mode': None, 'group': None, 'user': None, 'size': None, 'package': None, 'conffile': False}
-
-    apk_db_base_dir = apk_prepdb_from_squashtar(unpackdir, squashtar)
-    apkdbpath = os.path.join(apk_db_base_dir, 'lib', 'apk', 'db', 'installed')
-
-    try:
-        if os.path.exists(apkdbpath):
-            buf = None
-            try:
-                with open(apkdbpath, 'r') as FH:
-                    buf = FH.read()
-
-            except Exception as err:
-                buf = None
-                print("WARN: cannot read apk DB file - exception: " + str(err))
-
-            if buf:
-                fmode = raw_csum = uid = gid = sha1sum = fname = therealfile_apk = therealfile_fs = None
-                for line in buf.splitlines():
-                    #line = str(line.strip(), 'utf8')
-                    line = line.strip()
-                    patt = re.match("(.):(.*)", line)
-                    if patt:
-                        atype = patt.group(1)
-                        aval = patt.group(2)
-
-                        if atype == 'P':
-                            pkg = aval
-                        elif atype == 'F':
-                            fpath = aval
-                        elif atype == 'R':
-                            fname = aval
-                        elif atype == 'a':
-                            vvals = aval.split(":")
-                            try:
-                                uid = vvals[0]
-                            except:
-                                uid = None
-                            try:
-                                gid = vvals[1]
-                            except:
-                                gid = None
-                            try:
-                                fmode = vvals[2]
-                            except:
-                                fmode = None
-                        elif atype == 'Z':
-                            raw_csum = aval
-                            fname = '/'.join(['/'+fpath, fname])
-                            therealfile_apk = re.sub(r"\/+", "/", '/'.join([unpackdir, 'rootfs', fname]))
-                            therealfile_fs = os.path.realpath(therealfile_apk)
-                            if therealfile_apk == therealfile_fs:
-                                try:
-                                    #sha1sum = raw_csum[2:].decode('base64').encode('hex')
-                                    sha1sum = str(binascii.hexlify(base64.decodebytes(raw_csum[2:])), 'utf-8')
-                                except:
-                                    sha1sum = None
-                            else:
-                                sha1sum = None
-
-                            if fmode:
-                                fmode = fmode.zfill(4)
-
-                            if fname not in result:
-                                result[fname] = []
-
-                            el = copy.deepcopy(record_template)
-                            el.update({"package": pkg or None, "digest": sha1sum or None, "digestalgo": "sha1", "mode": fmode or None, "group": gid or None, "user": uid or None})
-                            result[fname].append(el)
-                            fmode = raw_csum = uid = gid = sha1sum = fname = therealfile_apk = therealfile_fs = None
-
-    except Exception as err:
-        import traceback
-        traceback.print_exc()
-        raise Exception("WARN: could not parse apk DB file, looking for file checksums - exception: " + str(err))
-
-    return result
 
 
 ##### File IO helpers
@@ -2003,6 +745,7 @@ def read_kvfile_todict(file):
 
     return ret
 
+
 def read_plainfile_tostr(file):
     if not os.path.isfile(file):
         return ""
@@ -2012,10 +755,12 @@ def read_plainfile_tostr(file):
 
     return ret
 
+
 def write_plainfile_fromstr(file, instr):
     with open(file, 'w') as FH:
         #thestr = instr.encode('utf8')
         FH.write(instr)
+
 
 def write_kvfile_fromlist(file, list, delim=' '):
     with open(file, 'w') as OFH:
@@ -2025,6 +770,7 @@ def write_kvfile_fromlist(file, list, delim=' '):
             thestr = delim.join(l) + "\n"
             #thestr = thestr.encode('utf8')
             OFH.write(thestr)
+
 
 def write_kvfile_fromdict(file, indict):
     """
@@ -2049,17 +795,20 @@ def write_kvfile_fromdict(file, indict):
             #thestr = thestr.encode('utf8')
             OFH.write(thestr)
 
+
 ### data transform helpers
+
 
 def defaultdict_to_dict(d):
     if isinstance(d, collections.defaultdict):
         d = {k: defaultdict_to_dict(v) for k, v in d.items()}
     return d
 
+
 def merge_nested_dict(a, b, path=None):
     if path is None:
         path = []
-    
+
     for key in b:
         if key in a:
             if isinstance(a[key], dict) and isinstance(b[key], dict):
@@ -2071,6 +820,7 @@ def merge_nested_dict(a, b, path=None):
         else:
             a[key] = b[key]
     return a
+
 
 def dig(target, *keys, **kwargs):
     """
@@ -2094,3 +844,23 @@ def dig(target, *keys, **kwargs):
                 return None
 
     return end_of_chain
+
+
+def content_hints(pkg_type):
+    """Content hints will provide the handlers with a means of inserting new data from
+    the user.
+
+    This function produces a dictionary with names as keys so that consumers
+    avoid having to loop, and can do simpler (faster) `.get()` operations.
+    """
+    hints = get_hintsfile()
+    packages = {}
+    for package in hints.get("packages", []):
+        if package.get("type", "") == pkg_type:
+            # Do not allow nameless packages to be inserted. The hints loader
+            # will warn if this is a problem, but will not stop execution
+            if not package.get("name"):
+                continue
+            packages[package["name"]] = package
+
+    return packages

--- a/anchore_engine/clients/localanchore_standalone.py
+++ b/anchore_engine/clients/localanchore_standalone.py
@@ -451,18 +451,6 @@ def make_staging_dirs(rootdir, use_cache_dir=None):
     rando = str(uuid.uuid4())
     unpackdir = os.path.join(rootdir, rando)
 
-    # XXX This highly questionable environment variable usage is the only way
-    # found to programmatically inject hintsfiles without requiring the
-    # hintsfile to exist in the image. Otherwise, it would require every
-    # permutation of a hintsfile to be an actual unique image. It leverages the
-    # fact that Anchore Engine will not try to extract the hinstfile if it has
-    # already been unpacked in the unpack directory.
-    try:
-        if os.environ.get['ANCHORE_TEST_HINTSFILE']:
-            shutil.copyfile(os.environ.get['ANCHORE_TEST_HINTSFILE'], unpackdir)
-    except Exception as err:
-        logger.debug("testing injection of hintsfile failed: %s", str(err))
-
     ret = {
         'unpackdir': unpackdir,
         'copydir': os.path.join(rootdir, rando, "raw"),
@@ -481,6 +469,20 @@ def make_staging_dirs(rootdir, use_cache_dir=None):
                 os.makedirs(ret[k])
         except Exception as err:
             raise Exception("unable to prep staging directory - exception: " + str(err))
+
+    # XXX This highly questionable environment variable usage is the only way
+    # found to programmatically inject hintsfiles without requiring the
+    # hintsfile to exist in the image. Otherwise, it would require every
+    # permutation of a hintsfile to be an actual unique image. It leverages the
+    # fact that Anchore Engine will not try to extract the hinstfile if it has
+    # already been unpacked in the unpack directory.
+    try:
+        if os.environ.get('ANCHORE_TEST_HINTSFILE'):
+            test_hints = os.environ['ANCHORE_TEST_HINTSFILE']
+            destination = os.path.join(unpackdir, 'anchore_hints.json')
+            shutil.copyfile(test_hints, destination)
+    except Exception as err:
+        logger.debug("testing injection of hintsfile failed: %s", str(err))
 
     # Set this env var so both scripts and modules that don't have access to
     # these values have a reliable way of retrieving it. This is set here

--- a/anchore_engine/clients/localanchore_standalone.py
+++ b/anchore_engine/clients/localanchore_standalone.py
@@ -484,11 +484,6 @@ def make_staging_dirs(rootdir, use_cache_dir=None):
     except Exception as err:
         logger.debug("testing injection of hintsfile failed: %s", str(err))
 
-    # Set this env var so both scripts and modules that don't have access to
-    # these values have a reliable way of retrieving it. This is set here
-    # because this is the function that creates the directories.
-    os.environ['ANCHORE_ANALYZERS_UNPACKDIR'] = unpackdir
-
     return ret
 
 
@@ -862,7 +857,7 @@ def run_anchore_analyzers(staging_dirs, imageDigest, imageId, localconfig):
             if data:
                 analyzer_report[analyzer_output][analyzer_output_el] = {'base': data }
 
-    syft_results = anchore_engine.analyzers.syft.catalog_image(image=copydir)
+    syft_results = anchore_engine.analyzers.syft.catalog_image(image=copydir, unpackdir=unpackdir)
 
     anchore_engine.analyzers.utils.merge_nested_dict(analyzer_report, syft_results)
 
@@ -960,6 +955,7 @@ def analyze_image(userId, manifest, image_record, tmprootdir, localconfig, regis
             dockerfile_contents = None
 
         staging_dirs = make_staging_dirs(tmprootdir, use_cache_dir=use_cache_dir)
+        unpackdir = staging_dirs['unpackdir']
 
         if image_source == 'docker-archive':
             try:

--- a/tests/functional/clients/scripts/standalone.py
+++ b/tests/functional/clients/scripts/standalone.py
@@ -111,7 +111,7 @@ def get_manifest(resource, destination):
     return json_manifest
 
 
-def analyze(registry, manifest, repo, digest, tag, work_dir):
+def analyze(registry, manifest, repo, digest, tag, work_dir, localconfig):
     userId = None  # Not used at all in analyze_image
     image_record = {
         'dockerfile_mode': 'actual',  # XXX no idea
@@ -125,9 +125,14 @@ def analyze(registry, manifest, repo, digest, tag, work_dir):
         }],
         'imageDigest': 'some sha256 - this seems repeated?',  # XXX
     }
-    localconfig = {'service_dir': join(work_dir, 'service_dir')}
+    _localconfig = {'service_dir': join(work_dir, 'service_dir')}
+    if localconfig:
+        _localconfig.update(localconfig)
+
+    localconfig = _localconfig
 
     click.echo('Starting the analyze process...')
+
     image_report, manifest = analyze_image(
         userId, manifest, image_record, work_dir, localconfig,
         use_cache_dir=join(work_dir, 'cache_dir')
@@ -184,13 +189,13 @@ def _main(registry, repo, digest, tag, work_dir):
     main(registry, repo, digest, tag, work_dir)
 
 
-def main(registry=None, repo=None, digest=None, tag=None, work_dir=None, **kw):
+def main(registry=None, repo=None, digest=None, tag=None, work_dir=None, localconfig=None, **kw):
     # Re-assign work_dir in case it is using the cache, which gets computed
     # dynamically
     work_dir = create_directories(work_dir)
     resource = '%s@%s' % (repo, digest)
     manifest = get_manifest(resource, join(work_dir, 'manifest.json'))
-    analyze(registry, manifest, repo, digest, tag, work_dir)
+    analyze(registry, manifest, repo, digest, tag, work_dir, localconfig)
 
 
 if __name__ == '__main__':

--- a/tests/functional/clients/standalone/package_list/test_busybox.py
+++ b/tests/functional/clients/standalone/package_list/test_busybox.py
@@ -6,4 +6,3 @@ class TestPksAll:
         result = analyzed_data("busybox")
         pkgs = result['image']['imagedata']['analysis_report']['package_list']['pkgs.all']['base']
         assert pkgs == {'BusyBox': '1.32.0'}
-

--- a/tests/functional/clients/standalone/test_hints.py
+++ b/tests/functional/clients/standalone/test_hints.py
@@ -6,6 +6,7 @@ class TestHintsNPM:
             "packages": [
                 {
                     "name": "safe-buffer",
+                    "location": "/usr/lib/node_modules/npm/node_modules/string_decoder/node_modules/safe-buffer/package.json",
                     "license": "FREE-FOR-ALL",
                     "version": "100",
                     "type": "npm"
@@ -29,11 +30,10 @@ class TestHintsNPM:
         assert package.get('sourcepkg') is None
 
         # Include non-existent package from a custom hint
-        package = pkgs.get('toure-awesome')
+        package = pkgs.get('/virtual/npmpkg/toure-awesome-1.0rc')
         assert package['name'] == "toure-awesome"
         assert package['license'] == 'Propietary'
         assert package['version'] == '1.0rc'
-
 
 
 class TestHintsRPM:
@@ -69,7 +69,14 @@ class TestHintsDPKG:
                     "version": "43",
                     "license": "GPL",
                     "type": "dpkg",
+                },
+                {
+                    "name": "master-alex",
+                    "version": "0.0.1rc",
+                    "license": "LGPLv8",
+                    "type": "dpkg",
                 }
+
             ]
         }
         result = hints_image(hints, 'stretch-slim')
@@ -78,3 +85,139 @@ class TestHintsDPKG:
         assert package['type'] == "dpkg"
         assert package['version'] == '43'
         assert package['license'] == 'GPL'
+
+        package = pkgs.get('master-alex')
+        assert package['type'] == "dpkg"
+        assert package['version'] == '0.0.1rc'
+        assert package['license'] == 'LGPLv8'
+
+
+
+class TestHintsJava:
+
+    def test_java_hints(self, hints_image):
+        hints = {
+            "packages": [
+                {
+                    "name": "TwilioNotifier",
+                    "origin": "com.twilio.jenkins",
+                    "location": "/TwilioNotifier.hpi",
+                    "type": "java-hpi",
+                    "version": "N/A"
+                },
+                {
+                    "name": "developer-dan",
+                    "origin": "com.twilio.jenkins",
+                    "type": "java-hpi",
+                    "version": "193.28"
+                },
+            ]
+        }
+        result = hints_image(hints, 'java')
+        pkgs = result['image']['imagedata']['analysis_report']['package_list']['pkgs.java']['base']
+        packages = pkgs.get('/TwilioNotifier.hpi')
+        assert packages['type'] == "java-hpi"
+        assert packages['location'] == "/TwilioNotifier.hpi"
+        assert packages['origin'] == "com.twilio.jenkins"
+
+        packages = pkgs.get('/virtual/javapkg/developer-dan-193.28.jar')
+        assert packages['type'] == "java-hpi"
+        assert packages['origin'] == "com.twilio.jenkins"
+        assert packages['version'] == "193.28"
+
+
+class TestHintsAPKG:
+
+    def test_apkg_hints(self, hints_image):
+        hints = {
+            "packages": [
+                {
+                    "version": "2.2",
+                    "sourcepkg": "alpine-keys",
+                    "release": "r0",
+                    "origin": "Natanael Copa <ncopa@alpinelinux.org>",
+                    "arch": "x86_64",
+                    "license": "MIT",
+                    "size": "1000",
+                    "type": "APKG",
+                    "name": "alpine-keys"
+                }
+            ]
+        }
+
+        result = hints_image(hints, 'py38')
+        pkgs = result['image']['imagedata']['analysis_report']['package_list']['pkgs.allinfo']['base']
+        packages = pkgs.get('alpine-keys')
+        assert packages['type'] == "APKG"
+        assert packages['size'] == "1000"
+        assert packages['license'] == "MIT"
+        assert packages['release'] == "r0"
+
+
+class TestHintsPython:
+
+    def test_python_hints(self, hints_image):
+        hints = {
+            "packages": [
+                {
+                    "name": "py",
+                    "version": "1.9.1",
+                    "type": "python",
+                    "location": "/usr/lib/python3.8/my-site-packages",
+                },
+                {
+                    "name": "hints-spectacular",
+                    "version": "1.0.0alpha",
+                    "type": "python",
+                }
+
+            ]
+        }
+
+        result = hints_image(hints, 'py38')
+        pkgs = result['image']['imagedata']['analysis_report']['package_list']['pkgs.python']['base']
+        packages = pkgs.get('/usr/lib/python3.8/my-site-packages')
+
+        assert packages['type'] == "python"
+        assert packages['version'] == "1.9.1"
+        assert packages['location'] == "/usr/lib/python3.8/my-site-packages"
+
+        packages = pkgs.get('/virtual/pypkg/site-packages/hints-spectacular-1.0.0alpha')
+        assert packages['type'] == "python"
+        assert packages['version'] == "1.0.0alpha"
+
+
+class TestHintsGem:
+    def test_gem_hints(self, hints_image):
+        hints = {
+            "packages": [
+                {
+                    "name": "uri",
+                    "lics": ["GPL"],
+                    "version": "0.11.0",
+                    "latest": "0.10.0",
+                    "origins": ["Akira Yamada"],
+                    "sourcepkg": "https://example.com",
+                    "type": "gem",
+                    "location": "/usr/lib/ruby/gems/2.7.0/specifications/default/uri-0.10.0.gemspec",
+                },
+                {
+                    "name": "diamonds",
+                    "version": "2.0",
+                    "type": "gem",
+                }
+            ]
+        }
+
+        result = hints_image(hints, 'lean')
+        pkgs = result['image']['imagedata']['analysis_report']['package_list']['pkgs.gems']['base']
+        path = "/usr/lib/ruby/gems/2.7.0/specifications/default/uri-0.10.0.gemspec"
+        packages = pkgs.get(path)
+        assert packages['lics'] == ["GPL"]
+        assert packages['version'] == "0.11.0"
+        assert packages['sourcepkg'] == "https://example.com"
+        assert packages['type'] == "gem"
+
+        packages = pkgs.get('/virtual/gempkg/diamonds-2.0')
+        assert packages['type'] == "gem"
+        assert packages['version'] == "2.0"

--- a/tests/functional/clients/standalone/test_hints.py
+++ b/tests/functional/clients/standalone/test_hints.py
@@ -1,0 +1,80 @@
+
+
+class TestHintsNPM:
+    def test_npm_hints(self, hints_image):
+        hints = {
+            "packages": [
+                {
+                    "name": "safe-buffer",
+                    "license": "FREE-FOR-ALL",
+                    "version": "100",
+                    "type": "npm"
+                },
+                {
+                    "name": "toure-awesome",
+                    "license": "Propietary",
+                    "version": "1.0rc",
+                    "type": "npm"
+                }
+
+            ]
+        }
+        result = hints_image(hints, 'npm')
+        pkgs = result['image']['imagedata']['analysis_report']['package_list']['pkgs.npms']['base']
+        path = "/usr/lib/node_modules/npm/node_modules/string_decoder/node_modules/safe-buffer/package.json"
+        package = pkgs.get(path)
+        assert package['name'] == "safe-buffer"
+        assert package['license'] == 'FREE-FOR-ALL'
+        assert package['version'] == '100'
+        assert package.get('sourcepkg') is None
+
+        # Include non-existent package from a custom hint
+        package = pkgs.get('toure-awesome')
+        assert package['name'] == "toure-awesome"
+        assert package['license'] == 'Propietary'
+        assert package['version'] == '1.0rc'
+
+
+
+class TestHintsRPM:
+
+    def test_rpm_hints(self, hints_image):
+        hints = {
+            "packages": [
+                {
+                    "name": "tar",
+                    "license": "MIT",
+                    "version": "42",
+                    "type": "rpm",
+                    "origin": "Centos"
+                }
+            ]
+        }
+        result = hints_image(hints, 'rpm')
+        pkgs = result['image']['imagedata']['analysis_report']['package_list']['pkgs.allinfo']['base']
+        package = pkgs.get('tar')
+        assert package['type'] == "rpm"
+        assert package['license'] == 'MIT'
+        assert package['version'] == '42'
+        assert package['origin'] == 'Centos'
+
+
+class TestHintsDPKG:
+
+    def test_dpkg_hints(self, hints_image):
+        hints = {
+            "packages": [
+                {
+                    "name": "adduser",
+                    "version": "43",
+                    "license": "GPL",
+                    "type": "dpkg",
+                }
+            ]
+        }
+        result = hints_image(hints, 'stretch-slim')
+        pkgs = result['image']['imagedata']['analysis_report']['package_list']['pkgs.allinfo']['base']
+        package = pkgs.get('adduser')
+        assert package['type'] == "dpkg"
+        assert package['version'] == '43'
+        assert package['license'] == 'GPL'


### PR DESCRIPTION
Signed-off-by: Toure Dunnon <toure.dunnon@anchore.com>

**What this PR does / why we need it**: The "content hints" functionality should behave as expected for all content types, which have been replaced by Syft.


**Which issue this PR fixes** fixes #703