### PR TITLE
Add cpes to swagger spec

### DIFF
--- a/anchore_engine/services/apiext/swagger/swagger.yaml
+++ b/anchore_engine/services/apiext/swagger/swagger.yaml
@@ -3709,6 +3709,7 @@ definitions:
               type: array
               items:
                 type: string
+              description: A list of Common Platform Enumerations that may uniquely identify the package
   ContentMalwareResponse:
     type: object
     description: Malware listing response
@@ -3777,6 +3778,7 @@ definitions:
               type: array
               items:
                 type: string
+              description: A list of Common Platform Enumerations that may uniquely identify the package
   MetadataResponse:
     type: object
     description: "Generic wrapper for metadata listings from images"
@@ -4485,6 +4487,9 @@ definitions:
     properties:
       selector:
         $ref: "#/definitions/ImageSelector"
+      rule_id:
+        type: string
+        description: Unique identifier for archive rule
       tag_versions_newer:
         type: integer
         description: Number of images mapped to the tag that are newer

--- a/anchore_engine/services/apiext/swagger/swagger.yaml
+++ b/anchore_engine/services/apiext/swagger/swagger.yaml
@@ -3705,6 +3705,10 @@ definitions:
                 type: string
             location:
               type: string
+            cpes:
+              type: array
+              items:
+                type: string
   ContentMalwareResponse:
     type: object
     description: Malware listing response
@@ -3769,6 +3773,10 @@ definitions:
               type: string
             origin:
               type: string
+            cpes:
+              type: array
+              items:
+                type: string
   MetadataResponse:
     type: object
     description: "Generic wrapper for metadata listings from images"


### PR DESCRIPTION
Signed-off-by: Samuel Dacanay <sam.dacanay@anchore.com>

<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**: While building out some automated tests for some recent features, discovered that the CPEs field was not present in the swagger spec for image content responses, even though the field is now returned.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #:

**Special notes**:


