### PR TITLE
Have skopeo remove signatures on signed images when copying them

### DIFF
--- a/anchore_engine/clients/skopeo_wrapper.py
+++ b/anchore_engine/clients/skopeo_wrapper.py
@@ -63,9 +63,14 @@ def manifest_to_digest_shellout(rawmanifest):
     return ret
 
 
-def copy_image_from_docker_archive(source_archive, dest_dir):
-    cmdstr = "skopeo copy docker-archive:{} oci:{}:image --remove-signatures".format(
-        source_archive, dest_dir
+def copy_image_from_docker_archive(source_archive, dest_dir, remove_signatures=True):
+    if remove_signatures:
+        remove_signatures_string = "--remove-signatures"
+    else:
+        remove_signatures_string = ""
+
+    cmdstr = "skopeo copy {} docker-archive:{} oci:{}:image".format(
+        remove_signatures_string, source_archive, dest_dir
     )
     cmd = cmdstr.split()
     try:
@@ -96,6 +101,7 @@ def download_image(
     manifest=None,
     parent_manifest=None,
     use_cache_dir=None,
+    remove_signatures=True,
 ):
     try:
         proc_env = os.environ.copy()
@@ -157,6 +163,11 @@ def download_image(
                         os_overrides.insert(0, "windows")
                         break
 
+        if remove_signatures:
+            remove_signatures_string = "--remove-signatures"
+        else:
+            remove_signatures_string = ""
+
         for os_override in os_overrides:
             success = False
             if os_override not in ["", "linux"]:
@@ -175,9 +186,10 @@ def download_image(
             cmd = [
                 "/bin/sh",
                 "-c",
-                "skopeo {} {} copy {} {} {} docker://{} oci:{}:image".format(
+                "skopeo {} {} copy {} {} {} {} docker://{} oci:{}:image".format(
                     os_override_str,
                     global_timeout_str,
+                    remove_signatures_string,
                     tlsverifystr,
                     credstr,
                     cachestr,

--- a/anchore_engine/clients/skopeo_wrapper.py
+++ b/anchore_engine/clients/skopeo_wrapper.py
@@ -64,7 +64,7 @@ def manifest_to_digest_shellout(rawmanifest):
 
 
 def copy_image_from_docker_archive(source_archive, dest_dir):
-    cmdstr = "skopeo copy docker-archive:{} oci:{}:image".format(
+    cmdstr = "skopeo copy docker-archive:{} oci:{}:image --remove-signatures".format(
         source_archive, dest_dir
     )
     cmd = cmdstr.split()


### PR DESCRIPTION
<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**:
Have skopeo remove signatures on signed images when copying them. This is needed because the destination currently does not support signed images, so skopeo will currently refuse to copy them.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #711

**Special notes**:


