### PR TITLE
Vulnerabilities refactor

### DIFF
--- a/anchore_engine/services/policy_engine/api/models.py
+++ b/anchore_engine/services/policy_engine/api/models.py
@@ -378,7 +378,6 @@ class VulnerabilityScanProblem(JsonSerializable):
 class ImageIngressResponse(JsonSerializable):
     class ImageIngressResponseV1Schema(Schema):
         status = fields.Str()
-        vulnerability_report = fields.Dict()
         problems = fields.List(
             fields.Nested(VulnerabilityScanProblem.VulnerabilityScanProblemV1Schema)
         )
@@ -389,9 +388,8 @@ class ImageIngressResponse(JsonSerializable):
 
     __schema__ = ImageIngressResponseV1Schema()
 
-    def __init__(self, status=None, vulnerability_report=None, problems=None):
+    def __init__(self, status=None, problems=None):
         self.status = status
-        self.vulnerability_report = vulnerability_report
         self.problems = problems
 
 

--- a/anchore_engine/services/policy_engine/engine/policy/gates/vulnerabilities.py
+++ b/anchore_engine/services/policy_engine/engine/policy/gates/vulnerabilities.py
@@ -29,7 +29,7 @@ from anchore_engine.services.policy_engine.engine.policy.params import (
 from anchore_engine.clients.services.common import get_service_endpoint
 from anchore_engine.common import nonos_package_types
 from anchore_engine.services.policy_engine.engine.feeds.feeds import feed_registry
-from anchore_engine.services.policy_engine.engine.scanner import get_scanner
+from anchore_engine.services.policy_engine.engine.vulns.scanners import get_scanner
 
 
 SEVERITY_ORDERING = ["unknown", "negligible", "low", "medium", "high", "critical"]
@@ -1037,14 +1037,14 @@ class VulnerabilitiesGate(Gate):
         _nvd_cls, _cpe_cls = select_nvd_classes()
         context.data["nvd_cpe_cls"] = (_nvd_cls, _cpe_cls)
 
-        scanner = get_scanner(_nvd_cls, _cpe_cls)
+        scanner = get_scanner()
 
         # Load the package vulnerability info up front
         pkg_vulns = scanner.get_vulnerabilities(image_obj)
         context.data["loaded_vulnerabilities"] = pkg_vulns
 
         # Load the non-package (CPE) vulnerability info up front
-        all_cpe_matches = scanner.get_cpe_vulnerabilities(image_obj)
+        all_cpe_matches = scanner.get_cpe_vulnerabilities(image_obj, _nvd_cls, _cpe_cls)
         if not all_cpe_matches:
             all_cpe_matches = []
 

--- a/anchore_engine/services/policy_engine/engine/vulns/providers.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/providers.py
@@ -1,0 +1,288 @@
+import json
+
+from anchore_engine.clients.services.common import get_service_endpoint
+from anchore_engine.common.helpers import make_response_error
+from anchore_engine.db import DistroNamespace
+from anchore_engine.db import (
+    Image,
+    get_thread_scoped_session as get_session,
+    select_nvd_classes,
+)
+from anchore_engine.services.policy_engine.engine.feeds.feeds import (
+    have_vulnerabilities_for,
+)
+from anchore_engine.db import Vulnerability, ImagePackage, ImagePackageVulnerability
+from anchore_engine.services.policy_engine.engine.vulns.scanners import (
+    LegacyScanner,
+)
+from anchore_engine.services.policy_engine.engine.vulnerabilities import (
+    merge_nvd_metadata_image_packages,
+)
+from anchore_engine.subsys import logger as log
+from anchore_engine.utils import timer
+
+
+TABLE_STYLE_HEADER_LIST = [
+    "CVE_ID",
+    "Severity",
+    "*Total_Affected",
+    "Vulnerable_Package",
+    "Fix_Available",
+    "Fix_Images",
+    "Rebuild_Images",
+    "URL",
+    "Package_Type",
+    "Feed",
+    "Feed_Group",
+    "Package_Name",
+    "Package_Path",
+    "Package_Version",
+    "CVES",
+]
+# Disabled by default, can be set in config file. Seconds for connection to cache for policy evals
+DEFAULT_CACHE_CONN_TIMEOUT = -1
+# Disabled by default, can be set in config file. Seconds for first byte timeout for policy eval cache
+DEFAULT_CACHE_READ_TIMEOUT = -1
+
+
+class VulnerabilitiesProvider:
+    """
+    This is an abstraction for providing answers to any and all vulnerability related questions in the system.
+    It encapsulates a scanner for finding vulnerabilities in an image and an optional cache manager to cache the resulting reports.
+    In addition the provider support queries for vulnerabilities and aggregating vulnerability data across images
+    """
+
+    __scanner__ = None
+    __cache_manager__ = None
+
+    def load_image(self, **kwargs):
+        """
+        Ingress the image and compute the vulnerability matches. To be used in the load image path to prime the matches
+        """
+        raise NotImplementedError()
+
+    def get_image_vulnerabilities(self, **kwargs):
+        """
+        Returns a vulnerabilities report for the image. To be used to fetch vulnerabilities for an already loaded image
+        """
+        raise NotImplementedError()
+
+    def get_vulnerabilities(self, **kwargs):
+        """
+        Query the vulnerabilities database (not matched vulnerabilities) with filters
+        """
+        raise NotImplementedError()
+
+    def get_images_by_vulnerability(self, **kwargs):
+        """
+        Query the image set impacted by a specific vulnerability
+        """
+        raise NotImplementedError()
+
+
+class LegacyProvider(VulnerabilitiesProvider):
+    """
+    The legacy provider is based on image data loaded into the policy-engine database.
+    For backwards compatibility there is no cache manager
+    """
+
+    __scanner__ = LegacyScanner
+    __cache_manager__ = None
+
+    def load_image(self, image: Image, db_session, cache=False):
+        # initialize the scanner
+        scanner = self.__scanner__()
+
+        # flush existing matches, recompute matches and add them to session
+        scanner.flush_and_recompute_vulnerabilities(image, db_session=db_session)
+
+    def get_image_vulnerabilities(
+        self,
+        image: Image,
+        db_session,
+        vendor_only: bool = True,
+        force_refresh: bool = False,
+        cache: bool = True,
+    ):
+        # select the nvd class once and be done
+        _nvd_cls, _cpe_cls = select_nvd_classes(db_session)
+
+        # initialize the scanner
+        scanner = self.__scanner__()
+
+        user_id = image.user_id
+        image_id = image.id
+
+        if force_refresh:
+            log.info(
+                "Forcing refresh of vulnerabilities for {}/{}".format(user_id, image_id)
+            )
+            try:
+                scanner.flush_and_recompute_vulnerabilities(
+                    image, db_session=db_session
+                )
+                db_session.commit()
+            except Exception as e:
+                log.exception(
+                    "Error refreshing cve matches for image {}/{}".format(
+                        user_id, image_id
+                    )
+                )
+                db_session.rollback()
+                return make_response_error(
+                    "Error refreshing vulnerability listing for image.",
+                    in_httpcode=500,
+                )
+
+            db_session = get_session()
+            db_session.refresh(image)
+
+        with timer("Image vulnerability primary lookup", log_level="debug"):
+            vulns = scanner.get_vulnerabilities(image)
+
+        # Has vulnerabilities?
+        warns = []
+        if not vulns:
+            vulns = []
+            ns = DistroNamespace.for_obj(image)
+            if not have_vulnerabilities_for(ns):
+                warns = [
+                    "No vulnerability data available for image distro: {}".format(
+                        ns.namespace_name
+                    )
+                ]
+
+        rows = []
+        with timer("Image vulnerability nvd metadata merge", log_level="debug"):
+            vulns = merge_nvd_metadata_image_packages(
+                db_session, vulns, _nvd_cls, _cpe_cls
+            )
+
+        with timer("Image vulnerability output formatting", log_level="debug"):
+            for vuln, nvd_records in vulns:
+                # Skip the vulnerability if the vendor_only flag is set to True and the issue won't be addressed by the vendor
+                if vendor_only and vuln.fix_has_no_advisory():
+                    continue
+
+                # rennovation this for new CVSS references
+                cves = ""
+                nvd_list = []
+                all_data = {"nvd_data": nvd_list, "vendor_data": []}
+
+                for nvd_record in nvd_records:
+                    nvd_list.extend(nvd_record.get_cvss_data_nvd())
+
+                cves = json.dumps(all_data)
+
+                if vuln.pkg_name != vuln.package.fullversion:
+                    pkg_final = "{}-{}".format(vuln.pkg_name, vuln.package.fullversion)
+                else:
+                    pkg_final = vuln.pkg_name
+
+                rows.append(
+                    [
+                        vuln.vulnerability_id,
+                        vuln.vulnerability.severity,
+                        1,
+                        pkg_final,
+                        str(vuln.fixed_in()),
+                        vuln.pkg_image_id,
+                        "None",  # Always empty this for now
+                        vuln.vulnerability.link,
+                        vuln.pkg_type,
+                        "vulnerabilities",
+                        vuln.vulnerability.namespace_name,
+                        vuln.pkg_name,
+                        vuln.pkg_path,
+                        vuln.package.fullversion,
+                        cves,
+                    ]
+                )
+
+        vuln_listing = {
+            "multi": {
+                "url_column_index": 7,
+                "result": {
+                    "header": TABLE_STYLE_HEADER_LIST,
+                    "rowcount": len(rows),
+                    "colcount": len(TABLE_STYLE_HEADER_LIST),
+                    "rows": rows,
+                },
+                "warns": warns,
+            }
+        }
+
+        cpe_vuln_listing = []
+        try:
+            with timer("Image vulnerabilities cpe matches", log_level="debug"):
+                all_cpe_matches = scanner.get_cpe_vulnerabilities(
+                    image, _nvd_cls, _cpe_cls
+                )
+
+                if not all_cpe_matches:
+                    all_cpe_matches = []
+
+                api_endpoint = self._get_api_endpoint()
+
+                for image_cpe, vulnerability_cpe in all_cpe_matches:
+                    link = vulnerability_cpe.parent.link
+                    if not link:
+                        link = "{}/query/vulnerabilities?id={}".format(
+                            api_endpoint, vulnerability_cpe.vulnerability_id
+                        )
+
+                    cpe_vuln_el = {
+                        "vulnerability_id": vulnerability_cpe.parent.normalized_id,
+                        "severity": vulnerability_cpe.parent.severity,
+                        "link": link,
+                        "pkg_type": image_cpe.pkg_type,
+                        "pkg_path": image_cpe.pkg_path,
+                        "name": image_cpe.name,
+                        "version": image_cpe.version,
+                        "cpe": image_cpe.get_cpestring(),
+                        "cpe23": image_cpe.get_cpe23string(),
+                        "feed_name": vulnerability_cpe.feed_name,
+                        "feed_namespace": vulnerability_cpe.namespace_name,
+                        "nvd_data": vulnerability_cpe.parent.get_cvss_data_nvd(),
+                        "vendor_data": vulnerability_cpe.parent.get_cvss_data_vendor(),
+                        "fixed_in": vulnerability_cpe.get_fixed_in(),
+                    }
+                    cpe_vuln_listing.append(cpe_vuln_el)
+        except Exception as err:
+            log.warn("could not fetch CPE matches - exception: " + str(err))
+
+        return {
+            "user_id": image.user_id,
+            "image_id": image.id,
+            "legacy_report": vuln_listing,
+            "cpe_report": cpe_vuln_listing,
+        }
+
+    @staticmethod
+    def _get_api_endpoint():
+        try:
+            return get_service_endpoint("apiext").strip("/")
+        except:
+            log.warn(
+                "Could not find valid apiext endpoint for links so will use policy engine endpoint instead"
+            )
+            try:
+                return get_service_endpoint("policy_engine").strip("/")
+            except:
+                log.warn(
+                    "No policy engine endpoint found either, using default but invalid url"
+                )
+                return "http://<valid endpoint not found>"
+
+    def get_vulnerabilities(self, **kwargs):
+        pass
+
+    def get_images_by_vulnerability(self, **kwargs):
+        pass
+
+
+default_type = LegacyProvider
+
+
+def get_vulnerabilities_provider():
+    return default_type()

--- a/anchore_engine/services/policy_engine/swagger/swagger.yaml
+++ b/anchore_engine/services/policy_engine/swagger/swagger.yaml
@@ -1049,8 +1049,6 @@ definitions:
         - accepted
         - failed
         - loaded
-      vulnerability_report:
-        $ref: "#/definitions/ImageVulnerabilityListing"
       problems:
         type: array
         description: list of error objects indicating errors encountered during vulnerability scan

--- a/tests/functional/clients/scripts/standalone.py
+++ b/tests/functional/clients/scripts/standalone.py
@@ -219,7 +219,7 @@ def main(
     tag=None,
     work_dir=None,
     localconfig=None,
-    **kw
+    **kw,
 ):
     # Re-assign work_dir in case it is using the cache, which gets computed
     # dynamically

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/schema_files/ingress_image.schema.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/schema_files/ingress_image.schema.json
@@ -1,17 +1,13 @@
 {
   "type": "object",
-  "$id": "ingress_vulnerability_report.schema.json",
+  "$id": "ingress_image.schema.json",
   "required": [
     "status",
-    "vulnerability_report",
     "problems"
   ],
   "properties": {
     "status": {
       "type": "string"
-    },
-    "vulnerability_report": {
-      "$ref": "vulnerability_report.schema.json"
     },
     "problems": {
       "type": "array",

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/test_vulnerability_scanner.py
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/test_vulnerability_scanner.py
@@ -20,9 +20,7 @@ class TestVulnerabilityScanner:
         image_load_resp: http_utils.APIResponse = ingress_image(image_digest)
         assert image_load_resp == http_utils.APIResponse(200)
         # check that response schema matches expected format
-        ingress_schema_validator = schema_validator(
-            "ingress_vulnerability_report.schema.json"
-        )
+        ingress_schema_validator = schema_validator("ingress_image.schema.json")
         is_valid: bool = ingress_schema_validator.is_valid(image_load_resp.body)
         assert is_valid, "\n".join(
             [str(e) for e in ingress_schema_validator.iter_errors(image_load_resp.body)]
@@ -65,45 +63,7 @@ class TestVulnerabilityScanner:
         assert len(image_load_resp.body["problems"]) == 0, image_load_resp.body[
             "problems"
         ]
-        # get the expected results
-        expected_content = expected_content(image_digest)
-        # check that the row count in the legacy response matches
-        actual_legacy_rowcount = image_load_resp.body["vulnerability_report"][
-            "legacy_report"
-        ]["multi"]["result"]["rowcount"]
-        expected_legacy_rowcount = expected_content["legacy_report"]["multi"]["result"][
-            "rowcount"
-        ]
-        assert actual_legacy_rowcount == expected_legacy_rowcount
-        # check that the legacy rows match (these are OS pkg vulns usually)
-        expected_legacy_rows = set(
-            [
-                tuple(x)
-                for x in expected_content["legacy_report"]["multi"]["result"]["rows"]
-            ]
-        )
-        actual_legacy_rows = set(
-            [
-                tuple(x)
-                for x in image_load_resp.body["vulnerability_report"]["legacy_report"][
-                    "multi"
-                ]["result"]["rows"]
-            ]
-        )
-        assert (
-            actual_legacy_rows == expected_legacy_rows
-        ), f"Expected vulnerabilities missing:\n{expected_legacy_rows - actual_legacy_rows}"
-        # check that the cpe reports match (non-os pkg vulns)
-        expected_cpes = set([json.dumps(x) for x in expected_content["cpe_report"]])
-        actual_cpes = set(
-            [
-                json.dumps(x)
-                for x in image_load_resp.body["vulnerability_report"]["cpe_report"]
-            ]
-        )
-        assert (
-            actual_cpes == expected_cpes
-        ), f"Expected vulnerabilities missing:\n{expected_cpes - actual_cpes}"
+        assert image_load_resp.body["status"] == "loaded"
 
     def test_get_vulnerabilities_content(
         self, image_digest, image_digest_id_map, ingress_image, expected_content

--- a/tests/integration/services/policy_engine/test_vulnerabilities.py
+++ b/tests/integration/services/policy_engine/test_vulnerabilities.py
@@ -6,7 +6,9 @@ from anchore_engine.services.policy_engine.engine import vulnerabilities
 from anchore_engine.db import get_thread_scoped_session, end_session, Image
 from anchore_engine.services.policy_engine.engine.tasks import (
     ImageLoadTask,
-    rescan_image,
+)
+from anchore_engine.services.policy_engine.engine.vulns.providers import (
+    get_vulnerabilities_provider,
 )
 from anchore_engine.services.policy_engine.engine.feeds.sync import DataFeeds
 from tests.integration.services.policy_engine.utils import reset_feed_sync_time
@@ -93,9 +95,9 @@ def _rescan_cve(img_id):
     db = get_thread_scoped_session()
     try:
         img = db.query(Image).filter_by(user_id="0", id=img_id).one_or_none()
-        v = rescan_image(db, img)
+        get_vulnerabilities_provider().load_image(db, img)
         db.commit()
-        return v
+        return
     except:
         db.rollback()
         raise

--- a/tests/unit/anchore_engine/services/policy_engine/api/test_models.py
+++ b/tests/unit/anchore_engine/services/policy_engine/api/test_models.py
@@ -144,14 +144,12 @@ def test_ingress_response():
 
     r = ImageIngressResponse()
     r.status = "ok"
-    r.vulnerability_report = {}
     r.problems = []
-    assert r.to_json() == {"status": "ok", "vulnerability_report": {}, "problems": []}
+    assert r.to_json() == {"status": "ok", "problems": []}
 
     r = ImageIngressResponse()
     assert r.to_json() == {
         "status": None,
-        "vulnerability_report": None,
         "problems": None,
     }
 

--- a/tests/unit/anchore_engine/services/policy_engine/engine/test_dedup.py
+++ b/tests/unit/anchore_engine/services/policy_engine/engine/test_dedup.py
@@ -1,4 +1,6 @@
-from anchore_engine.services.policy_engine.engine.scanner import DefaultVulnScanner
+from anchore_engine.services.policy_engine.engine.vulns.scanners import (
+    LegacyScanner,
+)
 from anchore_engine.services.policy_engine.engine.loaders import ImageLoader
 from anchore_engine.db.entities.policy_engine import ImageCpe
 import pytest
@@ -38,7 +40,7 @@ def cpe_builder():
     ],
 )
 def test_cpe_field_comparison(lhs, rhs, result):
-    assert DefaultVulnScanner(None, None).compare_fields(lhs, rhs) == result
+    assert LegacyScanner().compare_fields(lhs, rhs) == result
 
 
 @pytest.mark.parametrize(
@@ -104,4 +106,4 @@ def test_image_cpe_comparison(lhs, rhs, result, cpe_builder):
     lhs_cpe = cpe_builder(lhs)
     rhs_cpe = cpe_builder(rhs)
 
-    assert DefaultVulnScanner(None, None).compare_cpes(lhs_cpe, rhs_cpe) == result
+    assert LegacyScanner().compare_cpes(lhs_cpe, rhs_cpe) == result


### PR DESCRIPTION
This PR is the beginning of a refactor effort for all things vulnerabilities. It introduces a provider abstraction and refactors current logic spread out across policy-engine into legacy implementation. The abstraction provides a subsystem, a single landing spot for image vulnerabilities for now. There are place holders for other vulnerabilities related logic which follow in subsequent PRs