### PR TITLE
The allOf sections in these objects is breaking the swagger-codegen generated clients, so…

### DIFF
--- a/anchore_engine/services/apiext/swagger/swagger.yaml
+++ b/anchore_engine/services/apiext/swagger/swagger.yaml
@@ -2924,19 +2924,6 @@ paths:
         500:
           description: "Internal Error"
 definitions:
-  PaginationProperties:
-    type: object
-    properties:
-      page:
-        type: string
-        description: The page number returned (should match the requested page query string param)
-      next_page:
-        type: string
-        description: True if additional pages exist (page + 1) or False if this is the last page
-      returned_count:
-        type: integer
-        description: The number of items sent in this response
-    description: Properties for common pagination handling to be included in any wrapping object that needs pagination elements
   PackageReference:
     type: object
     properties:
@@ -3083,35 +3070,56 @@ definitions:
           $ref: '#/definitions/PackageReference'
     description: An image record that contains packages
   PaginatedVulnerableImageList:
-    allOf:
-      - $ref: '#/definitions/PaginationProperties'
-      - type: object
-        properties:
-          images:
-            type: array
-            items:
-              $ref: '#/definitions/VulnerableImage'
+    type: object
+    properties:
+      page:
+        type: string
+        description: The page number returned (should match the requested page query string param)
+      next_page:
+        type: string
+        description: True if additional pages exist (page + 1) or False if this is the last page
+      returned_count:
+        type: integer
+        description: The number of items sent in this response
+      images:
+        type: array
+        items:
+          $ref: '#/definitions/VulnerableImage'
     description: Pagination wrapped list of images with vulnerabilties that match some filter
   PaginatedVulnerabilityList:
-    allOf:
-      - $ref: '#/definitions/PaginationProperties'
-      - type: object
-        properties:
-          vulnerabilities:
-            type: array
-            description: The listing of matching vulnerabilities for the query subject to pagination
-            items:
-              $ref: '#/definitions/StandaloneVulnerability'
+    type: object
+    properties:
+      page:
+        type: string
+        description: The page number returned (should match the requested page query string param)
+      next_page:
+        type: string
+        description: True if additional pages exist (page + 1) or False if this is the last page
+      returned_count:
+        type: integer
+        description: The number of items sent in this response
+      vulnerabilities:
+        type: array
+        description: The listing of matching vulnerabilities for the query subject to pagination
+        items:
+          $ref: '#/definitions/StandaloneVulnerability'
     description: A paginated listing of vulnerability records sorted by ID in descending order
   PaginatedImageList:
-    allOf:
-      - $ref: '#/definitions/PaginationProperties'
-      - type: object
-        properties:
-          images:
-            type: array
-            items:
-              $ref: '#/definitions/ImageWithPackages'
+    type: object
+    properties:
+      page:
+        type: string
+        description: The page number returned (should match the requested page query string param)
+      next_page:
+        type: string
+        description: True if additional pages exist (page + 1) or False if this is the last page
+      returned_count:
+        type: integer
+        description: The number of items sent in this response
+      images:
+        type: array
+        items:
+          $ref: '#/definitions/ImageWithPackages'
     description: Pagination wrapped list of images that match some filter
   ImageAnalysisRequest:
     type: object
@@ -4709,9 +4717,9 @@ definitions:
       resource_type:
         type: string
         description: The type of resource this event is generated from
-  NotificationBase:
+  PolicyEvalNotification:
     type: object
-    description: base object for Notifications (every notification has this basic structure)
+    description: The Notification Object definition for Policy Eval Notifications
     properties:
       queueId:
         type: string
@@ -4733,41 +4741,88 @@ definitions:
         type: integer
       max_tries:
         type: integer
-  PolicyEvalNotification:
-    allOf:
-      - $ref: "#/definitions/NotificationBase"
-      - type: object
-        description: The Notification Object definition for Policy Eval Notifications
-        properties:
-          data:
-            $ref: "#/definitions/PolicyEvalNotificationData"
+      data:
+        $ref: "#/definitions/PolicyEvalNotificationData"
   TagUpdateNotification:
-    allOf:
-      - $ref: "#/definitions/NotificationBase"
-      - type: object
-        description: The Notification Object definition for Tag Update Notifications
-        properties:
-          data:
-            $ref: "#/definitions/TagUpdateNotificationData"
-  VulnUpdateNotification:
-    allOf:
-      - $ref: "#/definitions/NotificationBase"
-      - type: object
-        description: The Notification Object definition for Tag Update Notifications
-        properties:
-          data:
-            $ref: "#/definitions/VulnUpdateNotificationData"
-  AnalysisUpdateNotification:
-    allOf:
-      - $ref: "#/definitions/NotificationBase"
-      - type: object
-        description: The Notification Object definition for Tag Update Notifications
-        properties:
-          data:
-            $ref: "#/definitions/AnalysisUpdateNotificationData"
-  BaseNotificationData:
     type: object
-    description: Every notification has a payload, which follows this basic structure
+    description: The Notification Object definition for Tag Update Notifications
+    properties:
+      queueId:
+        type: string
+      userId:
+        type: string
+      dataId:
+        type: string
+      created_at:
+        type: integer
+      last_updated:
+        type: integer
+      record_state_key:
+        type: string
+        default: "active"
+      record_state_val:
+        type: string
+        x-nullable: true
+      tries:
+        type: integer
+      max_tries:
+        type: integer
+      data:
+        $ref: "#/definitions/TagUpdateNotificationData"
+  VulnUpdateNotification:
+    type: object
+    description: The Notification Object definition for Tag Update Notifications
+    properties:
+      queueId:
+        type: string
+      userId:
+        type: string
+      dataId:
+        type: string
+      created_at:
+        type: integer
+      last_updated:
+        type: integer
+      record_state_key:
+        type: string
+        default: "active"
+      record_state_val:
+        type: string
+        x-nullable: true
+      tries:
+        type: integer
+      max_tries:
+        type: integer
+      data:
+        $ref: "#/definitions/VulnUpdateNotificationData"
+  AnalysisUpdateNotification:
+    type: object
+    description: The Notification Object definition for Tag Update Notifications
+    properties:
+      queueId:
+        type: string
+      userId:
+        type: string
+      dataId:
+        type: string
+      created_at:
+        type: integer
+      last_updated:
+        type: integer
+      record_state_key:
+        type: string
+        default: "active"
+      record_state_val:
+        type: string
+        x-nullable: true
+      tries:
+        type: integer
+      max_tries:
+        type: integer
+      data:
+        $ref: "#/definitions/AnalysisUpdateNotificationData"
+  PolicyEvalNotificationData:
+    type: object
     properties:
       notification_user:
         type: string
@@ -4775,37 +4830,43 @@ definitions:
         type: string
       notification_type:
         type: string
-  PolicyEvalNotificationData:
-    allOf:
-      - $ref: "#/definitions/BaseNotificationData"
-      - type: object
-        properties:
-          notification_payload:
-            $ref: "#/definitions/PolicyEvalNotificationPayload"
+      notification_payload:
+        $ref: "#/definitions/PolicyEvalNotificationPayload"
   TagUpdateNotificationData:
-    allOf:
-      - $ref: "#/definitions/BaseNotificationData"
-      - type: object
-        properties:
-          notification_payload:
-            $ref: "#/definitions/TagUpdateNotificationPayload"
-  VulnUpdateNotificationData:
-    allOf:
-      - $ref: "#/definitions/BaseNotificationData"
-      - type: object
-        properties:
-          notification_payload:
-            $ref: "#/definitions/VulnUpdateNotificationPayload"
-  AnalysisUpdateNotificationData:
-    allOf:
-      - $ref: "#/definitions/BaseNotificationData"
-      - type: object
-        properties:
-          notification_payload:
-            $ref: "#/definitions/AnalysisUpdateNotificationPayload"
-  GenericNotificationPayload:
     type: object
-    description: Parent class for Notification Payloads
+    properties:
+      notification_user:
+        type: string
+      notification_user_email:
+        type: string
+      notification_type:
+        type: string
+      notification_payload:
+        $ref: "#/definitions/TagUpdateNotificationPayload"
+  VulnUpdateNotificationData:
+    type: object
+    properties:
+      notification_user:
+        type: string
+      notification_user_email:
+        type: string
+      notification_type:
+        type: string
+      notification_payload:
+        $ref: "#/definitions/VulnUpdateNotificationPayload"
+  AnalysisUpdateNotificationData:
+    type: object
+    properties:
+      notification_user:
+        type: string
+      notification_user_email:
+        type: string
+      notification_type:
+        type: string
+      notification_payload:
+        $ref: "#/definitions/AnalysisUpdateNotificationPayload"
+  PolicyEvalNotificationPayload:
+    type: object
     properties:
       userId:
         type: string
@@ -4815,64 +4876,77 @@ definitions:
         type: string
       notificationId:
         type: string
-  PolicyEvalNotificationPayload:
-    allOf:
-      - $ref: "#/definitions/GenericNotificationPayload"
-      - type: object
-        properties:
-          curr_eval:
-            type: object
-            description: The Current Policy Evaluation result
-          last_eval:
-            type: object
-            description: The Previous Policy Evaluation result
-          annotations:
-            type: object
-            description: List of Corresponding Image Annotations
-            x-nullable: true
+      curr_eval:
+        type: object
+        description: The Current Policy Evaluation result
+      last_eval:
+        type: object
+        description: The Previous Policy Evaluation result
+      annotations:
+        type: object
+        description: List of Corresponding Image Annotations
+        x-nullable: true
   TagUpdateNotificationPayload:
-    allOf:
-      - $ref: "#/definitions/GenericNotificationPayload"
-      - type: object
-        properties:
-          curr_eval:
-            type: array
-            items: {}
-            description: A list containing the current image digest
-          last_eval:
-            type: array
-            items: {}
-            description: A list containing the previous image digests
-          annotations:
-            type: object
-            description: List of Corresponding Image Annotations
-            x-nullable: true
+    type: object
+    properties:
+      userId:
+        type: string
+      subscription_key:
+        type: string
+      subscription_type:
+        type: string
+      notificationId:
+        type: string
+      curr_eval:
+        type: array
+        items: {}
+        description: A list containing the current image digest
+      last_eval:
+        type: array
+        items: {}
+        description: A list containing the previous image digests
+      annotations:
+        type: object
+        description: List of Corresponding Image Annotations
+        x-nullable: true
   VulnUpdateNotificationPayload:
-    allOf:
-      - $ref: "#/definitions/GenericNotificationPayload"
-      - type: object
-        properties:
-          diff_vulnerability_result:
-            $ref: "#/definitions/VulnDiffResult"
-          imageDigest:
-            type: string
-          annotations:
-            type: object
-            description: List of Corresponding Image Annotations
-            x-nullable: true
+    type: object
+    properties:
+      userId:
+        type: string
+      subscription_key:
+        type: string
+      subscription_type:
+        type: string
+      notificationId:
+        type: string
+      diff_vulnerability_result:
+        $ref: "#/definitions/VulnDiffResult"
+      imageDigest:
+        type: string
+      annotations:
+        type: object
+        description: List of Corresponding Image Annotations
+        x-nullable: true
   AnalysisUpdateNotificationPayload:
-    allOf:
-      - $ref: "#/definitions/GenericNotificationPayload"
-      - type: object
-        properties:
-          curr_eval:
-            $ref: "#/definitions/AnalysisUpdateEval"
-          last_eval:
-            $ref: "#/definitions/AnalysisUpdateEval"
-          annotations:
-            type: object
-            description: List of Corresponding Image Annotations
-            x-nullable: true
+    type: object
+    properties:
+      userId:
+        type: string
+      subscription_key:
+        type: string
+      subscription_type:
+        type: string
+      notificationId:
+        type: string
+      curr_eval:
+        $ref: "#/definitions/AnalysisUpdateEval"
+      last_eval:
+        $ref: "#/definitions/AnalysisUpdateEval"
+      annotations:
+        type: object
+        description: List of Corresponding Image Annotations
+        x-nullable: true
   VulnDiffResult:
     type: object
     description: The results of the comparing two vulnerability records during an update


### PR DESCRIPTION
… remove them, but keep the objects

Signed-off-by: Samuel Dacanay <sam.dacanay@anchore.com>

<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**: The branch name was a bit premature, but essentially the "allOf" logic in the swagger.yaml was affecting the ability of a python swagger codegen client to successfully be used (it resulted in some ImportErrors when the client got imported)

This PR replaces those blocks with the properties of the "inherited" definition. We don't get the allOf simplicity any more, but it allows the clients to still work and allows us to keep the definitions themselves, albeit with a little less reuse.

