### PR TITLE
Upgrade syft to v0.12.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN set -ex && \
 
 RUN set -ex && \
     echo "installing Syft" && \
-    curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /build_output/deps v0.12.3
+    curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /build_output/deps v0.12.4
 
 # stage RPM dependency binaries
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \


### PR DESCRIPTION
Updates syft to [v0.12.4](https://github.com/anchore/syft/releases/tag/v0.12.4)

Fixes an issue where syft would panic during Java cataloging: https://github.com/anchore/syft/issues/252