### PR TITLE
fix error message, add field_name parameter to improve error message usefulness

### DIFF
--- a/anchore_engine/services/apiext/swagger/swagger.yaml
+++ b/anchore_engine/services/apiext/swagger/swagger.yaml
@@ -3274,6 +3274,7 @@ definitions:
       expires_on:
         type: string
         format: "date-time"
+        pattern: ^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:\:\d+)?[A-Z]?$
   PolicyRule:
     type: object
     description: A rule that defines and decision value if the match is found true for a given image.

--- a/anchore_engine/services/policy_engine/api/models.py
+++ b/anchore_engine/services/policy_engine/api/models.py
@@ -1,6 +1,5 @@
 from anchore_engine.common.schemas import Schema, JsonSerializable, RFC3339DateTime
 from marshmallow import fields, post_load
-from anchore_engine.utils import rfc3339str_to_datetime, datetime_to_rfc3339
 
 
 class DistroMapping(JsonSerializable):

--- a/anchore_engine/utils.py
+++ b/anchore_engine/utils.py
@@ -385,7 +385,7 @@ def rfc3339str_to_datetime(rfc3339_str):
 
     if ret is None:
         raise Exception(
-            "could not convert input created_at value ({}) into datetime using formats in {}".format(
+            "could not convert input value ({}) into datetime using formats in {}".format(
                 rfc3339_str, rfc3339_date_input_fmts
             )
         )


### PR DESCRIPTION
Signed-off-by: Samuel Dacanay <sam.dacanay@anchore.com>

<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**: Resolves an issue with error messages around failure to convert a date time string into a date time object


**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: Fixes https://github.com/anchore/anchore-engine/issues/787

**Special notes**:


