### PR TITLE
use a ref that exists for the black linter github action

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -6,4 +6,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - uses: psf/black@stable
+      - uses: psf/black@20.8b1


### PR DESCRIPTION
Signed-off-by: Alfredo Deza <adeza@anchore.com>

<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**: Fixes a problem with the black linter github action that is broken because the branch was removed 


**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: closes https://github.com/anchore/anchore-engine/issues/962

**Special notes**:


