### PR TITLE
use build_output for all dep binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN set -ex && \
 
 RUN set -ex && \
     echo "installing Syft" && \
-    curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /anchore_engine/bin v0.9.2
+    curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /build_output/deps v0.9.2
 
 # stage RPM dependency binaries
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
@@ -67,9 +67,6 @@ ARG ANCHORE_ENGINE_RELEASE="r0"
 
 # Copy skopeo artifacts from build step
 COPY --from=anchore-engine-builder /build_output /build_output
-
-# Copy syft from build step
-COPY --from=anchore-engine-builder /anchore_engine/bin/syft /anchore_engine/bin/syft
 
 # Container metadata section
 
@@ -174,6 +171,7 @@ RUN set -ex && \
 RUN set -ex && \
     pip3 install --no-index --find-links=./ /build_output/wheels/*.whl && \
     cp /build_output/deps/skopeo /usr/bin/skopeo && \
+    cp /build_output/deps/syft /usr/bin/syft && \
     mkdir -p /etc/containers && \
     cp /build_output/configs/skopeo-policy.json /etc/containers/policy.json && \
     yum install -y /build_output/deps/*.rpm && \
@@ -186,6 +184,5 @@ HEALTHCHECK --start-period=20s \
 
 USER 1000
 
-ENV PATH="/anchore_engine/bin:${PATH}"
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["anchore-manager", "service", "start", "--all"]


### PR DESCRIPTION
Signed-off-by: Brady Todhunter <bradyt@anchore.com>

<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**:
Downloads syft to the build_output/ directory, which is used to create buildblobs for repo1 builds. Installs the final binary to /usr/bin so modifying the PATH isn't needed.


