### PR TITLE
enforce python version and remove typing backport for versions < 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,6 @@ swagger-spec-validator==2.4.3
 marshmallow==3.9.0
 treelib==1.5.5
 Twisted[tls]==20.3.0
-typing==3.7.4.1
 urllib3==1.25.9
 watchdog==0.9.0
 Werkzeug==0.16.0

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
     description=description,
     long_description=long_description,
     url=url,
+    python_requires="==3.8.*",
     packages=packages,
     version=version,
     data_files=data_files,


### PR DESCRIPTION
Signed-off-by: Vijay Pillai <vijay.pillai@anchore.com>

<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**:


**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #:

**Special notes**:

fixes: #899 
Also changes requirements.txt to not install typing backport if running 3.8+


