### PR TITLE
Dont allow selector to be empty if not max_images_per_account rule, a…

### DIFF
--- a/anchore_engine/db/db_catalog_image.py
+++ b/anchore_engine/db/db_catalog_image.py
@@ -486,7 +486,7 @@ def delete(imageDigest, userId, session=None):
     return True
 
 
-def get_oldest_images_with_limit(session, account, max_images, excluded_digests):
+def get_oldest_images_with_limit(session, account, max_images):
     """
     This method will return the oldest images which exceed the max_images limit
 
@@ -537,7 +537,6 @@ def get_oldest_images_with_limit(session, account, max_images, excluded_digests)
         .filter(
             CatalogImage.analysis_status == "analyzed",
             CatalogImage.userId == account,
-            CatalogImage.imageDigest.notin_(excluded_digests),
         )
         .order_by(CatalogImage.analyzed_at.asc())
         .limit(limit)

--- a/tests/unit/anchore_engine/services/catalog/test_archiver.py
+++ b/tests/unit/anchore_engine/services/catalog/test_archiver.py
@@ -154,9 +154,7 @@ def test_transitions_selector():
     rule.selector_tag = None
     rule.selector_repository = None
     rule.selector_registry = None
-    result, excluded_digests = task._evaluate_tag_history_and_exclude(
-        rule, data_generator()
-    )
+    result = task._evaluate_tag_history_and_exclude(rule, data_generator())
 
     print("Transitions found: {} results".format(result))
 


### PR DESCRIPTION
…nd force empty if it is

Signed-off-by: Samuel Dacanay <sam.dacanay@anchore.com>

<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**: This Change makes our logic around transition rules a bit better. Selector fields can no longer be empty strings unless its a global rule for max_images_per_account


**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #858

**Special notes**:


