### PR TITLE
add type hints and custom exception classes to session getters in common.py

### DIFF
--- a/anchore_engine/clients/services/simplequeue.py
+++ b/anchore_engine/clients/services/simplequeue.py
@@ -313,7 +313,7 @@ def run_target_with_lease(
 
         if autorefresh:
             # Run the task thread and monitor it, refreshing the task lease as needed
-            while handler_thread.isAlive():
+            while handler_thread.is_alive():
                 # If we're halfway to the timeout, refresh to have a safe buffer
                 if time.time() - t > (ttl / 2):
                     # refresh the lease

--- a/anchore_engine/db/entities/common.py
+++ b/anchore_engine/db/entities/common.py
@@ -16,6 +16,8 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.orm.session import Session as SessionObject
 
+from anchore_engine.utils import AnchoreException
+
 try:
     # Separate logger for use during bootstrap when logging may not be fully configured
     from twisted.python import log
@@ -306,25 +308,16 @@ def initialize(localconfig=None, versions=None):
     return ret
 
 
-class SessionNotInitializedError(Exception):
-    def __init__(self, message):
-        if message:
-            self.message = message
-        else:
-            self.message = "Invoked get_session without first calling do_connect to initialize the engine and session factory"
-        super().__init__(self.message)
-
-
-class ScopedSessionNotInitializedError(SessionNotInitializedError):
+class ScopedSessionNotInitializedError(AnchoreException):
     def __init__(self):
-        self.message = "Invoked get_thread_scoped_session without first calling init_thread_session to initialize the engine and session factory"
-        super().__init__(self.message)
+        super().__init__(
+            "Invoked get_thread_scoped_session without first calling init_thread_session to initialize "
+            "the engine and session factory"
+        )
 
 
 def get_session() -> SessionObject:
     global Session
-    if not Session:
-        raise SessionNotInitializedError
     return Session()
 
 

--- a/anchore_engine/db/entities/common.py
+++ b/anchore_engine/db/entities/common.py
@@ -11,7 +11,7 @@ from typing import Generator, Optional
 
 import sqlalchemy
 from sqlalchemy import types
-from sqlalchemy.engine import Engine
+from sqlalchemy.engine.base import Engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.orm.session import Session as SessionObject
@@ -307,8 +307,11 @@ def initialize(localconfig=None, versions=None):
 
 
 class SessionNotInitializedError(Exception):
-    def __init__(self):
-        self.message = "Invoked get_session without first calling do_connect to initialize the engine and session factory"
+    def __init__(self, message):
+        if message:
+            self.message = message
+        else:
+            self.message = "Invoked get_session without first calling do_connect to initialize the engine and session factory"
         super().__init__(self.message)
 
 
@@ -328,8 +331,7 @@ def get_session() -> SessionObject:
 @contextmanager
 def session_scope() -> Generator[SessionObject, None, None]:
     """Provide a transactional scope around a series of operations."""
-    global Session
-    session = Session()
+    session = get_session()
 
     # session.connection(execution_options={'isolation_level': 'SERIALIZABLE'})
 


### PR DESCRIPTION
Signed-off-by: Vijay Pillai <vijay.pillai@anchore.com>

<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**:
The globals in common.py are used pretty much anywhere the database is used, but the lack of type hints on the getters and the globals themselves prevent autocompletion/ide from recognizing the type returned by them. This is annoying, so i've added those things. Also switched out a deprecated method in simpleq.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #:

**Special notes**:


