### PR TITLE
Impose list ordering before result comparisons

### DIFF
--- a/tests/functional/services/policy_engine/conftest.py
+++ b/tests/functional/services/policy_engine/conftest.py
@@ -42,14 +42,14 @@ def read_expected_content(module_path, filename):
 
 
 @pytest.fixture
-def expected_content(request) -> Callable[[str], Dict]:
+def expected_content(request) -> Callable:
     """
     Returns method that will load expected vulnerability response json for a given image_digest
     :rtype: Callable[[str], Dict]
     :return: method that loads expected response json
     """
 
-    def get_expected_content(filename) -> Dict:
+    def get_expected_content(filename):
         module_path = request.module.__file__
         return read_expected_content(module_path, filename)
 

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/test_query_vulnerabilities.py
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/test_query_vulnerabilities.py
@@ -72,4 +72,9 @@ class TestQueryVulnerabilities:
 
         assert vulnerabilities_resp == http_utils.APIResponse(200)
         expected = expected_content(query.expected_output_file)
-        assert vulnerabilities_resp.body == expected
+        if expected:
+            expected.sort(key=lambda x: (x.get("id"), x.get("namespace")))
+        results = vulnerabilities_resp.body
+        if results:
+            results.sort(key=lambda x: (x.get("id"), x.get("namespace")))
+        assert results == expected


### PR DESCRIPTION
PR fixes an intermittent functional test failure. The test compares a list of expected results to the API response. There are no ordering guarantees from the API and this causes the comparison to fail. The fix orders the lists before comparing them.