### PR TITLE
passlib 1.7.4 version bump address a couple bugs.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ psycopg2-binary==2.8.4
 python-dateutil==2.8.1
 python-swiftclient==3.8.1
 pytz==2019.3
-PyYAML==5.3.1
+PyYAML==5.4.1
 requests==2.23.0
 retrying==1.3.3
 semantic-version==2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Click==7.0
 connexion==2.5.1
 Flask==1.1.1
 jsonschema==2.6.0
-passlib==1.7.2
+passlib==1.7.4
 pathlib==1.0.1
 prettytable==0.7.2
 prometheus-client==0.7.1


### PR DESCRIPTION
**What this PR does / why we need it**:
There are a couple corrections/improvement to the CrypContext class which is used in anchore-engine for password
hasher for database accounts.

* CryptContext will now throw UnknownHashError when it can’t identify a hash provided to methods such as CryptContext.verify(). Previously it would throw a generic ValueError.

**Which issue this PR fixes**
closes: #855 

**Special notes**:


