### PR TITLE
Bump PyYAML version to 5.4.1 from 5.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ psycopg2-binary==2.8.4
 python-dateutil==2.8.1
 python-swiftclient==3.8.1
 pytz==2019.3
-PyYAML==5.3.1
+PyYAML==5.4.1
 requests==2.23.0
 retrying==1.3.3
 semantic-version==2.6.0


### PR DESCRIPTION
Signed-off-by: Toure Dunnon <toure.dunnon@anchore.com>

**What this PR does / why we need it**:
The version bump will update anchore-engine to the latest version of PyYAML which will address the current
CVE 2020-14343.

**Which issue this PR fixes**
closes: #838 


