### PR TITLE
Update swagger url

### DIFF
--- a/docs/content/docs/quickstart/_index.md
+++ b/docs/content/docs/quickstart/_index.md
@@ -263,5 +263,5 @@ Now that you have Anchore Engine running, you can begin to learning more about A
     docker-compose up -d
     ```
 
-    You should see a new container started and can access prometheus via your browser on `http://localhost:8080/ui/`
+    You should see a new container started and can access swagger via your browser on `http://localhost:8080`
 

--- a/docs/content/docs/usage/api_usage/_index.md
+++ b/docs/content/docs/usage/api_usage/_index.md
@@ -58,7 +58,7 @@ http://localhost:8228/v1/swagger.json
     docker-compose up -d
     ```
 
-    You should see a new container started and can access prometheus via your browser on `http://localhost:8080/ui/`
+    You should see a new container started and can access swagger via your browser on `http://localhost:8080`
 
 ~
 ~


### PR DESCRIPTION
Engine quickstart had an incorrect link to the swagger spec ui