### PR TITLE
only validate rule if appropariate

### DIFF
--- a/anchore_engine/services/catalog/api/controllers/archives.py
+++ b/anchore_engine/services/catalog/api/controllers/archives.py
@@ -177,16 +177,20 @@ def create_analysis_archive_rule(rule):
     try:
         with session_scope() as session:
             # Validate that only one system_global rule has max_images_per_account set
-            qry = session.query(ArchiveTransitionRule).filter(
-                ArchiveTransitionRule.account == ApiRequestContextProxy.namespace(),
-                ArchiveTransitionRule.system_global == True,
-                ArchiveTransitionRule.max_images_per_account != None,
-            )
-            if qry.first() is not None:
-                raise BadRequest(
-                    "A system_global Archive Transition Rule already exists with max_images_per_account set",
-                    {"existingRule": repr(qry.first())},
+            if (
+                rule.get("system_global", False)
+                and rule.get("max_images_per_account", None) is not None
+            ):
+                qry = session.query(ArchiveTransitionRule).filter(
+                    ArchiveTransitionRule.account == ApiRequestContextProxy.namespace(),
+                    ArchiveTransitionRule.system_global.is_(True),
+                    ArchiveTransitionRule.max_images_per_account.isnot(None),
                 )
+                if qry.first() is not None:
+                    raise BadRequest(
+                        "A system_global Archive Transition Rule already exists with max_images_per_account set",
+                        {"existingRule": repr(qry.first())},
+                    )
 
             r = ArchiveTransitionRule()
             r.account = ApiRequestContextProxy.namespace()


### PR DESCRIPTION
Signed-off-by: Samuel Dacanay <sam.dacanay@anchore.com>

<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**:  During testing in preparation for the 0.9.0 engine release found a bug that makes it impossible to add a rule after a (system_global == true && max_images_per_account != null) rule already exists


**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #: (private repo issue)

**Special notes**:


