### PR TITLE
Fix Debian vulnerability matching by source package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN set -ex && \
 
 RUN set -ex && \
     echo "installing Syft" && \
-    curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /build_output/deps v0.9.2
+    curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /build_output/deps v0.11.0
 
 # stage RPM dependency binaries
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \

--- a/anchore_engine/analyzers/syft/handlers/debian.py
+++ b/anchore_engine/analyzers/syft/handlers/debian.py
@@ -43,8 +43,10 @@ def _all_package_info(findings, artifact):
     source_version = dig(artifact, "metadata", "sourceVersion")
 
     # Normalize this for downstream consumption etc. Eventually we want to leave it split out, but for now needs a join
-    if source:
-        source = source + "- " + source_version
+    if source and source_version:
+        source = source + "-" + source_version
+    elif source:
+        source = source + "-" + version
     else:
         source = "N/A"
 

--- a/anchore_engine/analyzers/syft/handlers/debian.py
+++ b/anchore_engine/analyzers/syft/handlers/debian.py
@@ -40,8 +40,11 @@ def _all_package_info(findings, artifact):
         size = "N/A"
 
     source = dig(artifact, "metadata", "source")
+    source_version = dig(artifact, "metadata", "sourceVersion")
+
+    # Normalize this for downstream consumption etc. Eventually we want to leave it split out, but for now needs a join
     if source:
-        source = source.split(" ")[0] + "-" + version
+        source = source + "- " + source_version
     else:
         source = "N/A"
 

--- a/anchore_engine/analyzers/syft/handlers/debian.py
+++ b/anchore_engine/analyzers/syft/handlers/debian.py
@@ -50,7 +50,7 @@ def _all_package_info(findings, artifact):
     else:
         source = "N/A"
 
-    license = dig(artifact, "licenses") or dig(artifact, "license")
+    license = dig(artifact, "licenses")
     if license:
         license = " ".join(license)
     else:

--- a/anchore_engine/analyzers/syft/handlers/python.py
+++ b/anchore_engine/analyzers/syft/handlers/python.py
@@ -30,9 +30,17 @@ def translate_and_save_entry(findings, artifact):
 
     # anchore engine always uses the name, however, the name may not be a top-level package
     # instead default to the first top-level package unless the name is listed among the
-    # top level packages explicitly defined in the metadata
-    pkg_key_name = artifact["metadata"]["topLevelPackages"][0]
-    if name in artifact["metadata"]["topLevelPackages"]:
+    # top level packages explicitly defined in the metadata. Note that the top-level package
+    # is optional!
+    pkg_key_names = dig(artifact, "metadata", "topLevelPackages", force_default=[])
+    pkg_key_name = None
+    for key_name in pkg_key_names:
+        if name in key_name:
+            pkg_key_name = name
+        else:
+            pkg_key_name = key_name
+
+    if not pkg_key_name:
         pkg_key_name = name
 
     pkg_key = os.path.join(site_pkg_root, pkg_key_name)

--- a/scripts/ci/Dockerfile.functional
+++ b/scripts/ci/Dockerfile.functional
@@ -23,4 +23,4 @@ RUN groupadd -g ${GID_CI} ci -f && \
 
 USER anchore
 
-RUN pip3 install --user tox
+RUN pip3 install --user tox pytest

--- a/tests/functional/clients/standalone/package_list/fixtures/alpine.py
+++ b/tests/functional/clients/standalone/package_list/fixtures/alpine.py
@@ -55,8 +55,8 @@ pkgs_allinfo = {
         "type": "APKG",
         "name": "alpine-baselayout",
         "cpes": [
-            "cpe:2.3:a:*:alpine-baselayout:3.2.0-r6:*:*:*:*:*:*:*",
             "cpe:2.3:a:alpine-baselayout:alpine-baselayout:3.2.0-r6:*:*:*:*:*:*:*",
+            "cpe:2.3:a:*:alpine-baselayout:3.2.0-r6:*:*:*:*:*:*:*",
         ],
         "files": [
             "/dev",
@@ -168,8 +168,8 @@ pkgs_allinfo = {
         "type": "APKG",
         "name": "alpine-keys",
         "cpes": [
-            "cpe:2.3:a:*:alpine-keys:2.2-r0:*:*:*:*:*:*:*",
             "cpe:2.3:a:alpine-keys:alpine-keys:2.2-r0:*:*:*:*:*:*:*",
+            "cpe:2.3:a:*:alpine-keys:2.2-r0:*:*:*:*:*:*:*",
         ],
         "files": [
             "/etc",
@@ -219,8 +219,8 @@ pkgs_allinfo = {
         "type": "APKG",
         "name": "busybox",
         "cpes": [
-            "cpe:2.3:a:*:busybox:1.31.1-r16:*:*:*:*:*:*:*",
             "cpe:2.3:a:busybox:busybox:1.31.1-r16:*:*:*:*:*:*:*",
+            "cpe:2.3:a:*:busybox:1.31.1-r16:*:*:*:*:*:*:*",
         ],
         "files": [
             "/bin/busybox",
@@ -264,8 +264,8 @@ pkgs_allinfo = {
         "type": "APKG",
         "name": "ca-certificates-bundle",
         "cpes": [
-            "cpe:2.3:a:*:ca-certificates-bundle:20191127-r2:*:*:*:*:*:*:*",
             "cpe:2.3:a:ca-certificates-bundle:ca-certificates-bundle:20191127-r2:*:*:*:*:*:*:*",
+            "cpe:2.3:a:*:ca-certificates-bundle:20191127-r2:*:*:*:*:*:*:*",
         ],
         "files": [
             "/etc",
@@ -286,8 +286,8 @@ pkgs_allinfo = {
         "type": "APKG",
         "name": "libcrypto1.1",
         "cpes": [
-            "cpe:2.3:a:*:libcrypto1.1:1.1.1g-r0:*:*:*:*:*:*:*",
             "cpe:2.3:a:libcrypto1.1:libcrypto1.1:1.1.1g-r0:*:*:*:*:*:*:*",
+            "cpe:2.3:a:*:libcrypto1.1:1.1.1g-r0:*:*:*:*:*:*:*",
         ],
         "files": [
             "/etc",
@@ -324,8 +324,8 @@ pkgs_allinfo = {
         "type": "APKG",
         "name": "libtls-standalone",
         "cpes": [
-            "cpe:2.3:a:*:libtls-standalone:2.9.1-r1:*:*:*:*:*:*:*",
             "cpe:2.3:a:libtls-standalone:libtls-standalone:2.9.1-r1:*:*:*:*:*:*:*",
+            "cpe:2.3:a:*:libtls-standalone:2.9.1-r1:*:*:*:*:*:*:*",
         ],
         "files": [
             "/usr",
@@ -345,8 +345,8 @@ pkgs_allinfo = {
         "type": "APKG",
         "name": "musl",
         "cpes": [
-            "cpe:2.3:a:*:musl:1.1.24-r8:*:*:*:*:*:*:*",
             "cpe:2.3:a:musl:musl:1.1.24-r8:*:*:*:*:*:*:*",
+            "cpe:2.3:a:*:musl:1.1.24-r8:*:*:*:*:*:*:*",
         ],
         "files": ["/lib/ld-musl-x86_64.so.1", "/lib/libc.musl-x86_64.so.1", "/lib"],
     },
@@ -361,8 +361,8 @@ pkgs_allinfo = {
         "type": "APKG",
         "name": "musl-utils",
         "cpes": [
-            "cpe:2.3:a:*:musl-utils:1.1.24-r8:*:*:*:*:*:*:*",
             "cpe:2.3:a:musl-utils:musl-utils:1.1.24-r8:*:*:*:*:*:*:*",
+            "cpe:2.3:a:*:musl-utils:1.1.24-r8:*:*:*:*:*:*:*",
         ],
         "files": [
             "/sbin/ldconfig",
@@ -386,8 +386,8 @@ pkgs_allinfo = {
         "type": "APKG",
         "name": "zlib",
         "cpes": [
-            "cpe:2.3:a:*:zlib:1.2.11-r3:*:*:*:*:*:*:*",
             "cpe:2.3:a:zlib:zlib:1.2.11-r3:*:*:*:*:*:*:*",
+            "cpe:2.3:a:*:zlib:1.2.11-r3:*:*:*:*:*:*:*",
         ],
         "files": ["/lib/libz.so.1", "/lib/libz.so.1.2.11", "/lib"],
     },

--- a/tests/functional/clients/standalone/package_list/fixtures/centos.py
+++ b/tests/functional/clients/standalone/package_list/fixtures/centos.py
@@ -36,8 +36,8 @@ pkgs_allinfo = {
         "origin": "CentOS",
         "type": "rpm",
         "cpes": [
-            "cpe:2.3:a:*:libmnl:1.0.4-6.el8:*:*:*:*:*:*:*",
             "cpe:2.3:a:libmnl:libmnl:1.0.4-6.el8:*:*:*:*:*:*:*",
+            "cpe:2.3:a:*:libmnl:1.0.4-6.el8:*:*:*:*:*:*:*",
         ],
     },
     "libdb": {
@@ -50,8 +50,8 @@ pkgs_allinfo = {
         "origin": "CentOS",
         "type": "rpm",
         "cpes": [
-            "cpe:2.3:a:*:libdb:5.3.28-37.el8:*:*:*:*:*:*:*",
             "cpe:2.3:a:libdb:libdb:5.3.28-37.el8:*:*:*:*:*:*:*",
+            "cpe:2.3:a:*:libdb:5.3.28-37.el8:*:*:*:*:*:*:*",
         ],
     },
     "libseccomp": {
@@ -64,8 +64,8 @@ pkgs_allinfo = {
         "origin": "CentOS",
         "type": "rpm",
         "cpes": [
-            "cpe:2.3:a:*:libseccomp:2.4.1-1.el8:*:*:*:*:*:*:*",
             "cpe:2.3:a:libseccomp:libseccomp:2.4.1-1.el8:*:*:*:*:*:*:*",
+            "cpe:2.3:a:*:libseccomp:2.4.1-1.el8:*:*:*:*:*:*:*",
         ],
     },
     "libsepol": {
@@ -78,8 +78,8 @@ pkgs_allinfo = {
         "origin": "CentOS",
         "type": "rpm",
         "cpes": [
-            "cpe:2.3:a:*:libsepol:2.9-1.el8:*:*:*:*:*:*:*",
             "cpe:2.3:a:libsepol:libsepol:2.9-1.el8:*:*:*:*:*:*:*",
+            "cpe:2.3:a:*:libsepol:2.9-1.el8:*:*:*:*:*:*:*",
         ],
     },
     "libunistring": {
@@ -92,8 +92,8 @@ pkgs_allinfo = {
         "origin": "CentOS",
         "type": "rpm",
         "cpes": [
-            "cpe:2.3:a:*:libunistring:0.9.9-3.el8:*:*:*:*:*:*:*",
             "cpe:2.3:a:libunistring:libunistring:0.9.9-3.el8:*:*:*:*:*:*:*",
+            "cpe:2.3:a:*:libunistring:0.9.9-3.el8:*:*:*:*:*:*:*",
         ],
     },
     "libkcapi": {
@@ -106,8 +106,8 @@ pkgs_allinfo = {
         "origin": "CentOS",
         "type": "rpm",
         "cpes": [
-            "cpe:2.3:a:*:libkcapi:1.1.1-16_1.el8:*:*:*:*:*:*:*",
             "cpe:2.3:a:libkcapi:libkcapi:1.1.1-16_1.el8:*:*:*:*:*:*:*",
+            "cpe:2.3:a:*:libkcapi:1.1.1-16_1.el8:*:*:*:*:*:*:*",
         ],
     },
     "tzdata": {
@@ -120,8 +120,8 @@ pkgs_allinfo = {
         "origin": "CentOS",
         "type": "rpm",
         "cpes": [
-            "cpe:2.3:a:*:tzdata:2020a-1.el8:*:*:*:*:*:*:*",
             "cpe:2.3:a:tzdata:tzdata:2020a-1.el8:*:*:*:*:*:*:*",
+            "cpe:2.3:a:*:tzdata:2020a-1.el8:*:*:*:*:*:*:*",
         ],
     },
     "cracklib": {
@@ -134,8 +134,8 @@ pkgs_allinfo = {
         "origin": "CentOS",
         "type": "rpm",
         "cpes": [
-            "cpe:2.3:a:*:cracklib:2.9.6-15.el8:*:*:*:*:*:*:*",
             "cpe:2.3:a:cracklib:cracklib:2.9.6-15.el8:*:*:*:*:*:*:*",
+            "cpe:2.3:a:*:cracklib:2.9.6-15.el8:*:*:*:*:*:*:*",
         ],
     },
     "bash": {
@@ -148,8 +148,8 @@ pkgs_allinfo = {
         "origin": "CentOS",
         "type": "rpm",
         "cpes": [
-            "cpe:2.3:a:*:bash:4.4.19-10.el8:*:*:*:*:*:*:*",
             "cpe:2.3:a:bash:bash:4.4.19-10.el8:*:*:*:*:*:*:*",
+            "cpe:2.3:a:*:bash:4.4.19-10.el8:*:*:*:*:*:*:*",
         ],
     },
     "libnsl2": {
@@ -162,8 +162,8 @@ pkgs_allinfo = {
         "origin": "CentOS",
         "type": "rpm",
         "cpes": [
-            "cpe:2.3:a:*:libnsl2:1.2.0-2.20180605git4a062cf.el8:*:*:*:*:*:*:*",
             "cpe:2.3:a:libnsl2:libnsl2:1.2.0-2.20180605git4a062cf.el8:*:*:*:*:*:*:*",
+            "cpe:2.3:a:*:libnsl2:1.2.0-2.20180605git4a062cf.el8:*:*:*:*:*:*:*",
         ],
     },
 }

--- a/tests/functional/clients/standalone/package_list/fixtures/debian.py
+++ b/tests/functional/clients/standalone/package_list/fixtures/debian.py
@@ -31,8 +31,8 @@ pkgs_allinfo = {
         "sourcepkg": "ustr-1.0.4-6",
         "type": "dpkg",
         "cpes": [
-            "cpe:2.3:a:*:libustr-1.0-1:1.0.4-6:*:*:*:*:*:*:*",
             "cpe:2.3:a:libustr-1.0-1:libustr-1.0-1:1.0.4-6:*:*:*:*:*:*:*",
+            "cpe:2.3:a:*:libustr-1.0-1:1.0.4-6:*:*:*:*:*:*:*",
         ],
     },
     "gcc-6-base": {
@@ -45,8 +45,8 @@ pkgs_allinfo = {
         "sourcepkg": "gcc-6-6.3.0-18+deb9u1",
         "type": "dpkg",
         "cpes": [
-            "cpe:2.3:a:*:gcc-6-base:6.3.0-18+deb9u1:*:*:*:*:*:*:*",
             "cpe:2.3:a:gcc-6-base:gcc-6-base:6.3.0-18+deb9u1:*:*:*:*:*:*:*",
+            "cpe:2.3:a:*:gcc-6-base:6.3.0-18+deb9u1:*:*:*:*:*:*:*",
         ],
     },
     "libc-bin": {
@@ -59,8 +59,8 @@ pkgs_allinfo = {
         "sourcepkg": "glibc-2.24-11+deb9u4",
         "type": "dpkg",
         "cpes": [
-            "cpe:2.3:a:*:libc-bin:2.24-11+deb9u4:*:*:*:*:*:*:*",
             "cpe:2.3:a:libc-bin:libc-bin:2.24-11+deb9u4:*:*:*:*:*:*:*",
+            "cpe:2.3:a:*:libc-bin:2.24-11+deb9u4:*:*:*:*:*:*:*",
         ],
     },
     "libaudit-common": {
@@ -73,8 +73,8 @@ pkgs_allinfo = {
         "sourcepkg": "audit-1:2.6.7-2",
         "type": "dpkg",
         "cpes": [
-            "cpe:2.3:a:*:libaudit-common:1:2.6.7-2:*:*:*:*:*:*:*",
             "cpe:2.3:a:libaudit-common:libaudit-common:1:2.6.7-2:*:*:*:*:*:*:*",
+            "cpe:2.3:a:*:libaudit-common:1:2.6.7-2:*:*:*:*:*:*:*",
         ],
     },
     "e2fslibs": {
@@ -87,8 +87,8 @@ pkgs_allinfo = {
         "sourcepkg": "e2fsprogs-1.43.4-2+deb9u2",
         "type": "dpkg",
         "cpes": [
-            "cpe:2.3:a:*:e2fslibs:1.43.4-2+deb9u2:*:*:*:*:*:*:*",
             "cpe:2.3:a:e2fslibs:e2fslibs:1.43.4-2+deb9u2:*:*:*:*:*:*:*",
+            "cpe:2.3:a:*:e2fslibs:1.43.4-2+deb9u2:*:*:*:*:*:*:*",
         ],
     },
     "gzip": {
@@ -98,11 +98,11 @@ pkgs_allinfo = {
         "size": "231000",
         "origin": "Bdale Garbee <bdale@gag.com> (maintainer)",
         "license": "Unknown",
-        "sourcepkg": "gzip-1.6-5+b1",
+        "sourcepkg": "gzip-1.6-5",
         "type": "dpkg",
         "cpes": [
-            "cpe:2.3:a:*:gzip:1.6-5+b1:*:*:*:*:*:*:*",
             "cpe:2.3:a:gzip:gzip:1.6-5+b1:*:*:*:*:*:*:*",
+            "cpe:2.3:a:*:gzip:1.6-5+b1:*:*:*:*:*:*:*",
         ],
     },
     "libpam0g": {
@@ -115,8 +115,8 @@ pkgs_allinfo = {
         "sourcepkg": "pam-1.1.8-3.6",
         "type": "dpkg",
         "cpes": [
-            "cpe:2.3:a:*:libpam0g:1.1.8-3.6:*:*:*:*:*:*:*",
             "cpe:2.3:a:libpam0g:libpam0g:1.1.8-3.6:*:*:*:*:*:*:*",
+            "cpe:2.3:a:*:libpam0g:1.1.8-3.6:*:*:*:*:*:*:*",
         ],
     },
     "sensible-utils": {
@@ -129,8 +129,8 @@ pkgs_allinfo = {
         "sourcepkg": "N/A",
         "type": "dpkg",
         "cpes": [
-            "cpe:2.3:a:*:sensible-utils:0.0.9+deb9u1:*:*:*:*:*:*:*",
             "cpe:2.3:a:sensible-utils:sensible-utils:0.0.9+deb9u1:*:*:*:*:*:*:*",
+            "cpe:2.3:a:*:sensible-utils:0.0.9+deb9u1:*:*:*:*:*:*:*",
         ],
     },
     "bash": {
@@ -143,8 +143,8 @@ pkgs_allinfo = {
         "sourcepkg": "N/A",
         "type": "dpkg",
         "cpes": [
-            "cpe:2.3:a:*:bash:4.4-5:*:*:*:*:*:*:*",
             "cpe:2.3:a:bash:bash:4.4-5:*:*:*:*:*:*:*",
+            "cpe:2.3:a:*:bash:4.4-5:*:*:*:*:*:*:*",
         ],
     },
 }


### PR DESCRIPTION
- Uses the `sourceVersion` in syft v0.11.0 for debian packages during vulnerability matching with the source package
- Since the `topLevelPackages` field is optional in syft output, changes the behavior to fallback to the package name in this case
- bump syft to v0.11.0

Closes #800 