### PR TITLE
[DO NOT MERGE] Imports API swagger updates

### DIFF
--- a/anchore_engine/services/apiext/swagger/swagger.yaml
+++ b/anchore_engine/services/apiext/swagger/swagger.yaml
@@ -495,7 +495,7 @@ paths:
       x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.images
       operationId: import_image_archive
       x-anchore-authz-action: importImage
-      summary: Import an anchore image tar.gz archive file.
+      summary: Import an anchore image tar.gz archive file. This is a deprecated API replaced by the "/imports/images" route
       consumes:
         - multipart/form-data
       parameters:
@@ -610,7 +610,6 @@ paths:
   /images/{imageDigest}/check:
     get:
       tags:
-      - Images
       - Policy Evaluation
       x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.images
       operationId: get_image_policy_check
@@ -655,7 +654,6 @@ paths:
   /images/by_id/{imageId}/check:
     get:
       tags:
-      - Images
       - Policy Evaluation
       x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.images
       operationId: get_image_policy_check_by_imageId
@@ -696,9 +694,7 @@ paths:
   /images/{imageDigest}/vuln:
     get:
       tags:
-      - Images
       - Vulnerabilities
-      - Queries
       x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.images
       operationId: get_image_vulnerability_types
       x-anchore-authz-action: getImage
@@ -727,9 +723,7 @@ paths:
   /images/{imageDigest}/vuln/{vtype}:
     get:
       tags:
-      - Images
       - Vulnerabilities
-      - Queries
       x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.images
       operationId: get_image_vulnerabilities_by_type
       x-anchore-authz-action: getImage
@@ -764,9 +758,7 @@ paths:
   /images/by_id/{imageId}/vuln:
     get:
       tags:
-      - Images
       - Vulnerabilities
-      - Queries
       x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.images
       operationId: get_image_vulnerability_types_by_imageId
       x-anchore-authz-action: getImage
@@ -795,9 +787,7 @@ paths:
   /images/by_id/{imageId}/vuln/{vtype}:
     get:
       tags:
-      - Images
       - Vulnerabilities
-      - Queries
       x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.images
       operationId: get_image_vulnerabilities_by_type_imageId
       x-anchore-authz-action: getImage
@@ -824,9 +814,7 @@ paths:
   /images/{imageDigest}/content:
     get:
       tags:
-      - Images
       - Image Content
-      - Queries
       x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.images
       operationId: list_image_content
       x-anchore-authz-action: getImage
@@ -851,9 +839,7 @@ paths:
   /images/by_id/{imageId}/content:
     get:
       tags:
-      - Images
       - Image Content
-      - Queries
       x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.images
       operationId: list_image_content_by_imageid
       x-anchore-authz-action: getImage
@@ -878,9 +864,7 @@ paths:
   /images/{imageDigest}/content/{ctype}:
     get:
       tags:
-      - Images
       - Image Content
-      - Queries
       x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.images
       operationId: get_image_content_by_type
       x-anchore-authz-action: getImage
@@ -907,9 +891,7 @@ paths:
   /images/{imageDigest}/content/files:
     get:
       tags:
-      - Images
       - Image Content
-      - Queries
       x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.images
       operationId: get_image_content_by_type_files
       x-anchore-authz-action: getImage
@@ -932,9 +914,7 @@ paths:
   /images/{imageDigest}/content/java:
     get:
       tags:
-      - Images
       - Image Content
-      - Queries
       x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.images
       operationId: get_image_content_by_type_javapackage
       x-anchore-authz-action: getImage
@@ -957,9 +937,7 @@ paths:
   /images/{imageDigest}/content/malware:
     get:
       tags:
-        - Images
         - Image Content
-        - Queries
       x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.images
       operationId: get_image_content_by_type_malware
       x-anchore-authz-action: getImage
@@ -982,9 +960,7 @@ paths:
   /images/by_id/{imageId}/content/{ctype}:
     get:
       tags:
-      - Images
       - Image Content
-      - Queries
       x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.images
       operationId: get_image_content_by_type_imageId
       x-anchore-authz-action: getImage
@@ -1011,9 +987,7 @@ paths:
   /images/by_id/{imageId}/content/files:
     get:
       tags:
-      - Images
       - Image Content
-      - Queries
       x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.images
       operationId: get_image_content_by_type_imageId_files
       x-anchore-authz-action: getImage
@@ -1036,9 +1010,7 @@ paths:
   /images/by_id/{imageId}/content/java:
     get:
       tags:
-      - Images
       - Image Content
-      - Queries
       x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.images
       operationId: get_image_content_by_type_imageId_javapackage
       x-anchore-authz-action: getImage
@@ -1122,7 +1094,6 @@ paths:
     get:
       tags:
       - Images
-      - Queries
       x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.images
       operationId: list_image_metadata
       x-anchore-authz-action: getImage
@@ -1148,7 +1119,6 @@ paths:
     get:
       tags:
       - Images
-      - Queries
       x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.images
       operationId: get_image_metadata_by_type
       x-anchore-authz-action: getImage
@@ -1533,7 +1503,6 @@ paths:
   /system/services:
     get:
       tags:
-      - System
       - Services
       x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.system
       operationId: list_services
@@ -1551,7 +1520,6 @@ paths:
   /system/services/{servicename}:
     get:
       tags:
-      - System
       - Services
       x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.system
       operationId: get_services_by_name
@@ -1574,7 +1542,6 @@ paths:
   /system/services/{servicename}/{hostid}:
     get:
       tags:
-      - System
       - Services
       x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.system
       operationId: get_services_by_name_and_host
@@ -1600,7 +1567,6 @@ paths:
             $ref: "#/definitions/ApiErrorResponse"
     delete:
       tags:
-      - System
       - Services
       x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.system
       operationId: delete_service
@@ -1629,7 +1595,6 @@ paths:
       operationId: describe_policy
       x-anchore-authz-action: None
       tags:
-      - System
       - Policy
       responses:
         200:
@@ -1819,7 +1784,6 @@ paths:
     get:
       tags:
       - Vulnerabilities
-      - Queries
       x-swagger-router-controller: "anchore_engine.services.apiext.api.controllers.query"
       operationId: query_images_by_vulnerability
       x-anchore-authz-action: listImages
@@ -1928,7 +1892,6 @@ paths:
     get:
       tags:
       - Vulnerabilities
-      - Queries
       x-swagger-router-controller: "anchore_engine.services.apiext.api.controllers.query"
       operationId: query_vulnerabilities
       x-anchore-authz-action: None
@@ -2641,6 +2604,293 @@ paths:
           schema:
             $ref: "#/definitions/ApiErrorResponse"
       x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.system
+  /imports/images:
+    post:
+      tags:
+      - Imports
+      x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.image_imports
+      operationId: create_operation
+      x-anchore-authz-action: importImage
+      summary: "Begin the import of an image analyzed by Syft into the system"
+      produces:
+        - "application/json"
+      responses:
+        200:
+          description: "success"
+          schema:
+            $ref: "#/definitions/ImageImportOperation"
+        500:
+          description: "Internal Error"
+    get:
+      tags:
+      - Imports
+      x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.image_imports
+      operationId: list_operations
+      x-anchore-authz-action: importImage
+      summary: "Lists in-progress imports"
+      produces:
+        - "application/json"
+      responses:
+        200:
+          description: "success"
+          schema:
+            $ref: "#/definitions/ImageImports"
+        500:
+          description: "Internal Error"
+  /imports/images/{operation_id}:
+    get:
+      tags:
+      - Imports
+      x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.image_imports
+      operationId: get_operation
+      x-anchore-authz-action: importImage
+      summary: "Get detail on a single import"
+      produces:
+        - "application/json"
+      parameters:
+        - name: operation_id
+          in: path
+          type: string
+          required: true
+      responses:
+        200:
+          description: "success"
+          schema:
+            $ref: "#/definitions/ImageImportOperation"
+        500:
+          description: "Internal Error"
+    delete:
+      tags:
+      - Imports
+      x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.image_imports
+      operationId: invalidate_operation
+      x-anchore-authz-action: importImage
+      summary: "Invalidate operation ID so it can be garbage collected"
+      produces:
+        - "application/json"
+      parameters:
+        - name: operation_id
+          in: path
+          type: string
+          required: true
+      responses:
+        200:
+          description: "success"
+          schema:
+            $ref: "#/definitions/ImageImportOperation"
+        500:
+          description: "Internal Error"
+  /imports/images/{operation_id}/packages:
+    get:
+      tags:
+      - Imports
+      x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.image_imports
+      operationId: list_import_packages
+      x-anchore-authz-action: importImage
+      summary: "List uploaded package manifests"
+      produces:
+        - "application/json"
+      parameters:
+        - name: operation_id
+          in: path
+          type: string
+          required: true
+      responses:
+        200:
+          description: "success"
+          schema:
+            $ref: "#/definitions/ImportContentDigestList"
+        500:
+          description: "Internal Error"
+    post:
+      tags:
+      - Imports
+      x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.image_imports
+      operationId: import_image_packages
+      x-anchore-authz-action: importImage
+      summary: "Begin the import of an image analyzed by Syft into the system"
+      produces:
+        - "application/json"
+      consumes:
+        - "application/json"
+      parameters:
+        - name: operation_id
+          in: path
+          type: string
+          required: true
+        - name: sbom
+          in: body
+          required: true
+          schema:
+            $ref: "#/definitions/ImagePackageManifest"
+      responses:
+        200:
+          description: "success"
+          schema:
+            $ref: "#/definitions/ImageImportContentResponse"
+        500:
+          description: "Internal Error"
+  /imports/images/{operation_id}/dockerfile:
+    get:
+      tags:
+      - Imports
+      x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.image_imports
+      operationId: list_import_dockerfiles
+      x-anchore-authz-action: importImage
+      summary: "List uploaded dockerfiles"
+      produces:
+        - "application/json"
+      parameters:
+        - name: operation_id
+          in: path
+          type: string
+          required: true
+      responses:
+        200:
+          description: "success"
+          schema:
+            $ref: "#/definitions/ImportContentDigestList"
+        500:
+          description: "Internal Error"
+    post:
+      tags:
+      - Imports
+      x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.image_imports
+      operationId: import_image_dockerfile
+      x-anchore-authz-action: importImage
+      summary: "Begin the import of an image analyzed by Syft into the system"
+      produces:
+        - "application/json"
+      consumes:
+        - "text/plain; utf-8"
+      parameters:
+        - name: operation_id
+          in: path
+          type: string
+          required: true
+        - in: body
+          name: contents
+          required: true
+          schema:
+            type: string
+
+      responses:
+        200:
+          description: "success"
+          schema:
+            $ref: "#/definitions/ImageImportContentResponse"
+        500:
+          description: "Internal Error"
+  /imports/images/{operation_id}/manifest:
+    get:
+      tags:
+      - Imports
+      x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.image_imports
+      operationId: list_import_image_manifests
+      x-anchore-authz-action: importImage
+      summary: "List uploaded image manifests"
+      produces:
+        - "application/json"
+      parameters:
+        - name: operation_id
+          in: path
+          type: string
+          required: true
+      responses:
+        200:
+          description: "success"
+          schema:
+            $ref: "#/definitions/ImportContentDigestList"
+        500:
+          description: "Internal Error"
+    post:
+      tags:
+      - Imports
+      x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.image_imports
+      operationId: import_image_manifest
+      x-anchore-authz-action: importImage
+      summary: "Import a docker or OCI distribution manifest to associate with the image"
+      produces:
+        - "application/json"
+      consumes:
+        - "application/vnd.oci.image.manifest.v1+json"
+        - "application/vnd.docker.distribution.manifest.v2+json"
+        - "application/vnd.docker.distribution.manifest.v1+json" # Older Docker spec
+        - "application/vnd.docker.distribution.manifest.v1+prettyjws" # Signed version
+      parameters:
+        - name: operation_id
+          in: path
+          type: string
+          required: true
+        - in: body
+          name: contents
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: "success"
+          schema:
+            $ref: "#/definitions/ImageImportContentResponse"
+        500:
+          description: "Internal Error"
+  /imports/images/{operation_id}/parent_manifest:
+    get:
+      tags:
+      - Imports
+      x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.image_imports
+      operationId: list_import_parent_manifests
+      x-anchore-authz-action: importImage
+      summary: "List uploaded parent manifests (manifest lists for a tag)"
+      produces:
+        - "application/json"
+      parameters:
+        - name: operation_id
+          in: path
+          type: string
+          required: true
+        - in: body
+          name: contents
+          required: true
+          schema:
+            type: string
+
+      responses:
+        200:
+          description: "success"
+          schema:
+            $ref: "#/definitions/ImportContentDigestList"
+        500:
+          description: "Internal Error"
+    post:
+      tags:
+      - Imports
+      x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.image_imports
+      operationId: import_image_parent_manifest
+      x-anchore-authz-action: importImage
+      summary: "Import a docker or OCI distribution manifest list to associate with the image"
+      produces:
+        - "application/json"
+      consumes:
+        - "application/vnd.docker.distribution.manifest.list.v2+json"
+        - "application/vnd.oci.image.index.v1+json"
+      parameters:
+        - name: operation_id
+          in: path
+          type: string
+          required: true
+        - in: body
+          name: contents
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: "success"
+          schema:
+            $ref: "#/definitions/ImageImportContentResponse"
+        500:
+          description: "Internal Error"
 definitions:
   PaginationProperties:
     type: object
@@ -2867,6 +3117,8 @@ definitions:
         $ref: "#/definitions/RegistryDigestSource"
       archive:
         $ref: "#/definitions/AnalysisArchiveSource"
+      import:
+        $ref: "#/definitions/ImageImportManifest"
   RegistryTagSource:
     type: object
     description: An image reference using a tag in a registry, this is the most common source type.
@@ -2911,6 +3163,11 @@ definitions:
         type: string
         description: The image digest identify the analysis. Archived analyses are based on digest, tag records are restored as analysis is restored.
         pattern: "^sha256:[a-fA-F0-9]{64}$"
+  LocalAnalysisSource:
+    type: object
+    properties:
+      digest:
+        type: string
   PolicyBundle:
     description: A bundle containing a set of policies, whitelists, and rules for mapping them to specific images
     type: object
@@ -2970,9 +3227,6 @@ definitions:
         type: string
       trigger_id:
         type: string
-      expires_on:
-        type: string
-        format: "date-time"
   PolicyRule:
     type: object
     description: A rule that defines and decision value if the match is found true for a given image.
@@ -3506,6 +3760,12 @@ definitions:
         x-nullable: True
       subscription_type:
         type: string
+        enum:
+        - policy_eval
+        - tag_update
+        - vuln_update
+        - repo_update
+        - analysis_update
   Subscription:
     description: Subscription entry
     type: object
@@ -3516,6 +3776,12 @@ definitions:
       subscription_type:
         type: string
         description: The type of the subscription
+        enum:
+        - policy_eval
+        - tag_update
+        - vuln_update
+        - repo_update
+        - analysis_update
       subscription_value:
         type: string
         x-nullable: True
@@ -3723,7 +3989,7 @@ definitions:
         description: Error code name
       description:
         type: string
-        description: Description of the error code
+        description: Description of the error code 
   GateSpec:
     type: object
     description: A description of the set of gates available in this engine and the triggers and parameters supported
@@ -4196,18 +4462,6 @@ definitions:
       last_updated:
         type: string
         format: date-time
-      exclude:
-        $ref: "#/definitions/AnalysisArchiveTransitionRuleExclude"
-  AnalysisArchiveTransitionRuleExclude:
-    type: object
-    description: Which Images to exclude from auto-archiving logic
-    properties:
-      selector:
-        $ref: "#/definitions/ImageSelector"
-      expiration_days:
-        type: integer
-        description: How long the image selected will be excluded from the archive transition
-        default: -1
   AnalysisArchiveTransitionHistory:
     type: object
     description: A rule for auto-archiving image analysis by time and/or tag-history
@@ -4587,3 +4841,181 @@ definitions:
         type: object
       image_digest:
         type: string
+  ImageImportOperation:
+    type: object
+    description: An import record, creating a unique identifier for referencing the operation as well as its state
+    properties:
+      uuid:
+        type: string
+      status:
+        type: string
+        enum:
+          - pending
+          - queued
+          - processing
+          - complete
+          - failed
+          - expired
+      expires_at:
+        type: string
+        format: date-time
+      created_at:
+        type: string
+        format: date-time
+  ImageImportContentResponse:
+    type: object
+    properties:
+      digest:
+        type: string
+      created_at:
+        type: string
+        format: date-time
+  ImageContentDeleteResponse:
+    type: object
+  ImageImportManifest:
+    type: object
+    properties:
+      contents:
+        $ref: "#/definitions/ImportContentDigests"
+      tags:
+        type: array
+        items:
+          type: string
+          description: Full docker reference tags
+          example: "docker.io/library/nginx:latest"
+      digest:
+        type: string
+      parent_digest:
+        type: string
+        description: The digest of the images's manifest-list parent if it was accessed from a multi-arch tag where the tag pointed to a manifest-list. This allows preservation of that relationship in the data
+      local_image_id:
+        type: string
+        description: An "imageId" as used by Docker if available
+      metadata:
+        $ref: "#/definitions/ImageImportManifestMetadata"
+  ImageImportManifestMetadata:
+    type: object
+    properties:
+      layers:
+        type: array
+        items:
+          $ref: "#/definitions/ImageImportLayerMetadata"
+      platform:
+        $ref: "#/definitions/ImageImportPlatform"
+      created_at:
+        type: string
+        format: date-time
+        description: The date of the image build/tagging to allow insertion into the tag history based on another timestamp than the record creation in Anchore. Use this with caution.
+  ImageImportPlatform:
+    type: object
+    description: An image platform is a combination of an OS and an architecture
+    properties:
+      os:
+        type: string
+        example: linux
+      architecture:
+        type: string
+        example: amd64
+  ImageImportLayerMetadata:
+    type: object
+    properties:
+      digest:
+        type: string
+      size:
+        type: integer
+      location:
+        type: string
+  ImportContentDigests:
+    type: object
+    required:
+      - packages
+    description: Digest of content to use in the final import
+    properties:
+      packages:
+        type: string
+        description: Digest to use for the packages content
+      manifest:
+        type: string
+        description: Digest to reference content for the image manifest
+      parent_manifest:
+        type: string
+        description: Digest for reference content for parent manifest
+      dockerfile:
+        type: string
+        description: Digest for reference content for dockerfile
+  Annotations:
+    type: object
+    description: Simple key/value pairs where the value may be optional
+  FinalizeImageImportResponse:
+    type: object
+    properties:
+      uuid:
+        type: string
+      status:
+        type: string
+  ImageImports:
+    type: array
+    items:
+      $ref: "#/definitions/ImageImportOperation"
+  ImagePackageManifest:
+    items:
+      $ref: "#/definitions/SyftPackage"
+    type: array
+  ImportContentDigestList:
+    type: array
+    items:
+      type: string
+      description: String digest of an uploaded content
+  SyftLocation:
+    required:
+      - path
+    properties:
+      path:
+        type: string
+      layerID:
+        type: string
+    additionalProperties: false
+    type: object
+  SyftPackage:
+    required:
+      - name
+      - version
+      - type
+      - foundBy
+      - locations
+      - licenses
+      - language
+      - cpes
+      - purl
+      - metadataType
+    properties:
+      name:
+        type: string
+      version:
+        type: string
+      type:
+        type: string
+      foundBy:
+        type: string
+      locations:
+        items:
+          "$ref": "#/definitions/SyftLocation"
+        type: array
+      licenses:
+        items:
+          type: string
+        type: array
+      language:
+        type: string
+      cpes:
+        items:
+          type: string
+        type: array
+      purl:
+        type: string
+      metadataType:
+        type: string
+      metadata:
+        additionalProperties: true
+    additionalProperties: false
+    type: object


### PR DESCRIPTION
The target base branch will be changed to the imports API branch in the future. This draft PR is to show the suggested changes so far (and when we change the target base branch the difference between the original document provided by @zhill  will be more apparent in the code diff).

Summary of changes:
- Ensures that tags in the swagger document are singular. The OpenAPI code generation tool assumes that the tags will be used to hint which service object an API function should be provided under. If multiple tags are provided these functions are duplicated, which is incorrect behavior. The source of truth for an API should be with a static swagger document instead of forcing consumers to modify it for use. (shout out if there is a good technical reason for multiple tags if I missed it, I could only see that it would change the way it's presented on a swagger page and really nothing else)
- Adds `SyftLocation` and `SyftPackage` definitions
- Specifies for import endpoints that take plain text or raw json bytes that the body content is required. This allows for the generated code to accept a body variable.

