### PR TITLE
Fixes distro mapping of redhat -> rhel for imported images

### DIFF
--- a/anchore_engine/services/analyzer/imports.py
+++ b/anchore_engine/services/analyzer/imports.py
@@ -132,12 +132,17 @@ def process_import(
 
         timer = time.time()
 
+        distro = syft_packages.get("distro", {}).get("name")
+        # Map 'redhat' distro to 'rhel' distro for consistency between internal metadata fetch from squashtar and the syft implementation used for import
+        if distro == "redhat":
+            distro = "rhel"
+
         # Move data from the syft sbom into the analyzer output
         analyzer_report = {
             "analyzer_meta": {
                 "analyzer_meta": {
                     "base": {
-                        "DISTRO": syft_packages.get("distro", {}).get("name"),
+                        "DISTRO": distro,
                         "DISTROVERS": syft_packages.get("distro", {}).get("version"),
                         "LIKEDISTRO": syft_packages.get("distro", {}).get("idLike"),
                     }

--- a/anchore_engine/services/policy_engine/__init__.py
+++ b/anchore_engine/services/policy_engine/__init__.py
@@ -157,6 +157,7 @@ def _init_distro_mappings():
         DistroMapping(from_distro="rhel", to_distro="rhel", flavor="RHEL"),
         DistroMapping(from_distro="ubuntu", to_distro="ubuntu", flavor="DEB"),
         DistroMapping(from_distro="amzn", to_distro="amzn", flavor="RHEL"),
+        DistroMapping(from_distro="redhat", to_distro="rhel", flavor="RHEL"),
     ]
 
     # set up any data necessary at system init

--- a/tests/integration/services/policy_engine/test_namespaces.py
+++ b/tests/integration/services/policy_engine/test_namespaces.py
@@ -170,8 +170,6 @@ distros_no_vulns = [
     ("alpine", "3.1.1", "alpine"),
     ("busybox", "3", "busybox"),
     ("linuxmint", "16", "debian"),
-    ("redhat", "4", "rhel"),
-    ("redhat", "5", "rhel"),
     ("ubuntu", "1.0", "ubuntu"),
     ("centos", "1.0", "ubuntu"),
     ("debian", "1.0", "ubuntu"),
@@ -234,11 +232,12 @@ def test_distromappings(initialized_mappings):
     assert c7.like_namespace_names == ["rhel:7"]
 
     r7 = DistroNamespace(name="rhel", version="7", like_distro="rhel")
-    assert set(r7.mapped_names()) == {"centos", "fedora", "rhel"}
+    assert set(r7.mapped_names()) == {"centos", "fedora", "rhel", "redhat"}
     assert r7.like_namespace_names == ["rhel:7"]
 
     assert sorted(DistroMapping.distros_mapped_to("rhel", "7")) == sorted(
         [
+            DistroTuple("redhat", "7", "RHEL"),
             DistroTuple("rhel", "7", "RHEL"),
             DistroTuple("centos", "7", "RHEL"),
             DistroTuple("fedora", "7", "RHEL"),


### PR DESCRIPTION
Fixes the issue in 2 ways:
1. Adds a new distro mapping record during policy engine bootstrap so any images that are identified as 'redhat' will be matched to 'rhel' feeds correctly. This allows vuln-rescan of existing images to work using internal APIs to work as a mitigation if re-analysis is not possible.
2. Adds an explicit mapping during the import process to change "redhat" to "rhel" to be consistent with the internal analysis path.

Fixes #944 