### PR TITLE
Update Quickstart Docker-Compose image tag to v0.9.2

### DIFF
--- a/anchore_engine/services/apiext/swagger/swagger.yaml
+++ b/anchore_engine/services/apiext/swagger/swagger.yaml
@@ -1,7 +1,7 @@
 swagger: "2.0"
 info:
   description: "This is the Anchore Engine API. Provides the primary external API for users of the service."
-  version: "0.1.16"
+  version: "0.1.17"
   title: "Anchore Engine API Server"
   contact:
     email: "nurmi@anchore.com"

--- a/docs/content/docs/quickstart/docker-compose.yaml
+++ b/docs/content/docs/quickstart/docker-compose.yaml
@@ -11,7 +11,7 @@ volumes:
 services:
   # The primary API endpoint service
   api:
-    image: anchore/anchore-engine:v0.9.0
+    image: anchore/anchore-engine:v0.9.2
     depends_on:
       - db
       - catalog
@@ -30,7 +30,7 @@ services:
 
   # Catalog is the primary persistence and state manager of the system
   catalog:
-    image: anchore/anchore-engine:v0.9.0
+    image: anchore/anchore-engine:v0.9.2
     depends_on:
       - db
     logging:
@@ -46,7 +46,7 @@ services:
       - ANCHORE_DB_PASSWORD=mysecretpassword
     command: ["anchore-manager", "service", "start", "catalog"]
   queue:
-    image: anchore/anchore-engine:v0.9.0
+    image: anchore/anchore-engine:v0.9.2
     depends_on:
       - db
       - catalog
@@ -63,7 +63,7 @@ services:
       - ANCHORE_DB_PASSWORD=mysecretpassword
     command: ["anchore-manager", "service", "start", "simplequeue"]
   policy-engine:
-    image: anchore/anchore-engine:v0.9.0
+    image: anchore/anchore-engine:v0.9.2
     depends_on:
       - db
       - catalog
@@ -80,7 +80,7 @@ services:
       - ANCHORE_DB_PASSWORD=mysecretpassword
     command: ["anchore-manager", "service", "start", "policy_engine"]
   analyzer:
-    image: anchore/anchore-engine:v0.9.0
+    image: anchore/anchore-engine:v0.9.2
     depends_on:
       - db
       - catalog


### PR DESCRIPTION
As part of release of engine v0.9.2, update the quickstart docker-compose image reference tags