### PR TITLE
Upgrade syft version to v0.11.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN set -ex && \
 
 RUN set -ex && \
     echo "installing Syft" && \
-    curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /build_output/deps v0.11.0
+    curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /build_output/deps v0.11.1
 
 # stage RPM dependency binaries
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \


### PR DESCRIPTION
Updates `syft` to `v0.11.1` to incorporate these fixes:

- Handle site packages based on which egg file is parsed [\#303](https://github.com/anchore/syft/pull/303) ([luhring](https://github.com/luhring))
- Python runtime is not a Python package itself, ignore it [\#301](https://github.com/anchore/syft/pull/301) ([alfredodeza](https://github.com/alfredodeza))