### PR TITLE
Bump version to 0.9.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ FROM registry.access.redhat.com/ubi8/ubi:8.3 as anchore-engine-final
 
 ARG CLI_COMMIT
 ARG ANCHORE_COMMIT
-ARG ANCHORE_ENGINE_VERSION="0.9.2"
+ARG ANCHORE_ENGINE_VERSION="0.9.3"
 ARG ANCHORE_ENGINE_RELEASE="r0"
 
 # Copy skopeo artifacts from build step

--- a/anchore_engine/version.py
+++ b/anchore_engine/version.py
@@ -1,2 +1,2 @@
-version = "0.9.2"
+version = "0.9.3"
 db_version = "0.0.14"

--- a/anchore_manager/version.py
+++ b/anchore_manager/version.py
@@ -1,1 +1,1 @@
-version = "0.9.2"
+version = "0.9.3"


### PR DESCRIPTION
This PR bumps the version in anchore_engine, anchore_manager and Dockerfile to 0.9.3