### PR TITLE
logging support for syft calls

### DIFF
--- a/anchore_engine/clients/syft_wrapper.py
+++ b/anchore_engine/clients/syft_wrapper.py
@@ -2,13 +2,7 @@ import os
 import json
 import shlex
 
-from anchore_engine.utils import (
-    run_command,
-    run_command_list,
-    manifest_to_digest,
-    AnchoreException,
-)
-from anchore_engine.subsys import logger
+from anchore_engine.utils import run_check
 
 
 def run_syft(image):
@@ -23,45 +17,6 @@ def run_syft(image):
 
     cmd = "syft -vv -o json oci-dir:{image}".format(image=image)
 
-    logger.debug("running syft: cmd={}".format(repr(cmd)))
-    rc, stdout, stderr = run_command_list(shlex.split(cmd), env=proc_env)
-    logger.debug(
-        "results: rc={} stdout={} stderr={}".format(rc, repr(stdout), repr(stderr))
-    )
-
-    if rc != 0:
-        raise SyftError(cmd=cmd, rc=rc, out=stdout, err=stderr)
+    stdout, _ = run_check(shlex.split(cmd), env=proc_env)
 
     return json.loads(stdout)
-
-
-class SyftError(AnchoreException):
-    def __init__(
-        self,
-        cmd=None,
-        rc=None,
-        out=None,
-        err=None,
-        msg="Error encountered in syft operation",
-    ):
-        from anchore_engine.common.errors import AnchoreError
-
-        self.cmd = " ".join(cmd) if isinstance(cmd, list) else cmd
-        self.exitcode = rc
-        self.stderr = (
-            str(err).replace("\r", " ").replace("\n", " ").strip() if err else None
-        )
-        self.stdout = (
-            str(out).replace("\r", " ").replace("\n", " ").strip() if out else None
-        )
-        self.msg = msg
-
-    def __repr__(self):
-        return "{}. cmd={}, rc={}, stdout={}, stderr={}".format(
-            self.msg, self.cmd, self.exitcode, self.stdout, self.stderr
-        )
-
-    def __str__(self):
-        return "{}. cmd={}, rc={}, stdout={}, stderr={}".format(
-            self.msg, self.cmd, self.exitcode, self.stdout, self.stderr
-        )

--- a/tests/unit/anchore_engine/clients/test_localanchore_standalone.py
+++ b/tests/unit/anchore_engine/clients/test_localanchore_standalone.py
@@ -1,8 +1,7 @@
 import pytest
-import os
 from anchore_engine.clients.localanchore_standalone import (
     retrying_pull_image,
-    ImagePullError,
+    AnalysisError,
 )
 from anchore_engine.clients import localanchore_standalone
 from anchore_engine.subsys import logger
@@ -16,8 +15,8 @@ fail_threshold = 2
 def always_fail(*args, **kwargs):
     global fail_counter
     fail_counter += 1
-    raise ImagePullError(
-        pull_string="testing", tag="latest", cause=Exception("cannot pull")
+    raise AnalysisError(
+        msg="", pull_string="testing", tag="latest", cause=Exception("cannot pull")
     )
 
 
@@ -26,8 +25,11 @@ def fail_twice(*args, **kwargs):
 
     if fail_counter < fail_threshold:
         fail_counter += 1
-        raise ImagePullError(
-            pull_string="somepullstring", tag="latest", cause=Exception("cannot pull")
+        raise AnalysisError(
+            msg="",
+            pull_string="somepullstring",
+            tag="latest",
+            cause=Exception("cannot pull"),
         )
     else:
         return True
@@ -51,7 +53,7 @@ def test_retrying_image_pull_full_failure(alwaysfail_pull):
     """
 
     global fail_counter
-    with pytest.raises(ImagePullError):
+    with pytest.raises(AnalysisError):
         retrying_pull_image(
             staging_dirs={},
             pullstring="somepullstring",

--- a/tests/unit/anchore_engine/test_utils.py
+++ b/tests/unit/anchore_engine/test_utils.py
@@ -1,102 +1,247 @@
-from anchore_engine.utils import parse_dockerimage_string
-from anchore_engine.subsys import logger
-
-logger.enable_test_logging(level="INFO")
+import pytest
+from anchore_engine.utils import parse_dockerimage_string, run_check, CommandException
 
 
-def test_parse_dockerimage_string():
-    tests = [
-        (
-            "docker.io/library/nginx",
-            {
-                "digest": None,
-                "fulldigest": None,
-                "fulltag": "docker.io/library/nginx:latest",
-                "host": "docker.io",
-                "imageId": None,
-                "port": None,
-                "pullstring": "docker.io/library/nginx:latest",
-                "registry": "docker.io",
-                "repo": "library/nginx",
-                "repotag": "library/nginx:latest",
-                "tag": "latest",
-            },
-        ),
-        (
-            "docker.io/nginx",
-            {
-                "digest": None,
-                "fulldigest": None,
-                "fulltag": "docker.io/nginx:latest",
-                "host": "docker.io",
-                "imageId": None,
-                "port": None,
-                "pullstring": "docker.io/nginx:latest",
-                "registry": "docker.io",
-                "repo": "nginx",
-                "repotag": "nginx:latest",
-                "tag": "latest",
-            },
-        ),
-        (
-            "nginx",
-            {
-                "digest": None,
-                "fulldigest": None,
-                "fulltag": "docker.io/nginx:latest",
-                "host": "docker.io",
-                "imageId": None,
-                "port": None,
-                "pullstring": "docker.io/nginx:latest",
-                "registry": "docker.io",
-                "repo": "nginx",
-                "repotag": "nginx:latest",
-                "tag": "latest",
-            },
-        ),
-        (
-            "docker.io/library/nginx@sha256:abcdef123",
-            {
-                "digest": "sha256:abcdef123",
-                "fulldigest": "docker.io/library/nginx@sha256:abcdef123",
-                "fulltag": None,
-                "host": "docker.io",
-                "imageId": None,
-                "port": None,
-                "pullstring": "docker.io/library/nginx@sha256:abcdef123",
-                "registry": "docker.io",
-                "repo": "library/nginx",
-                "repotag": None,
-                "tag": None,
-            },
-        ),
-        (
-            "docker.io/nginx@sha256:abcdef123",
-            {
-                "digest": "sha256:abcdef123",
-                "fulldigest": "docker.io/nginx@sha256:abcdef123",
-                "fulltag": None,
-                "host": "docker.io",
-                "imageId": None,
-                "port": None,
-                "pullstring": "docker.io/nginx@sha256:abcdef123",
-                "registry": "docker.io",
-                "repo": "nginx",
-                "repotag": None,
-                "tag": None,
-            },
-        ),
-    ]
+images = [
+    (
+        "docker.io/library/nginx",
+        {
+            "digest": None,
+            "fulldigest": None,
+            "fulltag": "docker.io/library/nginx:latest",
+            "host": "docker.io",
+            "imageId": None,
+            "port": None,
+            "pullstring": "docker.io/library/nginx:latest",
+            "registry": "docker.io",
+            "repo": "library/nginx",
+            "repotag": "library/nginx:latest",
+            "tag": "latest",
+        },
+    ),
+    (
+        "docker.io/nginx",
+        {
+            "digest": None,
+            "fulldigest": None,
+            "fulltag": "docker.io/nginx:latest",
+            "host": "docker.io",
+            "imageId": None,
+            "port": None,
+            "pullstring": "docker.io/nginx:latest",
+            "registry": "docker.io",
+            "repo": "nginx",
+            "repotag": "nginx:latest",
+            "tag": "latest",
+        },
+    ),
+    (
+        "nginx",
+        {
+            "digest": None,
+            "fulldigest": None,
+            "fulltag": "docker.io/nginx:latest",
+            "host": "docker.io",
+            "imageId": None,
+            "port": None,
+            "pullstring": "docker.io/nginx:latest",
+            "registry": "docker.io",
+            "repo": "nginx",
+            "repotag": "nginx:latest",
+            "tag": "latest",
+        },
+    ),
+    (
+        "docker.io/library/nginx@sha256:abcdef123",
+        {
+            "digest": "sha256:abcdef123",
+            "fulldigest": "docker.io/library/nginx@sha256:abcdef123",
+            "fulltag": None,
+            "host": "docker.io",
+            "imageId": None,
+            "port": None,
+            "pullstring": "docker.io/library/nginx@sha256:abcdef123",
+            "registry": "docker.io",
+            "repo": "library/nginx",
+            "repotag": None,
+            "tag": None,
+        },
+    ),
+    (
+        "docker.io/nginx@sha256:abcdef123",
+        {
+            "digest": "sha256:abcdef123",
+            "fulldigest": "docker.io/nginx@sha256:abcdef123",
+            "fulltag": None,
+            "host": "docker.io",
+            "imageId": None,
+            "port": None,
+            "pullstring": "docker.io/nginx@sha256:abcdef123",
+            "registry": "docker.io",
+            "repo": "nginx",
+            "repotag": None,
+            "tag": None,
+        },
+    ),
+]
 
-    for input, result in tests:
-        logger.info("Testing parsing {}".format(input))
-        output = parse_dockerimage_string(input)
-        try:
-            assert output == result
-        except:
-            logger.error(
-                "Failed parsing {} to expected: {}, Got: {}".format(
-                    input, result, output
-                )
-            )
-            raise
+
+@pytest.mark.parametrize("image,expected", images)
+def test_parse_dockerimage_string(image, expected):
+    result = parse_dockerimage_string(image)
+    assert result == expected
+
+
+# allows raising from a lambda
+def _raise(exc):
+    raise exc
+
+
+class FakePopen:
+    def __init__(self, code, stdout, stderr, raises=None):
+        self.returncode = code
+        self.stdout = stdout
+        self.stderr = stderr
+        self.raises = raises
+
+    def __call__(self, *a, **kw):
+        if self.raises is not None:
+            raise self.raises
+
+        return self
+
+    def communicate(self):
+        if self.raises is not None:
+            raise self.raises
+
+        return self.stdout, self.stderr
+
+
+class Capture:
+    """
+    Remember everything that was called, optionally return them
+    """
+
+    def __init__(self, *a, **kw):
+        self.a = a
+        self.kw = kw
+        self.calls = []
+        self.return_values = kw.get("return_values", False)
+        self.always_returns = kw.get("always_returns", False)
+
+    def __call__(self, *a, **kw):
+        self.calls.append({"args": a, "kwargs": kw})
+        if self.always_returns:
+            return self.always_returns
+        if self.return_values:
+            return self.return_values.pop()
+
+
+class TestRunCheck:
+    def test_file_not_found(self, monkeypatch):
+        monkeypatch.setattr(
+            "anchore_engine.utils.subprocess.Popen",
+            lambda a, **kw: _raise(FileNotFoundError),
+        )
+        with pytest.raises(CommandException) as error:
+            run_check(["foobar", "-vvv"])
+
+        assert "unable to run command. Executable does not exist" in str(error)
+        assert error.value.code == 1
+        assert error.value.cmd == "foobar -vvv"
+
+    def test_capture_string_std(self, monkeypatch):
+        monkeypatch.setattr(
+            "anchore_engine.utils.subprocess.Popen",
+            FakePopen(0, "stdout\nline", "stderr\nline"),
+        )
+        stdout, stderr = run_check(["ls"])
+        assert stdout == "stdout\nline"
+        assert stderr == "stderr\nline"
+
+    def test_capture_bytes_std(self, monkeypatch):
+        monkeypatch.setattr(
+            "anchore_engine.utils.subprocess.Popen",
+            FakePopen(0, b"stdout\nline", b"stderr\nline"),
+        )
+        stdout, stderr = run_check(["ls"])
+        assert stdout == "stdout\nline"
+        assert stderr == "stderr\nline"
+
+    def test_log_stdout(self, monkeypatch):
+        monkeypatch.setattr(
+            "anchore_engine.utils.subprocess.Popen",
+            FakePopen(0, "stdout\nline", b"stderr\nline"),
+        )
+
+        debug_log = Capture()
+        monkeypatch.setattr("anchore_engine.utils.logger.debug", debug_log)
+        stdout, stderr = run_check(["ls"])
+        assert debug_log.calls[0]["args"] == ("running cmd: %s", "ls")
+        assert debug_log.calls[1]["args"] == ("stdout: %s", "stdout")
+        assert debug_log.calls[2]["args"] == (
+            "stdout: %s",
+            "line",
+        )
+
+    def test_log_stderr_does_not_log(self, monkeypatch):
+        # a 0 exit status doesn't log stderr
+        monkeypatch.setattr(
+            "anchore_engine.utils.subprocess.Popen",
+            FakePopen(0, "stdout\nline", "stderr\nline"),
+        )
+
+        error_log = Capture()
+        monkeypatch.setattr("anchore_engine.utils.logger.error", error_log)
+        stdout, stderr = run_check(["ls"])
+        assert error_log.calls == []
+
+    def test_raises_on_non_zero(self, monkeypatch):
+        # a 0 exit status doesn't log stderr
+        monkeypatch.setattr(
+            "anchore_engine.utils.subprocess.Popen",
+            FakePopen(100, "gathering info", "error! bad input"),
+        )
+
+        error_log = Capture()
+        monkeypatch.setattr("anchore_engine.utils.logger.error", error_log)
+        with pytest.raises(CommandException) as error:
+            stdout, stderr = run_check(["ls"])
+
+        assert error.value.msg == "Non-zero exit status code when running subprocess"
+
+    def test_non_zero_doesnt_log_error(self, monkeypatch):
+        # at debug levels the stderr output is already logged
+        # set the log level to 4 (DEBUG)
+        monkeypatch.setattr("anchore_engine.utils.logger.log_level", 4)
+        monkeypatch.setattr(
+            "anchore_engine.utils.subprocess.Popen",
+            FakePopen(100, "gathering info", "error! bad input"),
+        )
+
+        error_log = Capture()
+        debug_log = Capture()
+        monkeypatch.setattr("anchore_engine.utils.logger.error", error_log)
+        monkeypatch.setattr("anchore_engine.utils.logger.debug", debug_log)
+        with pytest.raises(CommandException):
+            stdout, stderr = run_check(["ls"])
+
+        assert len(error_log.calls) == 0
+        assert len(debug_log.calls) == 3
+
+    def test_non_zero_logs_error(self, monkeypatch):
+        # set the log level to 2 (WARNING)
+        monkeypatch.setattr("anchore_engine.utils.logger.log_level", 2)
+        monkeypatch.setattr(
+            "anchore_engine.utils.subprocess.Popen",
+            FakePopen(100, "gathering info", "error! bad input"),
+        )
+
+        error_log = Capture()
+        debug_log = Capture()
+        monkeypatch.setattr("anchore_engine.utils.logger.error", error_log)
+        monkeypatch.setattr("anchore_engine.utils.logger.debug", debug_log)
+        with pytest.raises(CommandException):
+            stdout, stderr = run_check(["ls"])
+
+        assert len(error_log.calls) == 1


### PR DESCRIPTION
**What this PR does / why we need it**: Adds logging support for `syft` calls via `subprocess.Popen`


**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: closes #722 

**Special notes**:

* Creates a new `run_check()` helper to handle the logging. There are other utilities (like `skopeo_wrapper`) that can now use this, but this PR didn't update them to keep the down the size/scope.

* Adds a new exception to capture errors from failed `Popen()` calls to replace the other exceptions that had lots of information that was not used at all

* Removes the try/except blocks with exceptions that were granular but are rewritten at the end of `localanchore_standalone`

* Adds tests to the new utility to ensure that the logging calls are done automatically: always logs stdout at DEBUG levels, and adds stderr only when there are non-zero exit status at ERROR level

Note: DNM for now, since the target branch is about to be merged into master


