### PR TITLE
Fix Java pom.properties parsing and lang-pack matching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN set -ex && \
 
 RUN set -ex && \
     echo "installing Syft" && \
-    curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /build_output/deps v0.13.1
+    curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /build_output/deps v0.14.0
 
 # stage RPM dependency binaries
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \

--- a/anchore_engine/analyzers/syft/handlers/java.py
+++ b/anchore_engine/analyzers/syft/handlers/java.py
@@ -55,6 +55,18 @@ def translate_and_save_entry(findings, artifact):
     if group_id:
         origin = group_id
 
+    # synthesize a part of the pom.properties
+    pom_artifact_id = dig(artifact, "metadata", "pomProperties", "artifactId")
+    pom_version = dig(artifact, "metadata", "pomProperties", "version")
+
+    pomProperties = """
+groupId={}
+artifactId={}
+version={}
+""".format(
+        group_id, pom_artifact_id, pom_version
+    )
+
     pkg_value = {
         "name": artifact["name"],
         "specification-version": values.get("Specification-Version", "N/A"),
@@ -66,6 +78,7 @@ def translate_and_save_entry(findings, artifact):
         "location": pkg_key,  # this should be related to full path
         "type": "java-" + java_ext,
         "cpes": artifact.get("cpes", []),
+        "metadata": {"pom.properties": pomProperties},
     }
 
     # inject the artifact document into the "raw" analyzer document

--- a/anchore_engine/services/policy_engine/engine/loaders.py
+++ b/anchore_engine/services/policy_engine/engine/loaders.py
@@ -866,6 +866,10 @@ class ImageLoader(object):
             n.distro_version = "N/A"
             n.like_distro = "java"
 
+            m = pkg_json.get("metadata")
+            m["java_versions"] = versions_json
+            n.metadata_json = m
+
             fullname = n.name
             pomprops = n.get_pom_properties()
             pomversion = None


### PR DESCRIPTION
This PR achieves a few things:
- Bumps syft to v0.14.0 to pull in https://github.com/anchore/syft/pull/348 to allow for both `:` and `=` delimiters in parsed pom.property files when analyzing java packages.
- https://github.com/anchore/anchore-engine/pull/693 removed the java `metadata_json` data in the policy engine loader, which was used for the lang-pack matching (which is how GHSA matches are discovered). This PR synthesizes a pom.properties file and stores it in the `metadata_json` object.

Fixes #950 