### PR TITLE
set to cryptography version 3.3.2 to avoid setuptools-rust downstream dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Authlib==0.15.2
+cryptography==3.3.2
 boto3==1.11.6
 Click==7.0
 connexion==2.5.1


### PR DESCRIPTION
Signed-off-by: Samuel Dacanay <sam.dacanay@anchore.com>

<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**: [Over the weekend, the `cryptography` package released an update](https://cryptography.io/en/latest/changelog.html) that required the `setuptools-rust` dev tool package to be installed, which isn't in our image (for this repo or enterprise), and it's causing the build to fail

