### PR TITLE
Fix docker tag validation & epoch to RFC3339 extapi reference

### DIFF
--- a/anchore_engine/services/apiext/swagger/swagger.yaml
+++ b/anchore_engine/services/apiext/swagger/swagger.yaml
@@ -3465,11 +3465,11 @@ definitions:
     description: A metadata detail record for a specific image. Multiple detail records may map a single catalog image.
     properties:
       created_at:
-        # server returning epoch
-        type: number
+        type: string
+        format: date-time
       last_updated:
-        # server returning epoch
-        type: number
+        type: string
+        format: date-time
       fulltag:
         description: "Full docker-pullable tag string referencing the image"
         type: string
@@ -3529,11 +3529,11 @@ definitions:
         items:
           $ref: "#/definitions/ImageDetail"
       last_updated:
-        # server returning epoch
-        type: number
+        type: string
+        format: date-time
       created_at:
-        # server returning epoch
-        type: number
+        type: string
+        format: date-time
       imageDigest:
         type: string
       userId:

--- a/anchore_engine/util/docker.py
+++ b/anchore_engine/util/docker.py
@@ -181,17 +181,19 @@ class DockerImageReference:
         return self.image_id is not None
 
     def tag_pullstring(self):
-        raise Exception(
-            "missing one of registry, repository or tag to construct the pullstring"
-        )
+        if not all((self.registry, self.repository, self.tag)):
+            raise Exception(
+                "missing one of registry, repository or tag to construct the pullstring"
+            )
         return self._tag_pullstring_format.format(
             registry=self.registry, repository=self.repository, tag=self.tag
         )
 
     def digest_pullstring(self):
-        raise Exception(
-            "missing one of registry, repository or digest to construct the digest pullstring"
-        )
+        if not all((self.registry, self.repository, self.tag)):
+            raise Exception(
+                "missing one of registry, repository or tag to construct the pullstring"
+            )
         return self._digest_pullstring_format.format(
             registry=self.registry, repository=self.repository, digest=self.digest
         )


### PR DESCRIPTION
This is a follow up PR to #779 with a couple adjustments:
- add validation condition around docker tag and digest
- changed the type of timestamps on post to /images to expect RFC3339 strings (was epoch before hand)

cc: @zhill 