### PR TITLE
Fix bug in 2.3 CPE string construction logic. Use the cpe part as it is

### DIFF
--- a/anchore_engine/db/entities/policy_engine.py
+++ b/anchore_engine/db/entities/policy_engine.py
@@ -2168,7 +2168,7 @@ class ImageCpe(Base):
                 "-",
                 "-",
             ]
-            final_cpe[2] = self.cpetype[1]
+            final_cpe[2] = self.cpetype
             final_cpe[3] = self.vendor
             final_cpe[4] = self.name
             final_cpe[5] = self.version


### PR DESCRIPTION
This PR addresses the missing 2.3 CPE string in the vulnerabilities output. It gets rid of the legacy handling of cpes where in the policy engine generated cpes with `/` prefix in the cpe part 