### PR TITLE
If an image has not been analyzed it, do not consider it a candidate …

### DIFF
--- a/anchore_engine/db/db_catalog_image_docker.py
+++ b/anchore_engine/db/db_catalog_image_docker.py
@@ -242,7 +242,7 @@ def get_tag_histories(session, userId, registries=None, repositories=None, tags=
                 CatalogImageDocker.imageDigest == CatalogImage.imageDigest,
             ),
         )
-        .filter(CatalogImage.userId == userId, CatalogImage.analyzed_at.isnot(None))
+        .filter(CatalogImage.userId == userId)
         .order_by(*order_by_fields)
     )
 

--- a/anchore_engine/db/db_catalog_image_docker.py
+++ b/anchore_engine/db/db_catalog_image_docker.py
@@ -242,7 +242,7 @@ def get_tag_histories(session, userId, registries=None, repositories=None, tags=
                 CatalogImageDocker.imageDigest == CatalogImage.imageDigest,
             ),
         )
-        .filter(CatalogImage.userId == userId)
+        .filter(CatalogImage.userId == userId, CatalogImage.analyzed_at.isnot(None))
         .order_by(*order_by_fields)
     )
 

--- a/anchore_engine/services/catalog/archiver.py
+++ b/anchore_engine/services/catalog/archiver.py
@@ -560,7 +560,11 @@ class ImageAnalysisArchiver(object):
 
             # If the image matches the exclude selector, we do not consider it to be a candidate for transition,
             # therefore, we should skip it
-            if self._is_exclude_match(rule, catalog_image, catalog_image_docker):
+            # Note: if an image doesn't have a value for analyzed_at, we cannot evaluate the exclude because we don't
+            # know if the exclude is expired
+            if catalog_image.analyzed_at and self._is_exclude_match(
+                rule, catalog_image, catalog_image_docker
+            ):
                 logger.debug(
                     "Image is excluded from archive transition rule: {}".format(
                         catalog_image_docker


### PR DESCRIPTION
…for transition

Signed-off-by: Samuel Dacanay <sam.dacanay@anchore.com>

<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**: Addresses issue where stacktrace is printed when transition rules execute against images that are not done being analyzed


**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #:

**Special notes**:


