### PR TITLE
requirements: bump jsonschema to avoid legacy validator import issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ boto3==1.11.6
 Click==7.0
 connexion==2.5.1
 Flask==1.1.1
-jsonschema==2.6.0
+jsonschema==3.1.1
 passlib==1.7.4
 pathlib==1.0.1
 prettytable==0.7.2

--- a/tests/unit/anchore_engine/services/policy_engine/policy/test_parameters.py
+++ b/tests/unit/anchore_engine/services/policy_engine/policy/test_parameters.py
@@ -136,7 +136,7 @@ class TestTypeValidator(unittest.TestCase, ValidatorTestMixin):
         matrix = [
             ("blah", False),
             (1, True),
-            (1.0, False),
+            (1.0, True),
             (["a"], False),
             ({}, False),
             ({"a": "b"}, False),


### PR DESCRIPTION

**What this PR does / why we need it**: 
there is a third-party dependency from the connexion library that pulls in openapi-spec-validator>=0.2.4, that project in turn defines “jsonschema” as a dependency but it doesn’t pin it. Anchore Engine (and therefore Enterprise) uses jsonschema 2.6.0 which doesn’t have _legacy_validators. However, the latest jsonschema package (3.2.0) does have _legacy_validators

So Anchore Engine is pinning jsonschema (correctly) but that pinned version is not compatible to what the expectation is for openapi-spec-validator

**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #:

**Special notes**: 3.1.1 is the latest from jsonschema that seems to fix other 3.0.0 issues that would fix the import problem as well

According to draft-6 which the new jsonschema supports 1.0 is considered
an integer. Relevant doc from the draft:

> In draft-04, "integer" is listed as a primitive type and defined as “a JSON number without a fraction or exponent part”; in draft-06, "integer" is not considered a primitive type and is only defined in the section for keyword "type" as “any number with a zero fractional part”; 1.0 is thus not a valid "integer" type in draft-04 and earlier, but is a valid "integer" type in draft-06 and later; note that both drafts say that integers SHOULD be encoded in JSON without fractional parts

Link https://json-schema.org/draft-06/json-schema-release-notes.html



