### PR TITLE
Remove old helm installation steps and update some links to old enterprise urls

### DIFF
--- a/docs/content/docs/install/helm/_index.md
+++ b/docs/content/docs/install/helm/_index.md
@@ -26,21 +26,6 @@ The following guide requires:
 - Helm binary installed and available in your path
 
 ### Installation
-First, the official stable repository needs to be added to your helm client.
-
-```
-helm repo add stable https://kubernetes-charts.storage.googleapis.com
-```
-
-Next we need to ensure that we have an up to date list of Helm Charts.
-
-```
-$ helm repo update
-Hang tight while we grab the latest from your chart repositories...
-...Skip local chart repository
-...Successfully got an update from the "stable" chart repository
-Update Complete. ⎈ Happy Helming!⎈
-```
 
 By default, the Anchore Engine chart will deploy a single pod for each Anchore Engine service along with a PostgreSQL database container. This behavior can be overridden if you have an existing PostgreSQL service available, see the [README](https://github.com/anchore/anchore-charts/blob/master/stable/anchore-engine/README.md) for more details.
 

--- a/docs/content/docs/install/upgrade/_index.md
+++ b/docs/content/docs/install/upgrade/_index.md
@@ -54,7 +54,7 @@ For the latest upgrade instructions using the Helm chart, please refer to the of
 
 4. Download the latest docker-compose.yaml
 ```
-# curl https://docs.anchore.com/current/docs/quickstart/docker-compose.yaml
+# curl https://engine.anchore.io/docs/quickstart//docker-compose.yaml
 ```
 
 5. Review the latest docker-compose.yaml and merge any edits/changes from your original docker-compose.yaml.backup to the latest docker-compose.yaml

--- a/docs/content/docs/quickstart/_index.md
+++ b/docs/content/docs/quickstart/_index.md
@@ -28,7 +28,7 @@ The following instructions assume you are using a system running Docker v1.12 or
 ### Step 1: Download the docker-compose.yaml file and start.
 
 ```
-# curl -O https://docs.anchore.com/current/docs/quickstart/docker-compose.yaml
+# curl -O https://engine.anchore.io/docs/quickstart/docker-compose.yaml
 # docker-compose up -d
 ```
 

--- a/docs/content/docs/quickstart/_index.md
+++ b/docs/content/docs/quickstart/_index.md
@@ -220,7 +220,7 @@ Now that you have Anchore Engine running, you can begin to learning more about A
 1. Download the example prometheus configuration into the same directory as the docker-compose.yaml file, with name _anchore-prometheus.yml_
 
     ```
-    curl -O https://docs.anchore.com/current/docs/quickstart/anchore-prometheus.yml
+    curl -O https://engine.anchore.io/docs/quickstart/anchore-prometheus.yml
     docker-compose up -d
     ```
 
@@ -259,7 +259,7 @@ Now that you have Anchore Engine running, you can begin to learning more about A
 1. Download the nginx configuration into the same directory as the docker-compose.yaml file, with name _anchore-swaggerui-nginx.conf_
 
     ```
-    curl -O https://docs.anchore.com/current/docs/quickstart/anchore-swaggerui-nginx.conf
+    curl -O https://engine.anchore.io/docs/quickstart/anchore-swaggerui-nginx.conf
     docker-compose up -d
     ```
 

--- a/docs/content/docs/quickstart/docker-compose.yaml
+++ b/docs/content/docs/quickstart/docker-compose.yaml
@@ -1,5 +1,5 @@
 # This is a docker-compose file for development purposes. It refereneces unstable developer builds from the HEAD of master branch in https://github.com/anchore/anchore-engine
-# For a compose file intended for use with a released version, see https://docs.anchore.com/current/docs/quickstart/
+# For a compose file intended for use with a released version, see https://engine.anchore.io/docs/quickstart/
 #
 ---
 version: '2.1'

--- a/docs/content/docs/usage/api_usage/_index.md
+++ b/docs/content/docs/usage/api_usage/_index.md
@@ -54,7 +54,7 @@ http://localhost:8228/v1/swagger.json
 1. Download the nginx configuration into the same directory as the docker-compose.yaml file, with name _anchore-swaggerui-nginx.conf_
 
     ```
-    curl -O https://docs.anchore.com/current/docs/quickstart/anchore-swaggerui-nginx.conf
+    curl -O https://engine.anchore.io/docs/quickstart/anchore-swaggerui-nginx.conf
     docker-compose up -d
     ```
 


### PR DESCRIPTION
There were some old steps for adding the helm repo that are no longer accurate. Removed in favor of command that uses https://charts.anchore.io

Signed-off-by: Zane Burstein <zane.burstein@anchore.com>
