### PR TITLE
Safely dig for collections in syft analyzer mappers

### DIFF
--- a/anchore_engine/analyzers/syft/handlers/alpine.py
+++ b/anchore_engine/analyzers/syft/handlers/alpine.py
@@ -33,15 +33,15 @@ def _all_package_info(findings, artifact):
     pkg_value = {
         "name": name,
         "version": version,
-        "sourcepkg": dig(artifact, "metadata", "originPackage", default="N/A") or "N/A",
-        "arch": dig(artifact, "metadata", "architecture", default="N/A") or "N/A",
-        "origin": dig(artifact, "metadata", "maintainer", default="N/A") or "N/A",
+        "sourcepkg": dig(artifact, "metadata", "originPackage", force_default="N/A"),
+        "arch": dig(artifact, "metadata", "architecture", force_default="N/A"),
+        "origin": dig(artifact, "metadata", "maintainer", force_default="N/A"),
         "release": release,
-        "size": str(dig(artifact, "metadata", "installedSize", default="N/A")) or "N/A",
-        "license": dig(artifact, "metadata", "license", default="N/A") or "N/A",
+        "size": str(dig(artifact, "metadata", "installedSize", force_default="N/A")),
+        "license": dig(artifact, "metadata", "license", force_default="N/A"),
         "type": "APKG",
         "files": [
-            f.get("path") for f in dig(artifact, "metadata", "files", default=[])
+            f.get("path") for f in dig(artifact, "metadata", "files", force_default=[])
         ],
     }
 
@@ -70,7 +70,7 @@ def _all_packages(findings, artifact):
 
 
 def _all_package_files(findings, artifact):
-    for file in dig(artifact, "metadata", "files", default=[]):
+    for file in dig(artifact, "metadata", "files", force_default=[]):
         original_path = file.get("path")
         if not original_path.startswith("/"):
             # the 'alpine-baselayout' package is installed relative to root,

--- a/anchore_engine/analyzers/syft/handlers/debian.py
+++ b/anchore_engine/analyzers/syft/handlers/debian.py
@@ -54,7 +54,7 @@ def _all_package_info(findings, artifact):
     pkg_value = {
         "version": version,
         "sourcepkg": source,
-        "arch": dig(artifact, "metadata", "architecture", default="N/A") or "N/A",
+        "arch": dig(artifact, "metadata", "architecture", force_default="N/A"),
         "origin": maintainer or "N/A",
         "release": "N/A",
         "size": str(size),
@@ -86,7 +86,7 @@ def _all_packages(findings, artifact):
 
 
 def _all_package_files(findings, artifact):
-    for file in dig(artifact, "metadata", "files", default=[]):
+    for file in dig(artifact, "metadata", "files", force_default=[]):
         original_path = file.get("path")
         if not original_path.startswith("/"):
             # the 'alpine-baselayout' package is installed relative to root,

--- a/anchore_engine/analyzers/syft/handlers/gem.py
+++ b/anchore_engine/analyzers/syft/handlers/gem.py
@@ -31,11 +31,11 @@ def translate_and_save_entry(findings, artifact):
     pkg_value = {
         "name": name,
         "versions": versions,
-        "latest": dig(artifact, "version", default=""),
-        "sourcepkg": dig(artifact, "metadata", "homepage", default=""),
-        "files": dig(artifact, "metadata", "files", default=[]),
-        "origins": dig(artifact, "metadata", "authors", default=[]),
-        "lics": dig(artifact, "metadata", "licenses", default=[]),
+        "latest": dig(artifact, "version", force_default=""),
+        "sourcepkg": dig(artifact, "metadata", "homepage", force_default=""),
+        "files": dig(artifact, "metadata", "files", force_default=[]),
+        "origins": dig(artifact, "metadata", "authors", force_default=[]),
+        "lics": dig(artifact, "metadata", "licenses", force_default=[]),
     }
 
     save_entry(findings, pkg_value, pkg_key)

--- a/anchore_engine/analyzers/syft/handlers/npm.py
+++ b/anchore_engine/analyzers/syft/handlers/npm.py
@@ -24,9 +24,9 @@ def translate_and_save_entry(findings, artifact):
     """
     pkg_key = artifact["locations"][0]["path"]
     name = artifact["name"]
-    homepage = dig(artifact, "metadata", "homepage", default="")
-    author = dig(artifact, "metadata", "author", default="")
-    authors = dig(artifact, "metadata", "authors", default=[])
+    homepage = dig(artifact, "metadata", "homepage", force_default="")
+    author = dig(artifact, "metadata", "author", force_default="")
+    authors = dig(artifact, "metadata", "authors", force_default=[])
     origins = [] if not author else [author]
     origins.extend(authors)
 
@@ -34,9 +34,9 @@ def translate_and_save_entry(findings, artifact):
         "name": name,
         "versions": [artifact["version"]],
         "latest": artifact["version"],
-        "sourcepkg": dig(artifact, "metadata", "url", default=homepage),
+        "sourcepkg": dig(artifact, "metadata", "url", force_default=homepage),
         "origins": origins,
-        "lics": dig(artifact, "metadata", "licenses", default=[]),
+        "lics": dig(artifact, "metadata", "licenses", force_default=[]),
     }
 
     # inject the artifact document into the "raw" analyzer document

--- a/anchore_engine/analyzers/syft/handlers/python.py
+++ b/anchore_engine/analyzers/syft/handlers/python.py
@@ -36,13 +36,13 @@ def translate_and_save_entry(findings, artifact):
         pkg_key_name = name
 
     pkg_key = os.path.join(site_pkg_root, pkg_key_name)
-    origin = dig(artifact, "metadata", "author", default="")
+    origin = dig(artifact, "metadata", "author", force_default="")
     email = dig(artifact, "metadata", "authorEmail", default=None)
     if email:
         origin += " <%s>" % email
 
     files = []
-    for file in dig(artifact, "metadata", "files", default=[]):
+    for file in dig(artifact, "metadata", "files", force_default=[]):
         files.append(os.path.join(site_pkg_root, file["path"]))
 
     # craft the artifact document
@@ -52,7 +52,7 @@ def translate_and_save_entry(findings, artifact):
         "latest": artifact["version"],
         "files": files,
         "origin": origin,
-        "license": dig(artifact, "metadata", "license", default=""),
+        "license": dig(artifact, "metadata", "license", force_default=""),
         "location": site_pkg_root,
         "type": "python",
     }

--- a/anchore_engine/analyzers/syft/handlers/rpm.py
+++ b/anchore_engine/analyzers/syft/handlers/rpm.py
@@ -31,12 +31,12 @@ def _all_package_info(findings, artifact):
     pkg_value = {
         "type": "rpm",
         "version": version,
-        "arch": dig(artifact, "metadata", "architecture", default="x86_64"),
-        "sourcepkg": dig(artifact, "metadata", "sourceRpm", default="N/A"),
-        "origin": dig(artifact, "metadata", "vendor", default="Centos"),
+        "arch": dig(artifact, "metadata", "architecture", force_default="x86_64"),
+        "sourcepkg": dig(artifact, "metadata", "sourceRpm", force_default="N/A"),
+        "origin": dig(artifact, "metadata", "vendor", force_default="Centos"),
         "release": release,
-        "size": str(dig(artifact, "metadata", "size", default="N/A")),
-        "license": dig(artifact, "metadata", "license", default="N/A"),
+        "size": str(dig(artifact, "metadata", "size", force_default="N/A")),
+        "license": dig(artifact, "metadata", "license", force_default="N/A"),
     }
     if pkg_value["arch"] == "amd64":
         pkg_value["arch"] = "x86_64"
@@ -52,6 +52,6 @@ def _all_packages(findings, artifact):
 
 
 def _all_package_files(findings, artifact):
-    for file in dig(artifact, "metadata", "files", default=[]):
+    for file in dig(artifact, "metadata", "files", force_default=[]):
         pkgfile = file.get("path")
         findings["package_list"]["pkgfiles.all"]["base"][pkgfile] = "RPMFILE"

--- a/anchore_engine/analyzers/utils.py
+++ b/anchore_engine/analyzers/utils.py
@@ -924,7 +924,13 @@ def dig(target, *keys, **kwargs):
             elif "default" in kwargs:
                 return kwargs["default"]
             else:
-                return None
+                end_of_chain = None
+                break
+
+    # we may have found a falsy value in the collection at the given key
+    # and the caller has specified to return a default value in this case in it's place.
+    if not end_of_chain and "force_default" in kwargs:
+        end_of_chain = kwargs["force_default"]
 
     return end_of_chain
 

--- a/tests/unit/anchore_engine/analyzers/test_utils.py
+++ b/tests/unit/anchore_engine/analyzers/test_utils.py
@@ -40,3 +40,18 @@ class TestDig:
     def test_missing_index_with_fail(self, mixed_data):
         with pytest.raises(IndexError):
             assert dig(mixed_data, "a", "d", 111, fail=True)
+
+    def test_none_value(self):
+        assert dig({"a": None}, "a") == None
+
+    def test_empty_value_with_force_default(self):
+        assert dig({"a": ""}, "a", force_default=12) == 12
+
+    def test_false_value_with_force_default(self):
+        assert dig({"a": False}, "a", force_default=12) == 12
+
+    def test_explicit_empty_value_with_force_default(self):
+        assert dig({"a": None}, "a", force_default=12) == 12
+
+    def test_none_empty_value_with_force_default(self):
+        assert dig({"a": "b!"}, "a", force_default=12) == "b!"


### PR DESCRIPTION
@dakaneye noticed with the merge of #738 that some images were failing analysis and being deleted from the system:
```
2020-11-27 19:29:17+0000 [-] [Thread-1175] [anchore_engine.clients.localanchore_standalone/delete_staging_dirs()] [DEBUG] removing dir: unpackdir : /analysis_scratch/351471f8-5c8e-4abd-98a7-5bb38cc530d4
2020-11-27 19:29:18+0000 [-] Traceback (most recent call last):
2020-11-27 19:29:18+0000 [-]   File "/usr/local/lib/python3.8/site-packages/anchore_engine/clients/localanchore_standalone.py", line 1279, in analyze_image
2020-11-27 19:29:18+0000 [-]     analyzer_report = run_anchore_analyzers(
2020-11-27 19:29:18+0000 [-]   File "/usr/local/lib/python3.8/site-packages/anchore_engine/clients/localanchore_standalone.py", line 1051, in run_anchore_analyzers
2020-11-27 19:29:18+0000 [-]     syft_results = anchore_engine.analyzers.syft.catalog_image(
2020-11-27 19:29:18+0000 [-]   File "/usr/local/lib/python3.8/site-packages/anchore_engine/analyzers/syft/__init__.py", line 37, in catalog_image
2020-11-27 19:29:18+0000 [-]     handler.translate_and_save_entry(findings, artifact)
2020-11-27 19:29:18+0000 [-]   File "/usr/local/lib/python3.8/site-packages/anchore_engine/analyzers/syft/handlers/debian.py", line 17, in translate_and_save_entry
2020-11-27 19:29:18+0000 [-]     _all_package_files(findings, artifact)
2020-11-27 19:29:18+0000 [-]   File "/usr/local/lib/python3.8/site-packages/anchore_engine/analyzers/syft/handlers/debian.py", line 89, in _all_package_files
2020-11-27 19:29:18+0000 [-]     for file in dig(artifact, "metadata", "files", default=[]):
2020-11-27 19:29:18+0000 [-] TypeError: 'NoneType' object is not iterable
2020-11-27 19:29:18+0000 [-]
2020-11-27 19:29:18+0000 [-] During handling of the above exception, another exception occurred:
2020-11-27 19:29:18+0000 [-]
2020-11-27 19:29:18+0000 [-] Traceback (most recent call last):
2020-11-27 19:29:18+0000 [-]   File "/usr/local/lib/python3.8/site-packages/anchore_engine/services/analyzer/__init__.py", line 195, in process_analyzer_job
2020-11-27 19:29:18+0000 [-]     image_data = perform_analyze(
2020-11-27 19:29:18+0000 [-]   File "/usr/local/lib/python3.8/site-packages/anchore_engine/services/analyzer/__init__.py", line 48, in perform_analyze
2020-11-27 19:29:18+0000 [-]     return perform_analyze_nodocker(
2020-11-27 19:29:18+0000 [-]   File "/usr/local/lib/python3.8/site-packages/anchore_engine/services/analyzer/__init__.py", line 122, in perform_analyze_nodocker
2020-11-27 19:29:18+0000 [-]     analyzed_image_report, manifest_raw = localanchore_standalone.analyze_image(
2020-11-27 19:29:18+0000 [-]   File "/usr/local/lib/python3.8/site-packages/anchore_engine/clients/localanchore_standalone.py", line 1283, in analyze_image
2020-11-27 19:29:18+0000 [-]     raise AnalyzerError(cause=err, pull_string=pullstring, tag=fulltag)
2020-11-27 19:29:18+0000 [-] anchore_engine.clients.localanchore_standalone.AnalyzerError: Failed to run image through analyzers (docker.io/python@sha256:c1844ec02077272c56cd1782cc96c1e8000ad2848bbd48ec87ae92019a072099) - exception: 'NoneType' object is not iterable
```

This PR fixes this behavior by ensuring callers of `dig` within the syft analyzer handlers never assume that `None` cannot be returned, especially when collections are expected to be returned. This pattern is all over the place in the handlers (`dig(..., default="n/a") or "n/a"`), instead of adding to the pile this PR adds another kwarg to `dig` to force a default when a falsy value if found (replacing `dig(..., default="n/a") or "n/a"` with `dig(..., force_default="n/a")`).