### PR TITLE
Multiple policy bundle dirs

### DIFF
--- a/anchore_engine/configuration/localconfig.py
+++ b/anchore_engine/configuration/localconfig.py
@@ -120,6 +120,7 @@ def analyzer_paths():
 def register_policy_bundle_source_dir(source_dir):
     global POLICY_BUNDLE_SOURCE_DIRS
     POLICY_BUNDLE_SOURCE_DIRS.append(source_dir)
+    load_policy_bundle_paths()
 
 
 def policy_bundle_source_dirs():

--- a/anchore_engine/configuration/localconfig.py
+++ b/anchore_engine/configuration/localconfig.py
@@ -101,7 +101,11 @@ CRED_CACHE_TTL = int(os.getenv("ANCHORE_INTERNAL_CRED_CACHE_TTL", 600))
 CRED_CACHE_LOCK_WAIT_SEC = int(os.getenv("ANCHORE_INTERNAL_CRED_CACHE_WAIT_SEC", 3))
 
 ANALYZER_SEARCH_PATHS = ["anchore_engine.analyzers"]
-POLICY_BUNDLE_SOURCE_DIRS = ["conf/bundles/"]
+POLICY_BUNDLE_SOURCE_DIRS = [
+    os.path.join(
+        resource_filename("anchore_engine", "conf/bundles/")
+    )
+]
 
 
 def register_analyzers(module_path):
@@ -188,13 +192,7 @@ def load_policy_bundle_paths(src_dirs=None):
 
     # This value will typically == None, outside of automated tests
     if src_dirs == None:
-        src_dirs = []
-        for policy_bundles_source_dir in POLICY_BUNDLE_SOURCE_DIRS:
-            src_dirs.append(
-                os.path.join(
-                resource_filename("anchore_engine", policy_bundles_source_dir)
-                )
-            )
+        src_dirs = policy_bundle_source_dirs()
 
     try:
         if src_dirs is not None and len(src_dirs) > 0 and policy_bundles_dir is not None:

--- a/anchore_engine/configuration/localconfig.py
+++ b/anchore_engine/configuration/localconfig.py
@@ -215,9 +215,7 @@ def load_policy_bundle_paths(src_dirs=None):
             localconfig["policy_bundles"] = policy_bundles
             return
         else:
-            logger.warn(
-                "No configured policy bundle dir was found, unable to load."
-            )
+            logger.warn("No configured policy bundle dir was found, unable to load.")
             localconfig["policy_bundles"] = None
     except Exception as e:
         logger.warn(

--- a/anchore_engine/configuration/localconfig.py
+++ b/anchore_engine/configuration/localconfig.py
@@ -102,9 +102,7 @@ CRED_CACHE_LOCK_WAIT_SEC = int(os.getenv("ANCHORE_INTERNAL_CRED_CACHE_WAIT_SEC",
 
 ANALYZER_SEARCH_PATHS = ["anchore_engine.analyzers"]
 POLICY_BUNDLE_SOURCE_DIRS = [
-    os.path.join(
-        resource_filename("anchore_engine", "conf/bundles/")
-    )
+    os.path.join(resource_filename("anchore_engine", "conf/bundles/"))
 ]
 
 
@@ -196,7 +194,11 @@ def load_policy_bundle_paths(src_dirs=None):
         src_dirs = policy_bundle_source_dirs()
 
     try:
-        if src_dirs is not None and len(src_dirs) > 0 and policy_bundles_dir is not None:
+        if (
+            src_dirs is not None
+            and len(src_dirs) > 0
+            and policy_bundles_dir is not None
+        ):
             policy_bundles_dir_full_path = os.path.join(
                 localconfig["service_dir"], policy_bundles_dir
             )

--- a/anchore_engine/configuration/localconfig.py
+++ b/anchore_engine/configuration/localconfig.py
@@ -194,11 +194,7 @@ def load_policy_bundle_paths(src_dirs=None):
         src_dirs = policy_bundle_source_dirs()
 
     try:
-        if (
-            src_dirs is not None
-            and len(src_dirs) > 0
-            and policy_bundles_dir is not None
-        ):
+        if policy_bundles_dir and src_dirs:
             policy_bundles_dir_full_path = os.path.join(
                 localconfig["service_dir"], policy_bundles_dir
             )
@@ -208,23 +204,21 @@ def load_policy_bundle_paths(src_dirs=None):
             policy_bundles = []
             for src_dir in src_dirs:
                 for file_name in os.listdir(src_dir):
-                    try:
-                        file = os.path.join(policy_bundles_dir_full_path, file_name)
-                        policy_bundles.append(
-                            {
-                                "active": file_name == default_bundle_name,
-                                "bundle_path": file,
-                            }
-                        )
-                        copy_config_file(file, file_name, src_dir)
-                    except Exception as e:
-                        logger.warn(
-                            "Policy bundle {} from dir {} not found, unable to load. Exception: {}".format(
-                                file_name, src_dir, e
-                            )
-                        )
+                    file = os.path.join(policy_bundles_dir_full_path, file_name)
+                    policy_bundles.append(
+                        {
+                            "active": file_name == default_bundle_name,
+                            "bundle_path": file,
+                        }
+                    )
+                    copy_config_file(file, file_name, src_dir)
             localconfig["policy_bundles"] = policy_bundles
             return
+        else:
+            logger.warn(
+                "No configured policy bundle dir was found, unable to load."
+            )
+            localconfig["policy_bundles"] = None
     except Exception as e:
         logger.warn(
             "Configured policy bundle dir at {} not found, unable to load. Exception: {}".format(

--- a/tests/unit/anchore_engine/configuration/test_localconfig.py
+++ b/tests/unit/anchore_engine/configuration/test_localconfig.py
@@ -22,7 +22,7 @@ ANALYZER_CONFIG_TEXT = "analyzer\n"
 POLICY_BUNDLE_TEXT = "policy bundle\n"
 
 INPUT_CONFIG_DIR = "input_config"
-INPUT_BUNDLES_DIR = "input_bundles"
+INPUT_BUNDLES_DIR_ROOT = "input_bundles"
 OUTPUT_BUNDLES_DIR = "bundles"
 
 
@@ -73,30 +73,40 @@ def get_mock_config_with_policy_bundles(dir, bundle_filenames, simulate_exceptio
 
 
 @pytest.mark.parametrize(
-    "config_filenames",
+    "config_filename_sets",
     [
-        ([]),
-        (["anchore_default_bundle.json"]),
-        (["anchore_default_bundle.json", "second_bundle.json"]),
+        ([[]]),
+        ([["anchore_default_bundle.json"]]),
+        ([["anchore_default_bundle.json", "second_bundle.json"]]),
+        ([["anchore_default_bundle.json", "second_bundle.json"], ["third_bundle.json", "fourth_bundle.json"], ["fifth_bundle.json"]]),
     ],
 )
-def test_load_policy_bundle_paths(mock_default_config, tmpdir, config_filenames):
+def test_load_policy_bundle_paths(mock_default_config, tmpdir, config_filename_sets):
     # setup files to read
-    input_dir = tmpdir.mkdir(INPUT_BUNDLES_DIR)
-    mock_test_files(input_dir, config_filenames)
+    src_dirs = []
+    i = 0
+    for set in config_filename_sets:
+        input_dir = tmpdir.mkdir(INPUT_BUNDLES_DIR_ROOT + "_" + str(i))
+        i += 1
+        mock_test_files(input_dir, set)
+        src_dirs.append(input_dir.strpath)
+
+    # setup the expected output. We will expect to see output_dir_name contain the
+    # files in config_filenames_flat
     output_dir_name = tmpdir.strpath + "/bundles"
+    config_filenames_flat = [filename for set in config_filename_sets for filename in set]
 
     # setup the default config
     load_defaults(configdir=tmpdir)
 
     # function under test
-    load_policy_bundle_paths(src_dir=input_dir.strpath)
+    load_policy_bundle_paths(src_dirs=src_dirs)
 
     # get and validate the relevant config bits
     config = get_config()
     assert config["policy_bundles"] is not None
-    assert len(config["policy_bundles"]) == len(config_filenames)
-    for config_filename in config_filenames:
+    assert len(config["policy_bundles"]) == len(config_filenames_flat)
+    for config_filename in config_filenames_flat:
         policy_bundle = next(
             policy_bundle
             for policy_bundle in config["policy_bundles"]

--- a/tests/unit/anchore_engine/configuration/test_localconfig.py
+++ b/tests/unit/anchore_engine/configuration/test_localconfig.py
@@ -82,7 +82,7 @@ def get_mock_config_with_policy_bundles(dir, bundle_filenames, simulate_exceptio
             [
                 ["anchore_default_bundle.json", "second_bundle.json"],
                 ["third_bundle.json", "fourth_bundle.json"],
-                ["fifth_bundle.json"]]
+                ["fifth_bundle.json"]],
         ),
     ],
 )

--- a/tests/unit/anchore_engine/configuration/test_localconfig.py
+++ b/tests/unit/anchore_engine/configuration/test_localconfig.py
@@ -78,7 +78,12 @@ def get_mock_config_with_policy_bundles(dir, bundle_filenames, simulate_exceptio
         ([[]]),
         ([["anchore_default_bundle.json"]]),
         ([["anchore_default_bundle.json", "second_bundle.json"]]),
-        ([["anchore_default_bundle.json", "second_bundle.json"], ["third_bundle.json", "fourth_bundle.json"], ["fifth_bundle.json"]]),
+        (
+            [
+                ["anchore_default_bundle.json", "second_bundle.json"],
+                ["third_bundle.json", "fourth_bundle.json"],
+                ["fifth_bundle.json"]]
+        ),
     ],
 )
 def test_load_policy_bundle_paths(mock_default_config, tmpdir, config_filename_sets):
@@ -94,7 +99,9 @@ def test_load_policy_bundle_paths(mock_default_config, tmpdir, config_filename_s
     # setup the expected output. We will expect to see output_dir_name contain the
     # files in config_filenames_flat
     output_dir_name = tmpdir.strpath + "/bundles"
-    config_filenames_flat = [filename for set in config_filename_sets for filename in set]
+    config_filenames_flat = [
+        filename for set in config_filename_sets for filename in set
+    ]
 
     # setup the default config
     load_defaults(configdir=tmpdir)

--- a/tests/unit/anchore_engine/configuration/test_localconfig.py
+++ b/tests/unit/anchore_engine/configuration/test_localconfig.py
@@ -82,7 +82,8 @@ def get_mock_config_with_policy_bundles(dir, bundle_filenames, simulate_exceptio
             [
                 ["anchore_default_bundle.json", "second_bundle.json"],
                 ["third_bundle.json", "fourth_bundle.json"],
-                ["fifth_bundle.json"]],
+                ["fifth_bundle.json"],
+            ],
         ),
     ],
 )

--- a/tests/unit/anchore_engine/configuration/test_localconfig.py
+++ b/tests/unit/anchore_engine/configuration/test_localconfig.py
@@ -83,7 +83,7 @@ def get_mock_config_with_policy_bundles(dir, bundle_filenames, simulate_exceptio
                 ["anchore_default_bundle.json", "second_bundle.json"],
                 ["third_bundle.json", "fourth_bundle.json"],
                 ["fifth_bundle.json"],
-            ],
+            ]
         ),
     ],
 )

--- a/tests/unit/anchore_engine/configuration/test_localconfig.py
+++ b/tests/unit/anchore_engine/configuration/test_localconfig.py
@@ -72,6 +72,18 @@ def get_mock_config_with_policy_bundles(dir, bundle_filenames, simulate_exceptio
     return {"policy_bundles": policy_bundles}
 
 
+def test_empty_src_dirs(mock_default_config, tmpdir):
+    # setup the default config
+    load_defaults(configdir=tmpdir)
+
+    # function under test
+    load_policy_bundle_paths(src_dirs=[])
+
+    # get and validate the relevant config bits
+    config = get_config()
+    assert config["policy_bundles"] is None
+
+
 @pytest.mark.parametrize(
     "config_filename_sets",
     [


### PR DESCRIPTION
This PR updates localconfig to allow multiple folly-qualified dirs containing policy bundles to be passed in during bootstrap.