### PR TITLE
Vulnerabilities refactor - Part II

### DIFF
--- a/anchore_engine/db/entities/policy_engine.py
+++ b/anchore_engine/db/entities/policy_engine.py
@@ -1290,6 +1290,7 @@ class VulnDBMetadata(Base):
 
         if self.vendor_cvss_v2:
             for cvss_v2_item in self.vendor_cvss_v2:
+                # create a new record for every single score as there could be a different number of v2 and v3 scores and its not clear which belong as a pair
                 results.append(
                     {
                         "id": self.name,
@@ -1314,6 +1315,7 @@ class VulnDBMetadata(Base):
 
         if self.vendor_cvss_v3:
             for cvss_v3_item in self.vendor_cvss_v3:
+                # create a new record for every single score as there could be a different number of v2 and v3 scores and its not clear which belong as a pair
                 results.append(
                     {
                         "id": self.name,
@@ -2599,14 +2601,14 @@ class ImagePackageVulnerability(Base):
 
         return fixed_in
 
-    def fixed_in(self):
+    def fixed_in(self, fixed_in: FixedArtifact = None):
         """
         Return the fixed_in version string value given a package matched (in case there are multiple packages specified in the vuln.
 
-        :param package: package to find a fix version for, if available
         :return: the fixed in version string if any or None if not found
         """
-        fixed_in = self.fixed_artifact()
+        if not fixed_in:
+            fixed_in = self.fixed_artifact()
         fix_available_in = (
             fixed_in.version if fixed_in and fixed_in.version != "None" else None
         )
@@ -2632,13 +2634,14 @@ class ImagePackageVulnerability(Base):
 
         return fix_available_in
 
-    def fix_has_no_advisory(self):
+    def fix_has_no_advisory(self, fixed_in: FixedArtifact = None):
         """
         For a given package vulnerability match, if the issue won't be addressed by the vendor return True.
         Return False otherwise
         :return:
         """
-        fixed_in = self.fixed_artifact()
+        if not fixed_in:
+            fixed_in = self.fixed_artifact()
         return fixed_in and fixed_in.vendor_no_advisory
 
     @classmethod

--- a/anchore_engine/services/apiext/api/controllers/images.py
+++ b/anchore_engine/services/apiext/api/controllers/images.py
@@ -27,7 +27,8 @@ from anchore_engine.db.entities.common import anchore_now
 from anchore_engine.services.apiext.api.controllers.utils import (
     normalize_image_add_source,
     validate_image_add_source,
-    make_response_vulnerability,
+    # make_response_vulnerability,
+    make_response_vulnerability_report,
 )
 from anchore_engine.subsys import taskstate, logger
 from anchore_engine.subsys.metrics import flask_metrics
@@ -243,7 +244,8 @@ def vulnerability_query(
                 vendor_only=vendor_only,
             )
             if doformat:
-                ret = make_response_vulnerability(vulnerability_type, resp)
+                # ret = make_response_vulnerability(vulnerability_type, resp)
+                ret = make_response_vulnerability_report(vulnerability_type, resp)
                 return_object[imageDigest] = ret
             else:
                 return_object[imageDigest] = resp

--- a/anchore_engine/services/catalog/catalog_impl.py
+++ b/anchore_engine/services/catalog/catalog_impl.py
@@ -1602,11 +1602,12 @@ def perform_vulnerability_scan(
         doqueue = False
 
         vdiff = {}
-        if last_vuln_result and curr_vuln_result:
-            vdiff = anchore_utils.process_cve_status(
-                old_cves_result=last_vuln_result["legacy_report"],
-                new_cves_result=curr_vuln_result["legacy_report"],
-            )
+        # TODO implement the differ correctly for the new format
+        # if last_vuln_result and curr_vuln_result:
+        #     vdiff = anchore_utils.process_cve_status(
+        #         old_cves_result=last_vuln_result["legacy_report"],
+        #         new_cves_result=curr_vuln_result["legacy_report"],
+        #     )
 
         obj_store.put_document(
             userId, "vulnerability_scan", archiveId, curr_vuln_result

--- a/anchore_engine/services/policy_engine/api/controllers/synchronous_operations.py
+++ b/anchore_engine/services/policy_engine/api/controllers/synchronous_operations.py
@@ -866,7 +866,7 @@ def get_image_vulnerabilities(user_id, image_id, force_refresh=False, vendor_onl
         )
 
         db.commit()
-        return report
+        return report.to_json(), 200
 
     except HTTPException:
         db.rollback()

--- a/anchore_engine/services/policy_engine/api/models.py
+++ b/anchore_engine/services/policy_engine/api/models.py
@@ -572,3 +572,187 @@ class PolicyValidationResponse(JsonSerializable):
     def __init__(self, valid=None, validation_details=None):
         self.valid = valid
         self.validation_details = validation_details
+
+
+class Vulnerability(JsonSerializable):
+    class VulnerabilityV1Schema(Schema):
+        vulnerability_id = fields.Str()
+        description = fields.Str()
+        severity = fields.Str()
+        link = fields.Str()
+        feed = fields.Str()
+        feed_group = fields.Str()
+        cvss_scores_nvd = fields.List(fields.Nested(CvssCombined.CvssCombinedV1Schema))
+        cvss_scores_vendor = fields.List(
+            fields.Nested(CvssCombined.CvssCombinedV1Schema)
+        )
+        created_at = RFC3339DateTime()
+        last_modified = RFC3339DateTime()
+
+        @post_load
+        def make(self, data, **kwargs):
+            return Vulnerability(**data)
+
+    __schema__ = VulnerabilityV1Schema()
+
+    def __init__(
+        self,
+        vulnerability_id=None,
+        description=None,
+        severity=None,
+        link=None,
+        feed=None,
+        feed_group=None,
+        cvss_scores_nvd=None,
+        cvss_scores_vendor=None,
+        created_at=None,
+        last_modified=None,
+    ):
+        self.vulnerability_id = vulnerability_id
+        self.description = description
+        self.severity = severity
+        self.link = link
+        self.feed = feed
+        self.feed_group = feed_group
+        self.cvss_scores_nvd = cvss_scores_nvd
+        self.cvss_scores_vendor = cvss_scores_vendor
+        self.created_at = created_at
+        self.last_modified = last_modified
+
+
+class Artifact(JsonSerializable):
+    class ArtifactV1Schema(Schema):
+        name = fields.Str()
+        version = fields.Str()
+        pkg_type = fields.Str()
+        pkg_path = fields.Str()
+        cpe = fields.Str()
+        cpe23 = fields.Str()
+
+        @post_load
+        def make(self, data, **kwargs):
+            return Artifact(**data)
+
+    __schema__ = ArtifactV1Schema()
+
+    def __init__(
+        self,
+        name=None,
+        version=None,
+        pkg_type=None,
+        pkg_path=None,
+        cpe=None,
+        cpe23=None,
+    ):
+        self.name = name
+        self.version = version
+        self.pkg_type = pkg_type
+        self.pkg_path = pkg_path
+        self.cpe = cpe
+        self.cpe23 = cpe23
+
+
+class FixedArtifact(JsonSerializable):
+    class FixedArtifactV1Schema(Schema):
+        version = fields.Str()
+        wont_fix = fields.Bool()
+        observed_at = RFC3339DateTime()
+
+        @post_load
+        def make(self, data, **kwargs):
+            return FixedArtifact(**data)
+
+    __schema__ = FixedArtifactV1Schema()
+
+    def __init__(self, version=None, wont_fix=None, observed_at=None):
+        self.version = version
+        self.wont_fix = wont_fix
+        self.observed_at = observed_at
+
+
+class Match(JsonSerializable):
+    class MatchV1Schema(Schema):
+        detected_at = RFC3339DateTime()
+
+        @post_load
+        def make(self, data, **kwargs):
+            return Match(**data)
+
+    __schema__ = MatchV1Schema()
+
+    def __init__(self, detected_at=None):
+        self.detected_at = detected_at
+
+
+class VulnerabilityMatch(JsonSerializable):
+    class VulnerabilityMatchV1Schema(Schema):
+        vulnerability = fields.Nested(Vulnerability.VulnerabilityV1Schema)
+        artifact = fields.Nested(Artifact.ArtifactV1Schema)
+        fixes = fields.List(fields.Nested(FixedArtifact.FixedArtifactV1Schema))
+        match = fields.Nested(Match.MatchV1Schema)
+
+        @post_load
+        def make(self, data, **kwargs):
+            return VulnerabilityMatch(**data)
+
+    __schema__ = VulnerabilityMatchV1Schema()
+
+    def __init__(self, vulnerability=None, artifact=None, fixes=None, match=None):
+        self.vulnerability = vulnerability
+        self.artifact = artifact
+        self.fixes = fixes
+        self.match = match
+
+
+class VulnerabilitiesReportMetadata(JsonSerializable):
+    class VulnerabilitiesReportMetadataV1Schema(Schema):
+        generated_at = RFC3339DateTime()
+        uuid = fields.Str()
+        generated_by = fields.Dict()
+
+    @post_load
+    def make(self, data, **kwargs):
+        return VulnerabilitiesReportMetadata(**data)
+
+    __schema__ = VulnerabilitiesReportMetadataV1Schema()
+
+    def __init__(self, generated_at=None, uuid=None, generated_by=None):
+        self.generated_at = generated_at
+        self.uuid = uuid
+        self.generated_by = generated_by
+
+
+class ImageVulnerabilitiesReport(JsonSerializable):
+    class ImageVulnerabilitiesReportV1Schema(Schema):
+        account_id = fields.Str()
+        image_id = fields.Str()
+        results = fields.List(
+            fields.Nested(VulnerabilityMatch.VulnerabilityMatchV1Schema)
+        )
+        metadata = fields.Nested(
+            VulnerabilitiesReportMetadata.VulnerabilitiesReportMetadataV1Schema
+        )
+        problems = fields.List(
+            fields.Nested(VulnerabilityScanProblem.VulnerabilityScanProblemV1Schema)
+        )
+
+        @post_load
+        def make(self, data, **kwargs):
+            return ImageVulnerabilitiesReport(**data)
+
+    __schema__ = ImageVulnerabilitiesReportV1Schema()
+
+    def __init__(
+        self,
+        account_id=None,
+        image_id=None,
+        results=None,
+        metadata=None,
+        problems=None,
+    ):
+
+        self.account_id = account_id
+        self.image_id = image_id
+        self.results = results
+        self.metadata = metadata
+        self.problems = problems

--- a/anchore_engine/services/policy_engine/engine/policy/gates/vulnerabilities.py
+++ b/anchore_engine/services/policy_engine/engine/policy/gates/vulnerabilities.py
@@ -30,6 +30,10 @@ from anchore_engine.clients.services.common import get_service_endpoint
 from anchore_engine.common import nonos_package_types
 from anchore_engine.services.policy_engine.engine.feeds.feeds import feed_registry
 from anchore_engine.services.policy_engine.engine.vulns.scanners import get_scanner
+from anchore_engine.services.policy_engine.engine.vulns.providers import (
+    get_vulnerabilities_provider,
+)
+from anchore_engine.db.entities.common import get_thread_scoped_session
 
 
 SEVERITY_ORDERING = ["unknown", "negligible", "low", "medium", "high", "critical"]
@@ -1071,5 +1075,10 @@ class VulnerabilitiesGate(Gate):
                 severity_matches[sev].append((image_cpe, vulnerability_cpe))
 
         context.data["loaded_cpe_vulnerabilities"] = severity_matches
+        db_session = get_thread_scoped_session()
+        provider = get_vulnerabilities_provider()
+        context.data["loaded_vulnerabilities_new"] = provider.get_image_vulnerabilities(
+            image_obj, db_session
+        )
 
         return context

--- a/anchore_engine/services/policy_engine/swagger/swagger.yaml
+++ b/anchore_engine/services/policy_engine/swagger/swagger.yaml
@@ -371,7 +371,7 @@ paths:
         200:
           description: "Vulnerability listing"
           schema:
-            $ref: "#/definitions/ImageVulnerabilityListing"
+            $ref: "#/definitions/ImageVulnerabilitiesReport"
         404:
           description: "Image not found"
         500:
@@ -1356,3 +1356,114 @@ definitions:
           schema_version:
             type: string
             description: Semantic version of the db schema
+  CVSSScore:
+    type: object
+    properties:
+      base_score:
+        type: number
+      exploitability_score:
+        type: number
+      impact_score:
+        type: number
+  VulnerabilityCVSSScore:
+    type: object
+    properties:
+      id:
+        type: string
+      cvss_v2:
+        $ref: "#/definitions/CVSSScore"
+      cvss_v3:
+        $ref: "#/definitions/CVSSScore"
+  VulnerabilityMatch:
+    type: object
+    properties:
+      vulnerability:
+        type: object
+        properties:
+          vulnerability_id:
+            type: string
+          description:
+            type: string
+          severity:
+            type: string
+          link:
+            type: string
+          feed:
+            type: string
+          feed_group:
+            type: string
+          cvss_scores_nvd:
+            type: array
+            items:
+              $ref: "#/definitions/VulnerabilityCVSSScore"
+          cvss_scores_vendor:
+            type: array
+            items:
+              $ref: "#/definitions/VulnerabilityCVSSScore"
+          created_at:
+            type: string
+            format: "date-time"
+          last_modified:
+            type: string
+            format: "date-time"
+      artifact:
+        type: object
+        properties:
+          name:
+            type: string
+          version:
+            type: string
+          pkg_type:
+            type: string
+          pkg_path:
+            type: string
+          cpe:
+            type: string
+          cpe23:
+            type: string
+      fixes:
+        type: array
+        items:
+          type: object
+          properties:
+            version:
+              type: string
+            wont_fix:
+              type: boolean
+            observed_at:
+              type: string
+              format: "date-time"
+      match:
+        type: object
+        properties:
+          observed_at:
+            type: string
+            format: "date-time"
+  VulnerabilitiesReportMetadata:
+    type: object
+    properties:
+      uuid:
+        type: string
+      generated_at:
+        type: string
+        format: "date-time"
+      generated_by:
+        type: object
+  ImageVulnerabilitiesReport:
+    type: object
+    description: "Wrapper for image vulnerabilities and metadata for the generated report"
+    properties:
+      account_id:
+        type: string
+      image_id:
+        type: string
+      results:
+        type: array
+        items:
+          $ref: "#/definitions/VulnerabilityMatch"
+      problems:
+        type: array
+        items:
+          $ref: "#/definitions/VulnerabilityScanProblem"
+      metadata:
+        $ref: "#/definitions/VulnerabilitiesReportMetadata"

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:406413437f26223183d133ccc7186f24c827729e1b21adc7330dd43fcdc030b3.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:406413437f26223183d133ccc7186f24c827729e1b21adc7330dd43fcdc030b3.json
@@ -1,1 +1,4474 @@
-{"cpe_report": [{"cpe": "cpe:a:ftpd:ftpd:0.2.1:*:*", "cpe23": "cpe:2.3:a:ftpd:ftpd:0.2.1:*:-:-:-:-:-:*", "feed_name": "nvdv2", "feed_namespace": "nvdv2:cves", "fixed_in": [], "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512", "name": "ftpd", "nvd_data": [{"cvss_v2": {"additional_information": {"ac_insuf_info": false, "obtain_all_privilege": false, "obtain_other_privilege": false, "obtain_user_privilege": false, "user_interaction_required": false}, "base_metrics": {"access_complexity": "LOW", "access_vector": "NETWORK", "authentication": "NONE", "availability_impact": "COMPLETE", "base_score": 10.0, "confidentiality_impact": "COMPLETE", "exploitability_score": 10.0, "impact_score": 10.0, "integrity_impact": "COMPLETE"}, "severity": "High", "vector_string": "AV:N/AC:L/Au:N/C:C/I:C/A:C", "version": "2.0"}, "cvss_v3": {"base_metrics": {"attack_complexity": "LOW", "attack_vector": "NETWORK", "availability_impact": "HIGH", "base_score": 9.8, "base_severity": "Critical", "confidentiality_impact": "HIGH", "exploitability_score": 3.9, "impact_score": 5.9, "integrity_impact": "HIGH", "privileges_required": "NONE", "scope": "UNCHANGED", "user_interaction": "NONE"}, "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", "version": "3.1"}, "id": "CVE-2013-2512"}], "pkg_path": "/var/lib/gems/2.5.0/specifications/ftpd-0.2.1.gemspec", "pkg_type": "gem", "severity": "Critical", "vendor_data": [], "version": "0.2.1", "vulnerability_id": "CVE-2013-2512"}, {"cpe": "cpe:a:python-aiohttp:aiohttp:3.7.3:*:*", "cpe23": "cpe:2.3:a:python-aiohttp:aiohttp:3.7.3:*:-:-:-:-:-:*", "feed_name": "nvdv2", "feed_namespace": "nvdv2:cves", "fixed_in": [], "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21330", "name": "aiohttp", "nvd_data": [{"cvss_v2": {"additional_information": {"ac_insuf_info": false, "obtain_all_privilege": false, "obtain_other_privilege": false, "obtain_user_privilege": false, "user_interaction_required": true}, "base_metrics": {"access_complexity": "MEDIUM", "access_vector": "NETWORK", "authentication": "NONE", "availability_impact": "NONE", "base_score": 5.8, "confidentiality_impact": "PARTIAL", "exploitability_score": 8.6, "impact_score": 4.9, "integrity_impact": "PARTIAL"}, "severity": "Medium", "vector_string": "AV:N/AC:M/Au:N/C:P/I:P/A:N", "version": "2.0"}, "cvss_v3": {"base_metrics": {"attack_complexity": "LOW", "attack_vector": "NETWORK", "availability_impact": "NONE", "base_score": 6.1, "base_severity": "Medium", "confidentiality_impact": "LOW", "exploitability_score": 2.8, "impact_score": 2.7, "integrity_impact": "LOW", "privileges_required": "NONE", "scope": "CHANGED", "user_interaction": "REQUIRED"}, "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N", "version": "3.1"}, "id": "CVE-2021-21330"}], "pkg_path": "/usr/local/lib/python3.7/dist-packages/aiohttp", "pkg_type": "python", "severity": "Medium", "vendor_data": [], "version": "3.7.3", "vulnerability_id": "CVE-2021-21330"}, {"cpe": "cpe:a:guava:guava:23.0:*:*", "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*", "feed_name": "nvdv2", "feed_namespace": "nvdv2:cves", "fixed_in": [], "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237", "name": "guava", "nvd_data": [{"cvss_v2": {"additional_information": {"ac_insuf_info": false, "obtain_all_privilege": false, "obtain_other_privilege": false, "obtain_user_privilege": false, "user_interaction_required": false}, "base_metrics": {"access_complexity": "MEDIUM", "access_vector": "NETWORK", "authentication": "NONE", "availability_impact": "PARTIAL", "base_score": 4.3, "confidentiality_impact": "NONE", "exploitability_score": 8.6, "impact_score": 2.9, "integrity_impact": "NONE"}, "severity": "Medium", "vector_string": "AV:N/AC:M/Au:N/C:N/I:N/A:P", "version": "2.0"}, "cvss_v3": {"base_metrics": {"attack_complexity": "HIGH", "attack_vector": "NETWORK", "availability_impact": "HIGH", "base_score": 5.9, "base_severity": "Medium", "confidentiality_impact": "NONE", "exploitability_score": 2.2, "impact_score": 3.6, "integrity_impact": "NONE", "privileges_required": "NONE", "scope": "UNCHANGED", "user_interaction": "NONE"}, "vector_string": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H", "version": "3.1"}, "id": "CVE-2018-10237"}], "pkg_path": "/sandbox/target/original-my-app-1.jar:guava", "pkg_type": "java", "severity": "Medium", "vendor_data": [], "version": "23.0", "vulnerability_id": "CVE-2018-10237"}, {"cpe": "cpe:a:guava:guava:23.0:*:*", "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*", "feed_name": "nvdv2", "feed_namespace": "nvdv2:cves", "fixed_in": [], "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908", "name": "guava", "nvd_data": [{"cvss_v2": {"additional_information": {"ac_insuf_info": false, "obtain_all_privilege": false, "obtain_other_privilege": false, "obtain_user_privilege": false, "user_interaction_required": false}, "base_metrics": {"access_complexity": "LOW", "access_vector": "LOCAL", "authentication": "NONE", "availability_impact": "NONE", "base_score": 2.1, "confidentiality_impact": "PARTIAL", "exploitability_score": 3.9, "impact_score": 2.9, "integrity_impact": "NONE"}, "severity": "Low", "vector_string": "AV:L/AC:L/Au:N/C:P/I:N/A:N", "version": "2.0"}, "cvss_v3": {"base_metrics": {"attack_complexity": "LOW", "attack_vector": "LOCAL", "availability_impact": "NONE", "base_score": 3.3, "base_severity": "Low", "confidentiality_impact": "LOW", "exploitability_score": 1.8, "impact_score": 1.4, "integrity_impact": "NONE", "privileges_required": "LOW", "scope": "UNCHANGED", "user_interaction": "NONE"}, "vector_string": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N", "version": "3.1"}, "id": "CVE-2020-8908"}], "pkg_path": "/sandbox/target/original-my-app-1.jar:guava", "pkg_type": "java", "severity": "Low", "vendor_data": [], "version": "23.0", "vulnerability_id": "CVE-2020-8908"}, {"cpe": "cpe:a:guava:guava:23.0:*:*", "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*", "feed_name": "nvdv2", "feed_namespace": "nvdv2:cves", "fixed_in": [], "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237", "name": "guava", "nvd_data": [{"cvss_v2": {"additional_information": {"ac_insuf_info": false, "obtain_all_privilege": false, "obtain_other_privilege": false, "obtain_user_privilege": false, "user_interaction_required": false}, "base_metrics": {"access_complexity": "MEDIUM", "access_vector": "NETWORK", "authentication": "NONE", "availability_impact": "PARTIAL", "base_score": 4.3, "confidentiality_impact": "NONE", "exploitability_score": 8.6, "impact_score": 2.9, "integrity_impact": "NONE"}, "severity": "Medium", "vector_string": "AV:N/AC:M/Au:N/C:N/I:N/A:P", "version": "2.0"}, "cvss_v3": {"base_metrics": {"attack_complexity": "HIGH", "attack_vector": "NETWORK", "availability_impact": "HIGH", "base_score": 5.9, "base_severity": "Medium", "confidentiality_impact": "NONE", "exploitability_score": 2.2, "impact_score": 3.6, "integrity_impact": "NONE", "privileges_required": "NONE", "scope": "UNCHANGED", "user_interaction": "NONE"}, "vector_string": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H", "version": "3.1"}, "id": "CVE-2018-10237"}], "pkg_path": "/sandbox/target/my-app-1.jar:guava", "pkg_type": "java", "severity": "Medium", "vendor_data": [], "version": "23.0", "vulnerability_id": "CVE-2018-10237"}, {"cpe": "cpe:a:guava:guava:23.0:*:*", "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*", "feed_name": "nvdv2", "feed_namespace": "nvdv2:cves", "fixed_in": [], "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908", "name": "guava", "nvd_data": [{"cvss_v2": {"additional_information": {"ac_insuf_info": false, "obtain_all_privilege": false, "obtain_other_privilege": false, "obtain_user_privilege": false, "user_interaction_required": false}, "base_metrics": {"access_complexity": "LOW", "access_vector": "LOCAL", "authentication": "NONE", "availability_impact": "NONE", "base_score": 2.1, "confidentiality_impact": "PARTIAL", "exploitability_score": 3.9, "impact_score": 2.9, "integrity_impact": "NONE"}, "severity": "Low", "vector_string": "AV:L/AC:L/Au:N/C:P/I:N/A:N", "version": "2.0"}, "cvss_v3": {"base_metrics": {"attack_complexity": "LOW", "attack_vector": "LOCAL", "availability_impact": "NONE", "base_score": 3.3, "base_severity": "Low", "confidentiality_impact": "LOW", "exploitability_score": 1.8, "impact_score": 1.4, "integrity_impact": "NONE", "privileges_required": "LOW", "scope": "UNCHANGED", "user_interaction": "NONE"}, "vector_string": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N", "version": "3.1"}, "id": "CVE-2020-8908"}], "pkg_path": "/sandbox/target/my-app-1.jar:guava", "pkg_type": "java", "severity": "Low", "vendor_data": [], "version": "23.0", "vulnerability_id": "CVE-2020-8908"}], "image_id": "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "legacy_report": {"multi": {"result": {"colcount": 15, "header": ["CVE_ID", "Severity", "*Total_Affected", "Vulnerable_Package", "Fix_Available", "Fix_Images", "Rebuild_Images", "URL", "Package_Type", "Feed", "Feed_Group", "Package_Name", "Package_Path", "Package_Version", "CVES"], "rowcount": 92, "rows": [["GHSA-v6wp-4m6f-gcjg", "Low", 1, "aiohttp-3.7.3", "3.7.4", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://github.com/advisories/GHSA-v6wp-4m6f-gcjg", "python", "vulnerabilities", "github:python", "aiohttp", "/usr/local/lib/python3.7/dist-packages/aiohttp", "3.7.3", "{\"nvd_data\": [{\"id\": \"CVE-2021-21330\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": true}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 5.8, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 8.6, \"impact_score\": 4.9, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:P/I:P/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"NONE\", \"base_score\": 6.1, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"LOW\", \"exploitability_score\": 2.8, \"impact_score\": 2.7, \"integrity_impact\": \"LOW\", \"privileges_required\": \"NONE\", \"scope\": \"CHANGED\", \"user_interaction\": \"REQUIRED\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2011-3374", "Negligible", 1, "apt-1.8.2.2", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2011-3374", "dpkg", "vulnerabilities", "debian:10", "apt", "pkgdb", "1.8.2.2", "{\"nvd_data\": [{\"id\": \"CVE-2011-3374\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 4.3, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 8.6, \"impact_score\": 2.9, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:N/I:P/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"HIGH\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"NONE\", \"base_score\": 3.7, \"base_severity\": \"Low\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 2.2, \"impact_score\": 1.4, \"integrity_impact\": \"LOW\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2019-18276", "Negligible", 1, "bash-5.0-4", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2019-18276", "dpkg", "vulnerabilities", "debian:10", "bash", "pkgdb", "5.0-4", "{\"nvd_data\": [{\"id\": \"CVE-2019-18276\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"COMPLETE\", \"base_score\": 7.2, \"confidentiality_impact\": \"COMPLETE\", \"exploitability_score\": 3.9, \"impact_score\": 10.0, \"integrity_impact\": \"COMPLETE\"}, \"severity\": \"High\", \"vector_string\": \"AV:L/AC:L/Au:N/C:C/I:C/A:C\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"LOCAL\", \"availability_impact\": \"HIGH\", \"base_score\": 7.8, \"base_severity\": \"High\", \"confidentiality_impact\": \"HIGH\", \"exploitability_score\": 1.8, \"impact_score\": 5.9, \"integrity_impact\": \"HIGH\", \"privileges_required\": \"LOW\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2017-18018", "Negligible", 1, "coreutils-8.30-3", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2017-18018", "dpkg", "vulnerabilities", "debian:10", "coreutils", "pkgdb", "8.30-3", "{\"nvd_data\": [{\"id\": \"CVE-2017-18018\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 1.9, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 3.4, \"impact_score\": 2.9, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Low\", \"vector_string\": \"AV:L/AC:M/Au:N/C:N/I:P/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"HIGH\", \"attack_vector\": \"LOCAL\", \"availability_impact\": \"NONE\", \"base_score\": 4.7, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 1.0, \"impact_score\": 3.6, \"integrity_impact\": \"HIGH\", \"privileges_required\": \"LOW\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.0/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:H/A:N\", \"version\": \"3.0\"}}], \"vendor_data\": []}"], ["GHSA-5mg8-w23w-74h3", "Medium", 1, "guava-23.0", "30.0-jre", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://github.com/advisories/GHSA-5mg8-w23w-74h3", "java", "vulnerabilities", "github:java", "guava", "/sandbox/target/my-app-1.jar:guava", "23.0", "{\"nvd_data\": [{\"id\": \"CVE-2020-8908\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 2.1, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 3.9, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Low\", \"vector_string\": \"AV:L/AC:L/Au:N/C:P/I:N/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"LOCAL\", \"availability_impact\": \"NONE\", \"base_score\": 3.3, \"base_severity\": \"Low\", \"confidentiality_impact\": \"LOW\", \"exploitability_score\": 1.8, \"impact_score\": 1.4, \"integrity_impact\": \"NONE\", \"privileges_required\": \"LOW\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["GHSA-mvr2-9pj6-7w5j", "Medium", 1, "guava-23.0", "24.1.1-jre", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j", "java", "vulnerabilities", "github:java", "guava", "/sandbox/target/my-app-1.jar:guava", "23.0", "{\"nvd_data\": [{\"id\": \"CVE-2018-10237\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 4.3, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 8.6, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"HIGH\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 5.9, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 2.2, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["GHSA-5mg8-w23w-74h3", "Medium", 1, "guava-23.0", "30.0-jre", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://github.com/advisories/GHSA-5mg8-w23w-74h3", "java", "vulnerabilities", "github:java", "guava", "/sandbox/target/original-my-app-1.jar:guava", "23.0", "{\"nvd_data\": [{\"id\": \"CVE-2020-8908\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 2.1, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 3.9, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Low\", \"vector_string\": \"AV:L/AC:L/Au:N/C:P/I:N/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"LOCAL\", \"availability_impact\": \"NONE\", \"base_score\": 3.3, \"base_severity\": \"Low\", \"confidentiality_impact\": \"LOW\", \"exploitability_score\": 1.8, \"impact_score\": 1.4, \"integrity_impact\": \"NONE\", \"privileges_required\": \"LOW\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["GHSA-mvr2-9pj6-7w5j", "Medium", 1, "guava-23.0", "24.1.1-jre", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j", "java", "vulnerabilities", "github:java", "guava", "/sandbox/target/original-my-app-1.jar:guava", "23.0", "{\"nvd_data\": [{\"id\": \"CVE-2018-10237\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 4.3, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 8.6, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"HIGH\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 5.9, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 2.2, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2011-3374", "Negligible", 1, "libapt-pkg5.0-1.8.2.2", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2011-3374", "dpkg", "vulnerabilities", "debian:10", "libapt-pkg5.0", "pkgdb", "1.8.2.2", "{\"nvd_data\": [{\"id\": \"CVE-2011-3374\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 4.3, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 8.6, \"impact_score\": 2.9, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:N/I:P/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"HIGH\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"NONE\", \"base_score\": 3.7, \"base_severity\": \"Low\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 2.2, \"impact_score\": 1.4, \"integrity_impact\": \"LOW\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2010-4051", "Negligible", 1, "libc6-2.28-10", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2010-4051", "dpkg", "vulnerabilities", "debian:10", "libc6", "pkgdb", "2.28-10", "{\"nvd_data\": [{\"id\": \"CVE-2010-4051\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 5.0, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 10.0, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": null}], \"vendor_data\": []}"], ["CVE-2010-4052", "Negligible", 1, "libc6-2.28-10", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2010-4052", "dpkg", "vulnerabilities", "debian:10", "libc6", "pkgdb", "2.28-10", "{\"nvd_data\": [{\"id\": \"CVE-2010-4052\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 5.0, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 10.0, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": null}], \"vendor_data\": []}"], ["CVE-2010-4756", "Negligible", 1, "libc6-2.28-10", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2010-4756", "dpkg", "vulnerabilities", "debian:10", "libc6", "pkgdb", "2.28-10", "{\"nvd_data\": [{\"id\": \"CVE-2010-4756\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"SINGLE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 4.0, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 8.0, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:S/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": null}], \"vendor_data\": []}"], ["CVE-2018-20796", "Negligible", 1, "libc6-2.28-10", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2018-20796", "dpkg", "vulnerabilities", "debian:10", "libc6", "pkgdb", "2.28-10", "{\"nvd_data\": [{\"id\": \"CVE-2018-20796\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 5.0, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 10.0, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 7.5, \"base_severity\": \"High\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 3.9, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"version\": \"3.0\"}}], \"vendor_data\": []}"], ["CVE-2019-1010022", "Negligible", 1, "libc6-2.28-10", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2019-1010022", "dpkg", "vulnerabilities", "debian:10", "libc6", "pkgdb", "2.28-10", "{\"nvd_data\": [{\"id\": \"CVE-2019-1010022\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 7.5, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 10.0, \"impact_score\": 6.4, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"High\", \"vector_string\": \"AV:N/AC:L/Au:N/C:P/I:P/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 9.8, \"base_severity\": \"Critical\", \"confidentiality_impact\": \"HIGH\", \"exploitability_score\": 3.9, \"impact_score\": 5.9, \"integrity_impact\": \"HIGH\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H\", \"version\": \"3.0\"}}], \"vendor_data\": []}"], ["CVE-2019-1010023", "Negligible", 1, "libc6-2.28-10", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2019-1010023", "dpkg", "vulnerabilities", "debian:10", "libc6", "pkgdb", "2.28-10", "{\"nvd_data\": [{\"id\": \"CVE-2019-1010023\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": true}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 6.8, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 8.6, \"impact_score\": 6.4, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:P/I:P/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 8.8, \"base_severity\": \"High\", \"confidentiality_impact\": \"HIGH\", \"exploitability_score\": 2.8, \"impact_score\": 5.9, \"integrity_impact\": \"HIGH\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"REQUIRED\"}, \"vector_string\": \"CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H\", \"version\": \"3.0\"}}], \"vendor_data\": []}"], ["CVE-2019-1010024", "Negligible", 1, "libc6-2.28-10", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2019-1010024", "dpkg", "vulnerabilities", "debian:10", "libc6", "pkgdb", "2.28-10", "{\"nvd_data\": [{\"id\": \"CVE-2019-1010024\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 5.0, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 10.0, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:N/C:P/I:N/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"NONE\", \"base_score\": 5.3, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"LOW\", \"exploitability_score\": 3.9, \"impact_score\": 1.4, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N\", \"version\": \"3.0\"}}], \"vendor_data\": []}"], ["CVE-2019-1010025", "Negligible", 1, "libc6-2.28-10", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2019-1010025", "dpkg", "vulnerabilities", "debian:10", "libc6", "pkgdb", "2.28-10", "{\"nvd_data\": [{\"id\": \"CVE-2019-1010025\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 5.0, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 10.0, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:N/C:P/I:N/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"NONE\", \"base_score\": 5.3, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"LOW\", \"exploitability_score\": 3.9, \"impact_score\": 1.4, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N\", \"version\": \"3.0\"}}], \"vendor_data\": []}"], ["CVE-2019-9192", "Negligible", 1, "libc6-2.28-10", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2019-9192", "dpkg", "vulnerabilities", "debian:10", "libc6", "pkgdb", "2.28-10", "{\"nvd_data\": [{\"id\": \"CVE-2019-9192\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 5.0, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 10.0, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 7.5, \"base_severity\": \"High\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 3.9, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"version\": \"3.0\"}}], \"vendor_data\": []}"], ["CVE-2010-4051", "Negligible", 1, "libc-bin-2.28-10", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2010-4051", "dpkg", "vulnerabilities", "debian:10", "libc-bin", "pkgdb", "2.28-10", "{\"nvd_data\": [{\"id\": \"CVE-2010-4051\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 5.0, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 10.0, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": null}], \"vendor_data\": []}"], ["CVE-2010-4052", "Negligible", 1, "libc-bin-2.28-10", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2010-4052", "dpkg", "vulnerabilities", "debian:10", "libc-bin", "pkgdb", "2.28-10", "{\"nvd_data\": [{\"id\": \"CVE-2010-4052\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 5.0, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 10.0, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": null}], \"vendor_data\": []}"], ["CVE-2010-4756", "Negligible", 1, "libc-bin-2.28-10", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2010-4756", "dpkg", "vulnerabilities", "debian:10", "libc-bin", "pkgdb", "2.28-10", "{\"nvd_data\": [{\"id\": \"CVE-2010-4756\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"SINGLE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 4.0, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 8.0, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:S/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": null}], \"vendor_data\": []}"], ["CVE-2018-20796", "Negligible", 1, "libc-bin-2.28-10", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2018-20796", "dpkg", "vulnerabilities", "debian:10", "libc-bin", "pkgdb", "2.28-10", "{\"nvd_data\": [{\"id\": \"CVE-2018-20796\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 5.0, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 10.0, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 7.5, \"base_severity\": \"High\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 3.9, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"version\": \"3.0\"}}], \"vendor_data\": []}"], ["CVE-2019-1010022", "Negligible", 1, "libc-bin-2.28-10", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2019-1010022", "dpkg", "vulnerabilities", "debian:10", "libc-bin", "pkgdb", "2.28-10", "{\"nvd_data\": [{\"id\": \"CVE-2019-1010022\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 7.5, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 10.0, \"impact_score\": 6.4, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"High\", \"vector_string\": \"AV:N/AC:L/Au:N/C:P/I:P/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 9.8, \"base_severity\": \"Critical\", \"confidentiality_impact\": \"HIGH\", \"exploitability_score\": 3.9, \"impact_score\": 5.9, \"integrity_impact\": \"HIGH\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H\", \"version\": \"3.0\"}}], \"vendor_data\": []}"], ["CVE-2019-1010023", "Negligible", 1, "libc-bin-2.28-10", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2019-1010023", "dpkg", "vulnerabilities", "debian:10", "libc-bin", "pkgdb", "2.28-10", "{\"nvd_data\": [{\"id\": \"CVE-2019-1010023\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": true}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 6.8, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 8.6, \"impact_score\": 6.4, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:P/I:P/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 8.8, \"base_severity\": \"High\", \"confidentiality_impact\": \"HIGH\", \"exploitability_score\": 2.8, \"impact_score\": 5.9, \"integrity_impact\": \"HIGH\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"REQUIRED\"}, \"vector_string\": \"CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H\", \"version\": \"3.0\"}}], \"vendor_data\": []}"], ["CVE-2019-1010024", "Negligible", 1, "libc-bin-2.28-10", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2019-1010024", "dpkg", "vulnerabilities", "debian:10", "libc-bin", "pkgdb", "2.28-10", "{\"nvd_data\": [{\"id\": \"CVE-2019-1010024\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 5.0, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 10.0, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:N/C:P/I:N/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"NONE\", \"base_score\": 5.3, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"LOW\", \"exploitability_score\": 3.9, \"impact_score\": 1.4, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N\", \"version\": \"3.0\"}}], \"vendor_data\": []}"], ["CVE-2019-1010025", "Negligible", 1, "libc-bin-2.28-10", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2019-1010025", "dpkg", "vulnerabilities", "debian:10", "libc-bin", "pkgdb", "2.28-10", "{\"nvd_data\": [{\"id\": \"CVE-2019-1010025\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 5.0, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 10.0, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:N/C:P/I:N/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"NONE\", \"base_score\": 5.3, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"LOW\", \"exploitability_score\": 3.9, \"impact_score\": 1.4, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N\", \"version\": \"3.0\"}}], \"vendor_data\": []}"], ["CVE-2019-9192", "Negligible", 1, "libc-bin-2.28-10", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2019-9192", "dpkg", "vulnerabilities", "debian:10", "libc-bin", "pkgdb", "2.28-10", "{\"nvd_data\": [{\"id\": \"CVE-2019-9192\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 5.0, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 10.0, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 7.5, \"base_severity\": \"High\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 3.9, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"version\": \"3.0\"}}], \"vendor_data\": []}"], ["CVE-2018-6829", "Negligible", 1, "libgcrypt20-1.8.4-5", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2018-6829", "dpkg", "vulnerabilities", "debian:10", "libgcrypt20", "pkgdb", "1.8.4-5", "{\"nvd_data\": [{\"id\": \"CVE-2018-6829\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 5.0, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 10.0, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:N/C:P/I:N/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"NONE\", \"base_score\": 7.5, \"base_severity\": \"High\", \"confidentiality_impact\": \"HIGH\", \"exploitability_score\": 3.9, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N\", \"version\": \"3.0\"}}], \"vendor_data\": []}"], ["CVE-2012-0039", "Negligible", 1, "libglib2.0-0-2.58.3-2+deb10u2", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2012-0039", "dpkg", "vulnerabilities", "debian:10", "libglib2.0-0", "pkgdb", "2.58.3-2+deb10u2", "{\"nvd_data\": [{\"id\": \"CVE-2012-0039\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 5.0, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 10.0, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": null}], \"vendor_data\": []}"], ["CVE-2020-35457", "Negligible", 1, "libglib2.0-0-2.58.3-2+deb10u2", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2020-35457", "dpkg", "vulnerabilities", "debian:10", "libglib2.0-0", "pkgdb", "2.58.3-2+deb10u2", "{\"nvd_data\": [{\"id\": \"CVE-2020-35457\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 4.6, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 3.9, \"impact_score\": 6.4, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:L/AC:L/Au:N/C:P/I:P/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"LOCAL\", \"availability_impact\": \"HIGH\", \"base_score\": 7.8, \"base_severity\": \"High\", \"confidentiality_impact\": \"HIGH\", \"exploitability_score\": 1.8, \"impact_score\": 5.9, \"integrity_impact\": \"HIGH\", \"privileges_required\": \"LOW\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2011-3389", "Medium", 1, "libgnutls30-3.6.7-4+deb10u6", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2011-3389", "dpkg", "vulnerabilities", "debian:10", "libgnutls30", "pkgdb", "3.6.7-4+deb10u6", "{\"nvd_data\": [{\"id\": \"CVE-2011-3389\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 4.3, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 8.6, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:P/I:N/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": null}], \"vendor_data\": []}"], ["CVE-2004-0971", "Negligible", 1, "libgssapi-krb5-2-1.17-3+deb10u1", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2004-0971", "dpkg", "vulnerabilities", "debian:10", "libgssapi-krb5-2", "pkgdb", "1.17-3+deb10u1", "{\"nvd_data\": [{\"id\": \"CVE-2004-0971\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 2.1, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 3.9, \"impact_score\": 2.9, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Low\", \"vector_string\": \"AV:L/AC:L/Au:N/C:N/I:P/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": null}], \"vendor_data\": []}"], ["CVE-2018-5709", "Negligible", 1, "libgssapi-krb5-2-1.17-3+deb10u1", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2018-5709", "dpkg", "vulnerabilities", "debian:10", "libgssapi-krb5-2", "pkgdb", "1.17-3+deb10u1", "{\"nvd_data\": [{\"id\": \"CVE-2018-5709\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": true, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 5.0, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 10.0, \"impact_score\": 2.9, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:N/C:N/I:P/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"NONE\", \"base_score\": 7.5, \"base_severity\": \"High\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 3.9, \"impact_score\": 3.6, \"integrity_impact\": \"HIGH\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N\", \"version\": \"3.0\"}}], \"vendor_data\": []}"], ["CVE-2015-3276", "Negligible", 1, "libldap-common-2.4.47+dfsg-3+deb10u6", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2015-3276", "dpkg", "vulnerabilities", "debian:10", "libldap-common", "pkgdb", "2.4.47+dfsg-3+deb10u6", "{\"nvd_data\": [{\"id\": \"CVE-2015-3276\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": true, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 5.0, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 10.0, \"impact_score\": 2.9, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:N/C:N/I:P/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": null}], \"vendor_data\": []}"], ["CVE-2017-14159", "Negligible", 1, "libldap-common-2.4.47+dfsg-3+deb10u6", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2017-14159", "dpkg", "vulnerabilities", "debian:10", "libldap-common", "pkgdb", "2.4.47+dfsg-3+deb10u6", "{\"nvd_data\": [{\"id\": \"CVE-2017-14159\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 1.9, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 3.4, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Low\", \"vector_string\": \"AV:L/AC:M/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"HIGH\", \"attack_vector\": \"LOCAL\", \"availability_impact\": \"HIGH\", \"base_score\": 4.7, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 1.0, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"LOW\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.0/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:H\", \"version\": \"3.0\"}}], \"vendor_data\": []}"], ["CVE-2017-17740", "Negligible", 1, "libldap-common-2.4.47+dfsg-3+deb10u6", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2017-17740", "dpkg", "vulnerabilities", "debian:10", "libldap-common", "pkgdb", "2.4.47+dfsg-3+deb10u6", "{\"nvd_data\": [{\"id\": \"CVE-2017-17740\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 5.0, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 10.0, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 7.5, \"base_severity\": \"High\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 3.9, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"version\": \"3.0\"}}], \"vendor_data\": []}"], ["CVE-2020-15719", "Negligible", 1, "libldap-common-2.4.47+dfsg-3+deb10u6", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2020-15719", "dpkg", "vulnerabilities", "debian:10", "libldap-common", "pkgdb", "2.4.47+dfsg-3+deb10u6", "{\"nvd_data\": [{\"id\": \"CVE-2020-15719\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": true}, \"base_metrics\": {\"access_complexity\": \"HIGH\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 4.0, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 4.9, \"impact_score\": 4.9, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:H/Au:N/C:P/I:P/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"HIGH\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"NONE\", \"base_score\": 4.2, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"LOW\", \"exploitability_score\": 1.6, \"impact_score\": 2.5, \"integrity_impact\": \"LOW\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"REQUIRED\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:N\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2013-4392", "Negligible", 1, "libnss-systemd-241-7~deb10u7", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2013-4392", "dpkg", "vulnerabilities", "debian:10", "libnss-systemd", "pkgdb", "241-7~deb10u7", "{\"nvd_data\": [{\"id\": \"CVE-2013-4392\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 3.3, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 3.4, \"impact_score\": 4.9, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Low\", \"vector_string\": \"AV:L/AC:M/Au:N/C:P/I:P/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": null}], \"vendor_data\": []}"], ["CVE-2019-20386", "Negligible", 1, "libnss-systemd-241-7~deb10u7", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2019-20386", "dpkg", "vulnerabilities", "debian:10", "libnss-systemd", "pkgdb", "241-7~deb10u7", "{\"nvd_data\": [{\"id\": \"CVE-2019-20386\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 2.1, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 3.9, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Low\", \"vector_string\": \"AV:L/AC:L/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"PHYSICAL\", \"availability_impact\": \"LOW\", \"base_score\": 2.4, \"base_severity\": \"Low\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 0.9, \"impact_score\": 1.4, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2020-13776", "Negligible", 1, "libnss-systemd-241-7~deb10u7", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2020-13776", "dpkg", "vulnerabilities", "debian:10", "libnss-systemd", "pkgdb", "241-7~deb10u7", "{\"nvd_data\": [{\"id\": \"CVE-2020-13776\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": true}, \"base_metrics\": {\"access_complexity\": \"HIGH\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"COMPLETE\", \"base_score\": 6.2, \"confidentiality_impact\": \"COMPLETE\", \"exploitability_score\": 1.9, \"impact_score\": 10.0, \"integrity_impact\": \"COMPLETE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:L/AC:H/Au:N/C:C/I:C/A:C\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"HIGH\", \"attack_vector\": \"LOCAL\", \"availability_impact\": \"HIGH\", \"base_score\": 6.7, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"HIGH\", \"exploitability_score\": 0.8, \"impact_score\": 5.9, \"integrity_impact\": \"HIGH\", \"privileges_required\": \"LOW\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"REQUIRED\"}, \"vector_string\": \"CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2017-11164", "Negligible", 1, "libpcre3-2:8.39-12", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2017-11164", "dpkg", "vulnerabilities", "debian:10", "libpcre3", "pkgdb", "2:8.39-12", "{\"nvd_data\": [{\"id\": \"CVE-2017-11164\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"COMPLETE\", \"base_score\": 7.8, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 10.0, \"impact_score\": 6.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"High\", \"vector_string\": \"AV:N/AC:L/Au:N/C:N/I:N/A:C\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 7.5, \"base_severity\": \"High\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 3.9, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"version\": \"3.0\"}}], \"vendor_data\": []}"], ["CVE-2017-16231", "Negligible", 1, "libpcre3-2:8.39-12", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2017-16231", "dpkg", "vulnerabilities", "debian:10", "libpcre3", "pkgdb", "2:8.39-12", "{\"nvd_data\": [{\"id\": \"CVE-2017-16231\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 2.1, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 3.9, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Low\", \"vector_string\": \"AV:L/AC:L/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"LOCAL\", \"availability_impact\": \"HIGH\", \"base_score\": 5.5, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 1.8, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"LOW\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H\", \"version\": \"3.0\"}}], \"vendor_data\": []}"], ["CVE-2017-7245", "Negligible", 1, "libpcre3-2:8.39-12", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2017-7245", "dpkg", "vulnerabilities", "debian:10", "libpcre3", "pkgdb", "2:8.39-12", "{\"nvd_data\": [{\"id\": \"CVE-2017-7245\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": true}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 6.8, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 8.6, \"impact_score\": 6.4, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:P/I:P/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"LOCAL\", \"availability_impact\": \"HIGH\", \"base_score\": 7.8, \"base_severity\": \"High\", \"confidentiality_impact\": \"HIGH\", \"exploitability_score\": 1.8, \"impact_score\": 5.9, \"integrity_impact\": \"HIGH\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"REQUIRED\"}, \"vector_string\": \"CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H\", \"version\": \"3.0\"}}], \"vendor_data\": []}"], ["CVE-2017-7246", "Negligible", 1, "libpcre3-2:8.39-12", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2017-7246", "dpkg", "vulnerabilities", "debian:10", "libpcre3", "pkgdb", "2:8.39-12", "{\"nvd_data\": [{\"id\": \"CVE-2017-7246\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": true}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 6.8, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 8.6, \"impact_score\": 6.4, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:P/I:P/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"LOCAL\", \"availability_impact\": \"HIGH\", \"base_score\": 7.8, \"base_severity\": \"High\", \"confidentiality_impact\": \"HIGH\", \"exploitability_score\": 1.8, \"impact_score\": 5.9, \"integrity_impact\": \"HIGH\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"REQUIRED\"}, \"vector_string\": \"CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H\", \"version\": \"3.0\"}}], \"vendor_data\": []}"], ["CVE-2019-20838", "Negligible", 1, "libpcre3-2:8.39-12", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2019-20838", "dpkg", "vulnerabilities", "debian:10", "libpcre3", "pkgdb", "2:8.39-12", "{\"nvd_data\": [{\"id\": \"CVE-2019-20838\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 4.3, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 8.6, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 7.5, \"base_severity\": \"High\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 3.9, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2013-7040", "Negligible", 1, "libpython2.7-minimal-2.7.16-2+deb10u1", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2013-7040", "dpkg", "vulnerabilities", "debian:10", "libpython2.7-minimal", "pkgdb", "2.7.16-2+deb10u1", "{\"nvd_data\": [{\"id\": \"CVE-2013-7040\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 4.3, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 8.6, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": null}], \"vendor_data\": []}"], ["CVE-2017-17522", "Negligible", 1, "libpython2.7-minimal-2.7.16-2+deb10u1", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2017-17522", "dpkg", "vulnerabilities", "debian:10", "libpython2.7-minimal", "pkgdb", "2.7.16-2+deb10u1", "{\"nvd_data\": [{\"id\": \"CVE-2017-17522\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": true}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 6.8, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 8.6, \"impact_score\": 6.4, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:P/I:P/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 8.8, \"base_severity\": \"High\", \"confidentiality_impact\": \"HIGH\", \"exploitability_score\": 2.8, \"impact_score\": 5.9, \"integrity_impact\": \"HIGH\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"REQUIRED\"}, \"vector_string\": \"CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H\", \"version\": \"3.0\"}}], \"vendor_data\": []}"], ["CVE-2019-18348", "Negligible", 1, "libpython2.7-minimal-2.7.16-2+deb10u1", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2019-18348", "dpkg", "vulnerabilities", "debian:10", "libpython2.7-minimal", "pkgdb", "2.7.16-2+deb10u1", "{\"nvd_data\": [{\"id\": \"CVE-2019-18348\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": true}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 4.3, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 8.6, \"impact_score\": 2.9, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:N/I:P/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"NONE\", \"base_score\": 6.1, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"LOW\", \"exploitability_score\": 2.8, \"impact_score\": 2.7, \"integrity_impact\": \"LOW\", \"privileges_required\": \"NONE\", \"scope\": \"CHANGED\", \"user_interaction\": \"REQUIRED\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2019-9674", "Negligible", 1, "libpython2.7-minimal-2.7.16-2+deb10u1", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2019-9674", "dpkg", "vulnerabilities", "debian:10", "libpython2.7-minimal", "pkgdb", "2.7.16-2+deb10u1", "{\"nvd_data\": [{\"id\": \"CVE-2019-9674\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 5.0, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 10.0, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 7.5, \"base_severity\": \"High\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 3.9, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2021-23336", "Medium", 1, "libpython2.7-minimal-2.7.16-2+deb10u1", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2021-23336", "dpkg", "vulnerabilities", "debian:10", "libpython2.7-minimal", "pkgdb", "2.7.16-2+deb10u1", "{\"nvd_data\": [{\"id\": \"CVE-2021-23336\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": true}, \"base_metrics\": {\"access_complexity\": \"HIGH\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 4.0, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 4.9, \"impact_score\": 4.9, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:H/Au:N/C:N/I:P/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"HIGH\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 5.9, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 1.6, \"impact_score\": 4.2, \"integrity_impact\": \"LOW\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"REQUIRED\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2017-17522", "Negligible", 1, "libpython3.7-minimal-3.7.3-2+deb10u3", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2017-17522", "dpkg", "vulnerabilities", "debian:10", "libpython3.7-minimal", "pkgdb", "3.7.3-2+deb10u3", "{\"nvd_data\": [{\"id\": \"CVE-2017-17522\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": true}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 6.8, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 8.6, \"impact_score\": 6.4, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:P/I:P/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 8.8, \"base_severity\": \"High\", \"confidentiality_impact\": \"HIGH\", \"exploitability_score\": 2.8, \"impact_score\": 5.9, \"integrity_impact\": \"HIGH\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"REQUIRED\"}, \"vector_string\": \"CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H\", \"version\": \"3.0\"}}], \"vendor_data\": []}"], ["CVE-2019-18348", "Negligible", 1, "libpython3.7-minimal-3.7.3-2+deb10u3", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2019-18348", "dpkg", "vulnerabilities", "debian:10", "libpython3.7-minimal", "pkgdb", "3.7.3-2+deb10u3", "{\"nvd_data\": [{\"id\": \"CVE-2019-18348\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": true}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 4.3, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 8.6, \"impact_score\": 2.9, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:N/I:P/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"NONE\", \"base_score\": 6.1, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"LOW\", \"exploitability_score\": 2.8, \"impact_score\": 2.7, \"integrity_impact\": \"LOW\", \"privileges_required\": \"NONE\", \"scope\": \"CHANGED\", \"user_interaction\": \"REQUIRED\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2019-9674", "Negligible", 1, "libpython3.7-minimal-3.7.3-2+deb10u3", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2019-9674", "dpkg", "vulnerabilities", "debian:10", "libpython3.7-minimal", "pkgdb", "3.7.3-2+deb10u3", "{\"nvd_data\": [{\"id\": \"CVE-2019-9674\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 5.0, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 10.0, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 7.5, \"base_severity\": \"High\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 3.9, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2020-27619", "Negligible", 1, "libpython3.7-minimal-3.7.3-2+deb10u3", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2020-27619", "dpkg", "vulnerabilities", "debian:10", "libpython3.7-minimal", "pkgdb", "3.7.3-2+deb10u3", "{\"nvd_data\": [{\"id\": \"CVE-2020-27619\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 7.5, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 10.0, \"impact_score\": 6.4, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"High\", \"vector_string\": \"AV:N/AC:L/Au:N/C:P/I:P/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 9.8, \"base_severity\": \"Critical\", \"confidentiality_impact\": \"HIGH\", \"exploitability_score\": 3.9, \"impact_score\": 5.9, \"integrity_impact\": \"HIGH\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2019-9893", "Negligible", 1, "libseccomp2-2.3.3-4", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2019-9893", "dpkg", "vulnerabilities", "debian:10", "libseccomp2", "pkgdb", "2.3.3-4", "{\"nvd_data\": [{\"id\": \"CVE-2019-9893\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 7.5, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 10.0, \"impact_score\": 6.4, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"High\", \"vector_string\": \"AV:N/AC:L/Au:N/C:P/I:P/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 9.8, \"base_severity\": \"Critical\", \"confidentiality_impact\": \"HIGH\", \"exploitability_score\": 3.9, \"impact_score\": 5.9, \"integrity_impact\": \"HIGH\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H\", \"version\": \"3.0\"}}], \"vendor_data\": []}"], ["CVE-2007-6755", "Negligible", 1, "libssl1.1-1.1.1d-0+deb10u6", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2007-6755", "dpkg", "vulnerabilities", "debian:10", "libssl1.1", "pkgdb", "1.1.1d-0+deb10u6", "{\"nvd_data\": [{\"id\": \"CVE-2007-6755\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 5.8, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 8.6, \"impact_score\": 4.9, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:P/I:P/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": null}], \"vendor_data\": []}"], ["CVE-2010-0928", "Negligible", 1, "libssl1.1-1.1.1d-0+deb10u6", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2010-0928", "dpkg", "vulnerabilities", "debian:10", "libssl1.1", "pkgdb", "1.1.1d-0+deb10u6", "{\"nvd_data\": [{\"id\": \"CVE-2010-0928\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"HIGH\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 4.0, \"confidentiality_impact\": \"COMPLETE\", \"exploitability_score\": 1.9, \"impact_score\": 6.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:L/AC:H/Au:N/C:C/I:N/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": null}], \"vendor_data\": []}"], ["CVE-2013-4392", "Negligible", 1, "libsystemd0-241-7~deb10u7", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2013-4392", "dpkg", "vulnerabilities", "debian:10", "libsystemd0", "pkgdb", "241-7~deb10u7", "{\"nvd_data\": [{\"id\": \"CVE-2013-4392\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 3.3, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 3.4, \"impact_score\": 4.9, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Low\", \"vector_string\": \"AV:L/AC:M/Au:N/C:P/I:P/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": null}], \"vendor_data\": []}"], ["CVE-2019-20386", "Negligible", 1, "libsystemd0-241-7~deb10u7", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2019-20386", "dpkg", "vulnerabilities", "debian:10", "libsystemd0", "pkgdb", "241-7~deb10u7", "{\"nvd_data\": [{\"id\": \"CVE-2019-20386\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 2.1, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 3.9, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Low\", \"vector_string\": \"AV:L/AC:L/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"PHYSICAL\", \"availability_impact\": \"LOW\", \"base_score\": 2.4, \"base_severity\": \"Low\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 0.9, \"impact_score\": 1.4, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2020-13776", "Negligible", 1, "libsystemd0-241-7~deb10u7", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2020-13776", "dpkg", "vulnerabilities", "debian:10", "libsystemd0", "pkgdb", "241-7~deb10u7", "{\"nvd_data\": [{\"id\": \"CVE-2020-13776\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": true}, \"base_metrics\": {\"access_complexity\": \"HIGH\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"COMPLETE\", \"base_score\": 6.2, \"confidentiality_impact\": \"COMPLETE\", \"exploitability_score\": 1.9, \"impact_score\": 10.0, \"integrity_impact\": \"COMPLETE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:L/AC:H/Au:N/C:C/I:C/A:C\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"HIGH\", \"attack_vector\": \"LOCAL\", \"availability_impact\": \"HIGH\", \"base_score\": 6.7, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"HIGH\", \"exploitability_score\": 0.8, \"impact_score\": 5.9, \"integrity_impact\": \"HIGH\", \"privileges_required\": \"LOW\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"REQUIRED\"}, \"vector_string\": \"CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2018-1000654", "Negligible", 1, "libtasn1-6-4.13-3", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2018-1000654", "dpkg", "vulnerabilities", "debian:10", "libtasn1-6", "pkgdb", "4.13-3", "{\"nvd_data\": [{\"id\": \"CVE-2018-1000654\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": true}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"COMPLETE\", \"base_score\": 7.1, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 8.6, \"impact_score\": 6.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"High\", \"vector_string\": \"AV:N/AC:M/Au:N/C:N/I:N/A:C\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"LOCAL\", \"availability_impact\": \"HIGH\", \"base_score\": 5.5, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 1.8, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"REQUIRED\"}, \"vector_string\": \"CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H\", \"version\": \"3.0\"}}], \"vendor_data\": []}"], ["CVE-2013-4392", "Negligible", 1, "libudev1-241-7~deb10u6", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2013-4392", "dpkg", "vulnerabilities", "debian:10", "libudev1", "pkgdb", "241-7~deb10u6", "{\"nvd_data\": [{\"id\": \"CVE-2013-4392\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 3.3, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 3.4, \"impact_score\": 4.9, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Low\", \"vector_string\": \"AV:L/AC:M/Au:N/C:P/I:P/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": null}], \"vendor_data\": []}"], ["CVE-2019-20386", "Negligible", 1, "libudev1-241-7~deb10u6", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2019-20386", "dpkg", "vulnerabilities", "debian:10", "libudev1", "pkgdb", "241-7~deb10u6", "{\"nvd_data\": [{\"id\": \"CVE-2019-20386\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 2.1, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 3.9, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Low\", \"vector_string\": \"AV:L/AC:L/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"PHYSICAL\", \"availability_impact\": \"LOW\", \"base_score\": 2.4, \"base_severity\": \"Low\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 0.9, \"impact_score\": 1.4, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2020-13776", "Negligible", 1, "libudev1-241-7~deb10u6", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2020-13776", "dpkg", "vulnerabilities", "debian:10", "libudev1", "pkgdb", "241-7~deb10u6", "{\"nvd_data\": [{\"id\": \"CVE-2020-13776\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": true}, \"base_metrics\": {\"access_complexity\": \"HIGH\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"COMPLETE\", \"base_score\": 6.2, \"confidentiality_impact\": \"COMPLETE\", \"exploitability_score\": 1.9, \"impact_score\": 10.0, \"integrity_impact\": \"COMPLETE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:L/AC:H/Au:N/C:C/I:C/A:C\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"HIGH\", \"attack_vector\": \"LOCAL\", \"availability_impact\": \"HIGH\", \"base_score\": 6.7, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"HIGH\", \"exploitability_score\": 0.8, \"impact_score\": 5.9, \"integrity_impact\": \"HIGH\", \"privileges_required\": \"LOW\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"REQUIRED\"}, \"vector_string\": \"CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2007-5686", "Negligible", 1, "login-1:4.5-1.1", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2007-5686", "dpkg", "vulnerabilities", "debian:10", "login", "pkgdb", "1:4.5-1.1", "{\"nvd_data\": [{\"id\": \"CVE-2007-5686\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 4.9, \"confidentiality_impact\": \"COMPLETE\", \"exploitability_score\": 3.9, \"impact_score\": 6.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:L/AC:L/Au:N/C:C/I:N/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": null}], \"vendor_data\": []}"], ["CVE-2013-4235", "Negligible", 1, "login-1:4.5-1.1", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2013-4235", "dpkg", "vulnerabilities", "debian:10", "login", "pkgdb", "1:4.5-1.1", "{\"nvd_data\": [{\"id\": \"CVE-2013-4235\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 3.3, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 3.4, \"impact_score\": 4.9, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Low\", \"vector_string\": \"AV:L/AC:M/Au:N/C:N/I:P/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"HIGH\", \"attack_vector\": \"LOCAL\", \"availability_impact\": \"NONE\", \"base_score\": 4.7, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 1.0, \"impact_score\": 3.6, \"integrity_impact\": \"HIGH\", \"privileges_required\": \"LOW\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:H/A:N\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2019-19882", "Negligible", 1, "login-1:4.5-1.1", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2019-19882", "dpkg", "vulnerabilities", "debian:10", "login", "pkgdb", "1:4.5-1.1", "{\"nvd_data\": [{\"id\": \"CVE-2019-19882\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"COMPLETE\", \"base_score\": 6.9, \"confidentiality_impact\": \"COMPLETE\", \"exploitability_score\": 3.4, \"impact_score\": 10.0, \"integrity_impact\": \"COMPLETE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:L/AC:M/Au:N/C:C/I:C/A:C\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"LOCAL\", \"availability_impact\": \"HIGH\", \"base_score\": 7.8, \"base_severity\": \"High\", \"confidentiality_impact\": \"HIGH\", \"exploitability_score\": 1.8, \"impact_score\": 5.9, \"integrity_impact\": \"HIGH\", \"privileges_required\": \"LOW\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2007-6755", "Negligible", 1, "openssl-1.1.1d-0+deb10u6", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2007-6755", "dpkg", "vulnerabilities", "debian:10", "openssl", "pkgdb", "1.1.1d-0+deb10u6", "{\"nvd_data\": [{\"id\": \"CVE-2007-6755\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 5.8, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 8.6, \"impact_score\": 4.9, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:P/I:P/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": null}], \"vendor_data\": []}"], ["CVE-2010-0928", "Negligible", 1, "openssl-1.1.1d-0+deb10u6", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2010-0928", "dpkg", "vulnerabilities", "debian:10", "openssl", "pkgdb", "1.1.1d-0+deb10u6", "{\"nvd_data\": [{\"id\": \"CVE-2010-0928\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"HIGH\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 4.0, \"confidentiality_impact\": \"COMPLETE\", \"exploitability_score\": 1.9, \"impact_score\": 6.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:L/AC:H/Au:N/C:C/I:N/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": null}], \"vendor_data\": []}"], ["CVE-2007-5686", "Negligible", 1, "passwd-1:4.5-1.1", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2007-5686", "dpkg", "vulnerabilities", "debian:10", "passwd", "pkgdb", "1:4.5-1.1", "{\"nvd_data\": [{\"id\": \"CVE-2007-5686\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 4.9, \"confidentiality_impact\": \"COMPLETE\", \"exploitability_score\": 3.9, \"impact_score\": 6.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:L/AC:L/Au:N/C:C/I:N/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": null}], \"vendor_data\": []}"], ["CVE-2013-4235", "Negligible", 1, "passwd-1:4.5-1.1", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2013-4235", "dpkg", "vulnerabilities", "debian:10", "passwd", "pkgdb", "1:4.5-1.1", "{\"nvd_data\": [{\"id\": \"CVE-2013-4235\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 3.3, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 3.4, \"impact_score\": 4.9, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Low\", \"vector_string\": \"AV:L/AC:M/Au:N/C:N/I:P/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"HIGH\", \"attack_vector\": \"LOCAL\", \"availability_impact\": \"NONE\", \"base_score\": 4.7, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 1.0, \"impact_score\": 3.6, \"integrity_impact\": \"HIGH\", \"privileges_required\": \"LOW\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:H/A:N\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2019-19882", "Negligible", 1, "passwd-1:4.5-1.1", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2019-19882", "dpkg", "vulnerabilities", "debian:10", "passwd", "pkgdb", "1:4.5-1.1", "{\"nvd_data\": [{\"id\": \"CVE-2019-19882\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"COMPLETE\", \"base_score\": 6.9, \"confidentiality_impact\": \"COMPLETE\", \"exploitability_score\": 3.4, \"impact_score\": 10.0, \"integrity_impact\": \"COMPLETE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:L/AC:M/Au:N/C:C/I:C/A:C\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"LOCAL\", \"availability_impact\": \"HIGH\", \"base_score\": 7.8, \"base_severity\": \"High\", \"confidentiality_impact\": \"HIGH\", \"exploitability_score\": 1.8, \"impact_score\": 5.9, \"integrity_impact\": \"HIGH\", \"privileges_required\": \"LOW\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2011-4116", "Negligible", 1, "perl-5.28.1-6+deb10u1", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2011-4116", "dpkg", "vulnerabilities", "debian:10", "perl", "pkgdb", "5.28.1-6+deb10u1", "{\"nvd_data\": [{\"id\": \"CVE-2011-4116\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 5.0, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 10.0, \"impact_score\": 2.9, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:N/C:N/I:P/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"NONE\", \"base_score\": 7.5, \"base_severity\": \"High\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 3.9, \"impact_score\": 3.6, \"integrity_impact\": \"HIGH\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2011-4116", "Negligible", 1, "perl-base-5.28.1-6+deb10u1", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2011-4116", "dpkg", "vulnerabilities", "debian:10", "perl-base", "pkgdb", "5.28.1-6+deb10u1", "{\"nvd_data\": [{\"id\": \"CVE-2011-4116\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 5.0, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 10.0, \"impact_score\": 2.9, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:N/C:N/I:P/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"NONE\", \"base_score\": 7.5, \"base_severity\": \"High\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 3.9, \"impact_score\": 3.6, \"integrity_impact\": \"HIGH\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2008-4108", "Negligible", 1, "python-2.7.16-1", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2008-4108", "dpkg", "vulnerabilities", "debian:10", "python", "pkgdb", "2.7.16-1", "{\"nvd_data\": [{\"id\": \"CVE-2008-4108\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"COMPLETE\", \"base_score\": 7.2, \"confidentiality_impact\": \"COMPLETE\", \"exploitability_score\": 3.9, \"impact_score\": 10.0, \"integrity_impact\": \"COMPLETE\"}, \"severity\": \"High\", \"vector_string\": \"AV:L/AC:L/Au:N/C:C/I:C/A:C\", \"version\": \"2.0\"}, \"cvss_v3\": null}], \"vendor_data\": []}"], ["CVE-2013-7040", "Negligible", 1, "python2.7-minimal-2.7.16-2+deb10u1", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2013-7040", "dpkg", "vulnerabilities", "debian:10", "python2.7-minimal", "pkgdb", "2.7.16-2+deb10u1", "{\"nvd_data\": [{\"id\": \"CVE-2013-7040\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 4.3, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 8.6, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": null}], \"vendor_data\": []}"], ["CVE-2017-17522", "Negligible", 1, "python2.7-minimal-2.7.16-2+deb10u1", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2017-17522", "dpkg", "vulnerabilities", "debian:10", "python2.7-minimal", "pkgdb", "2.7.16-2+deb10u1", "{\"nvd_data\": [{\"id\": \"CVE-2017-17522\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": true}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 6.8, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 8.6, \"impact_score\": 6.4, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:P/I:P/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 8.8, \"base_severity\": \"High\", \"confidentiality_impact\": \"HIGH\", \"exploitability_score\": 2.8, \"impact_score\": 5.9, \"integrity_impact\": \"HIGH\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"REQUIRED\"}, \"vector_string\": \"CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H\", \"version\": \"3.0\"}}], \"vendor_data\": []}"], ["CVE-2019-18348", "Negligible", 1, "python2.7-minimal-2.7.16-2+deb10u1", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2019-18348", "dpkg", "vulnerabilities", "debian:10", "python2.7-minimal", "pkgdb", "2.7.16-2+deb10u1", "{\"nvd_data\": [{\"id\": \"CVE-2019-18348\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": true}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 4.3, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 8.6, \"impact_score\": 2.9, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:N/I:P/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"NONE\", \"base_score\": 6.1, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"LOW\", \"exploitability_score\": 2.8, \"impact_score\": 2.7, \"integrity_impact\": \"LOW\", \"privileges_required\": \"NONE\", \"scope\": \"CHANGED\", \"user_interaction\": \"REQUIRED\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2019-9674", "Negligible", 1, "python2.7-minimal-2.7.16-2+deb10u1", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2019-9674", "dpkg", "vulnerabilities", "debian:10", "python2.7-minimal", "pkgdb", "2.7.16-2+deb10u1", "{\"nvd_data\": [{\"id\": \"CVE-2019-9674\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 5.0, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 10.0, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 7.5, \"base_severity\": \"High\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 3.9, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2021-23336", "Medium", 1, "python2.7-minimal-2.7.16-2+deb10u1", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2021-23336", "dpkg", "vulnerabilities", "debian:10", "python2.7-minimal", "pkgdb", "2.7.16-2+deb10u1", "{\"nvd_data\": [{\"id\": \"CVE-2021-23336\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": true}, \"base_metrics\": {\"access_complexity\": \"HIGH\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 4.0, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 4.9, \"impact_score\": 4.9, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:H/Au:N/C:N/I:P/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"HIGH\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 5.9, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 1.6, \"impact_score\": 4.2, \"integrity_impact\": \"LOW\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"REQUIRED\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2017-17522", "Negligible", 1, "python3.7-minimal-3.7.3-2+deb10u3", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2017-17522", "dpkg", "vulnerabilities", "debian:10", "python3.7-minimal", "pkgdb", "3.7.3-2+deb10u3", "{\"nvd_data\": [{\"id\": \"CVE-2017-17522\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": true}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 6.8, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 8.6, \"impact_score\": 6.4, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:P/I:P/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 8.8, \"base_severity\": \"High\", \"confidentiality_impact\": \"HIGH\", \"exploitability_score\": 2.8, \"impact_score\": 5.9, \"integrity_impact\": \"HIGH\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"REQUIRED\"}, \"vector_string\": \"CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H\", \"version\": \"3.0\"}}], \"vendor_data\": []}"], ["CVE-2019-18348", "Negligible", 1, "python3.7-minimal-3.7.3-2+deb10u3", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2019-18348", "dpkg", "vulnerabilities", "debian:10", "python3.7-minimal", "pkgdb", "3.7.3-2+deb10u3", "{\"nvd_data\": [{\"id\": \"CVE-2019-18348\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": true}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 4.3, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 8.6, \"impact_score\": 2.9, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:N/I:P/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"NONE\", \"base_score\": 6.1, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"LOW\", \"exploitability_score\": 2.8, \"impact_score\": 2.7, \"integrity_impact\": \"LOW\", \"privileges_required\": \"NONE\", \"scope\": \"CHANGED\", \"user_interaction\": \"REQUIRED\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2019-9674", "Negligible", 1, "python3.7-minimal-3.7.3-2+deb10u3", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2019-9674", "dpkg", "vulnerabilities", "debian:10", "python3.7-minimal", "pkgdb", "3.7.3-2+deb10u3", "{\"nvd_data\": [{\"id\": \"CVE-2019-9674\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 5.0, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 10.0, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 7.5, \"base_severity\": \"High\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 3.9, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2020-27619", "Negligible", 1, "python3.7-minimal-3.7.3-2+deb10u3", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2020-27619", "dpkg", "vulnerabilities", "debian:10", "python3.7-minimal", "pkgdb", "3.7.3-2+deb10u3", "{\"nvd_data\": [{\"id\": \"CVE-2020-27619\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 7.5, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 10.0, \"impact_score\": 6.4, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"High\", \"vector_string\": \"AV:N/AC:L/Au:N/C:P/I:P/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 9.8, \"base_severity\": \"Critical\", \"confidentiality_impact\": \"HIGH\", \"exploitability_score\": 3.9, \"impact_score\": 5.9, \"integrity_impact\": \"HIGH\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2013-4392", "Negligible", 1, "systemd-241-7~deb10u7", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2013-4392", "dpkg", "vulnerabilities", "debian:10", "systemd", "pkgdb", "241-7~deb10u7", "{\"nvd_data\": [{\"id\": \"CVE-2013-4392\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 3.3, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 3.4, \"impact_score\": 4.9, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Low\", \"vector_string\": \"AV:L/AC:M/Au:N/C:P/I:P/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": null}], \"vendor_data\": []}"], ["CVE-2019-20386", "Negligible", 1, "systemd-241-7~deb10u7", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2019-20386", "dpkg", "vulnerabilities", "debian:10", "systemd", "pkgdb", "241-7~deb10u7", "{\"nvd_data\": [{\"id\": \"CVE-2019-20386\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 2.1, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 3.9, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Low\", \"vector_string\": \"AV:L/AC:L/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"PHYSICAL\", \"availability_impact\": \"LOW\", \"base_score\": 2.4, \"base_severity\": \"Low\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 0.9, \"impact_score\": 1.4, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2020-13776", "Negligible", 1, "systemd-241-7~deb10u7", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2020-13776", "dpkg", "vulnerabilities", "debian:10", "systemd", "pkgdb", "241-7~deb10u7", "{\"nvd_data\": [{\"id\": \"CVE-2020-13776\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": true}, \"base_metrics\": {\"access_complexity\": \"HIGH\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"COMPLETE\", \"base_score\": 6.2, \"confidentiality_impact\": \"COMPLETE\", \"exploitability_score\": 1.9, \"impact_score\": 10.0, \"integrity_impact\": \"COMPLETE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:L/AC:H/Au:N/C:C/I:C/A:C\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"HIGH\", \"attack_vector\": \"LOCAL\", \"availability_impact\": \"HIGH\", \"base_score\": 6.7, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"HIGH\", \"exploitability_score\": 0.8, \"impact_score\": 5.9, \"integrity_impact\": \"HIGH\", \"privileges_required\": \"LOW\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"REQUIRED\"}, \"vector_string\": \"CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2005-2541", "Negligible", 1, "tar-1.30+dfsg-6", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2005-2541", "dpkg", "vulnerabilities", "debian:10", "tar", "pkgdb", "1.30+dfsg-6", "{\"nvd_data\": [{\"id\": \"CVE-2005-2541\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": true, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"COMPLETE\", \"base_score\": 10.0, \"confidentiality_impact\": \"COMPLETE\", \"exploitability_score\": 10.0, \"impact_score\": 10.0, \"integrity_impact\": \"COMPLETE\"}, \"severity\": \"High\", \"vector_string\": \"AV:N/AC:L/Au:N/C:C/I:C/A:C\", \"version\": \"2.0\"}, \"cvss_v3\": null}], \"vendor_data\": []}"], ["CVE-2019-9923", "Negligible", 1, "tar-1.30+dfsg-6", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2019-9923", "dpkg", "vulnerabilities", "debian:10", "tar", "pkgdb", "1.30+dfsg-6", "{\"nvd_data\": [{\"id\": \"CVE-2019-9923\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 5.0, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 10.0, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 7.5, \"base_severity\": \"High\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 3.9, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"version\": \"3.0\"}}], \"vendor_data\": []}"], ["CVE-2021-20193", "Negligible", 1, "tar-1.30+dfsg-6", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2021-20193", "dpkg", "vulnerabilities", "debian:10", "tar", "pkgdb", "1.30+dfsg-6", "{\"nvd_data\": [{\"id\": \"CVE-2021-20193\", \"cvss_v2\": null, \"cvss_v3\": null}], \"vendor_data\": []}"], ["CVE-2017-15131", "Negligible", 1, "xdg-user-dirs-0.17-2", "None", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://security-tracker.debian.org/tracker/CVE-2017-15131", "dpkg", "vulnerabilities", "debian:10", "xdg-user-dirs", "pkgdb", "0.17-2", "{\"nvd_data\": [{\"id\": \"CVE-2017-15131\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 4.6, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 3.9, \"impact_score\": 6.4, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:L/AC:L/Au:N/C:P/I:P/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"LOCAL\", \"availability_impact\": \"HIGH\", \"base_score\": 7.8, \"base_severity\": \"High\", \"confidentiality_impact\": \"HIGH\", \"exploitability_score\": 1.8, \"impact_score\": 5.9, \"integrity_impact\": \"HIGH\", \"privileges_required\": \"LOW\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H\", \"version\": \"3.0\"}}], \"vendor_data\": []}"], ["GHSA-h6q6-9hqw-rwfv", "Low", 1, "xmldom-0.4.0", "0.5.0", "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565", "None", "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv", "npm", "vulnerabilities", "github:npm", "xmldom", "/sandbox/node_modules/xmldom/package.json", "0.4.0", "{\"nvd_data\": [{\"id\": \"CVE-2021-21366\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": true}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 4.3, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 8.6, \"impact_score\": 2.9, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:N/I:P/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"NONE\", \"base_score\": 4.3, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 2.8, \"impact_score\": 1.4, \"integrity_impact\": \"LOW\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"REQUIRED\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N\", \"version\": \"3.1\"}}], \"vendor_data\": []}"]]}, "url_column_index": 7, "warns": []}}, "user_id": "admin"}
+[
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "aiohttp",
+      "pkg_path": "/usr/local/lib/python3.7/dist-packages/aiohttp",
+      "pkg_type": "python",
+      "version": "3.7.3"
+    },
+    "fixes": [
+      {
+        "observed_at": "2021-03-31T17:30:49Z",
+        "version": "3.7.4",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2021-03-31T17:30:49Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5.8,
+            "exploitability_score": 8.6,
+            "impact_score": 4.9
+          },
+          "cvss_v3": {
+            "base_score": 6.1,
+            "exploitability_score": 2.8,
+            "impact_score": 2.7
+          },
+          "id": "CVE-2021-21330"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "github:python",
+      "last_modified": "2021-03-31T17:30:49Z",
+      "link": "https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
+      "severity": "Low",
+      "vulnerability_id": "GHSA-v6wp-4m6f-gcjg"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "apt",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "1.8.2.2"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:00:32Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 3.7,
+            "exploitability_score": 2.2,
+            "impact_score": 1.4
+          },
+          "id": "CVE-2011-3374"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T23:00:32Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2011-3374",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2011-3374"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "bash",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "5.0-4"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:58:42Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 7.2,
+            "exploitability_score": 3.9,
+            "impact_score": 10
+          },
+          "cvss_v3": {
+            "base_score": 7.8,
+            "exploitability_score": 1.8,
+            "impact_score": 5.9
+          },
+          "id": "CVE-2019-18276"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-07-05T09:12:19Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18276",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-18276"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "coreutils",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "8.30-3"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:59:57Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 1.9,
+            "exploitability_score": 3.4,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 4.7,
+            "exploitability_score": 1,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2017-18018"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:59:57Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-18018",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-18018"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "guava",
+      "pkg_path": "/sandbox/target/my-app-1.jar:guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fixes": [
+      {
+        "observed_at": "2021-03-31T17:30:52Z",
+        "version": "30.0-jre",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2021-03-31T17:30:52Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 3.3,
+            "exploitability_score": 1.8,
+            "impact_score": 1.4
+          },
+          "id": "CVE-2020-8908"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "last_modified": "2021-03-31T17:30:52Z",
+      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "guava",
+      "pkg_path": "/sandbox/target/my-app-1.jar:guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fixes": [
+      {
+        "observed_at": "2020-06-16T09:10:15Z",
+        "version": "24.1.1-jre",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-06-16T09:10:15Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 5.9,
+            "exploitability_score": 2.2,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2018-10237"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "last_modified": "2020-06-16T09:10:15Z",
+      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "guava",
+      "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fixes": [
+      {
+        "observed_at": "2021-03-31T17:30:52Z",
+        "version": "30.0-jre",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2021-03-31T17:30:52Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 3.3,
+            "exploitability_score": 1.8,
+            "impact_score": 1.4
+          },
+          "id": "CVE-2020-8908"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "last_modified": "2021-03-31T17:30:52Z",
+      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "guava",
+      "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fixes": [
+      {
+        "observed_at": "2020-06-16T09:10:15Z",
+        "version": "24.1.1-jre",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-06-16T09:10:15Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 5.9,
+            "exploitability_score": 2.2,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2018-10237"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "last_modified": "2020-06-16T09:10:15Z",
+      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libapt-pkg5.0",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "1.8.2.2"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:00:32Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 3.7,
+            "exploitability_score": 2.2,
+            "impact_score": 1.4
+          },
+          "id": "CVE-2011-3374"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T23:00:32Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2011-3374",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2011-3374"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libc6",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:00:05Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5,
+            "exploitability_score": 10,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": -1,
+            "exploitability_score": -1,
+            "impact_score": -1
+          },
+          "id": "CVE-2010-4051"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T23:00:05Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4051",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2010-4051"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libc6",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:00:05Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5,
+            "exploitability_score": 10,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": -1,
+            "exploitability_score": -1,
+            "impact_score": -1
+          },
+          "id": "CVE-2010-4052"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T23:00:05Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4052",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2010-4052"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libc6",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:00:06Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4,
+            "exploitability_score": 8,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": -1,
+            "exploitability_score": -1,
+            "impact_score": -1
+          },
+          "id": "CVE-2010-4756"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T23:00:06Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4756",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2010-4756"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libc6",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:00:05Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5,
+            "exploitability_score": 10,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2018-20796"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T23:00:05Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2018-20796",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2018-20796"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libc6",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:00:06Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 7.5,
+            "exploitability_score": 10,
+            "impact_score": 6.4
+          },
+          "cvss_v3": {
+            "base_score": 9.8,
+            "exploitability_score": 3.9,
+            "impact_score": 5.9
+          },
+          "id": "CVE-2019-1010022"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T23:00:06Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010022",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-1010022"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libc6",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:00:05Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 6.8,
+            "exploitability_score": 8.6,
+            "impact_score": 6.4
+          },
+          "cvss_v3": {
+            "base_score": 8.8,
+            "exploitability_score": 2.8,
+            "impact_score": 5.9
+          },
+          "id": "CVE-2019-1010023"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T23:00:05Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010023",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-1010023"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libc6",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:00:05Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5,
+            "exploitability_score": 10,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 5.3,
+            "exploitability_score": 3.9,
+            "impact_score": 1.4
+          },
+          "id": "CVE-2019-1010024"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T23:00:05Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010024",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-1010024"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libc6",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:00:05Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5,
+            "exploitability_score": 10,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 5.3,
+            "exploitability_score": 3.9,
+            "impact_score": 1.4
+          },
+          "id": "CVE-2019-1010025"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T23:00:05Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010025",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-1010025"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libc6",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:00:05Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5,
+            "exploitability_score": 10,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2019-9192"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T23:00:05Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9192",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-9192"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libc-bin",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:00:05Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5,
+            "exploitability_score": 10,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": -1,
+            "exploitability_score": -1,
+            "impact_score": -1
+          },
+          "id": "CVE-2010-4051"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T23:00:05Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4051",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2010-4051"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libc-bin",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:00:05Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5,
+            "exploitability_score": 10,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": -1,
+            "exploitability_score": -1,
+            "impact_score": -1
+          },
+          "id": "CVE-2010-4052"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T23:00:05Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4052",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2010-4052"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libc-bin",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:00:06Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4,
+            "exploitability_score": 8,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": -1,
+            "exploitability_score": -1,
+            "impact_score": -1
+          },
+          "id": "CVE-2010-4756"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T23:00:06Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4756",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2010-4756"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libc-bin",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:00:05Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5,
+            "exploitability_score": 10,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2018-20796"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T23:00:05Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2018-20796",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2018-20796"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libc-bin",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:00:06Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 7.5,
+            "exploitability_score": 10,
+            "impact_score": 6.4
+          },
+          "cvss_v3": {
+            "base_score": 9.8,
+            "exploitability_score": 3.9,
+            "impact_score": 5.9
+          },
+          "id": "CVE-2019-1010022"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T23:00:06Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010022",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-1010022"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libc-bin",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:00:05Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 6.8,
+            "exploitability_score": 8.6,
+            "impact_score": 6.4
+          },
+          "cvss_v3": {
+            "base_score": 8.8,
+            "exploitability_score": 2.8,
+            "impact_score": 5.9
+          },
+          "id": "CVE-2019-1010023"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T23:00:05Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010023",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-1010023"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libc-bin",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:00:05Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5,
+            "exploitability_score": 10,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 5.3,
+            "exploitability_score": 3.9,
+            "impact_score": 1.4
+          },
+          "id": "CVE-2019-1010024"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T23:00:05Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010024",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-1010024"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libc-bin",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:00:05Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5,
+            "exploitability_score": 10,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 5.3,
+            "exploitability_score": 3.9,
+            "impact_score": 1.4
+          },
+          "id": "CVE-2019-1010025"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T23:00:05Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010025",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-1010025"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libc-bin",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:00:05Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5,
+            "exploitability_score": 10,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2019-9192"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T23:00:05Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9192",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-9192"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libgcrypt20",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "1.8.4-5"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:56:27Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5,
+            "exploitability_score": 10,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2018-6829"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:56:27Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2018-6829",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2018-6829"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libglib2.0-0",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.58.3-2+deb10u2"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:01:10Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5,
+            "exploitability_score": 10,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": -1,
+            "exploitability_score": -1,
+            "impact_score": -1
+          },
+          "id": "CVE-2012-0039"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T23:01:10Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2012-0039",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2012-0039"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libglib2.0-0",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.58.3-2+deb10u2"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-12-16T09:16:22Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.6,
+            "exploitability_score": 3.9,
+            "impact_score": 6.4
+          },
+          "cvss_v3": {
+            "base_score": 7.8,
+            "exploitability_score": 1.8,
+            "impact_score": 5.9
+          },
+          "id": "CVE-2020-35457"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-12-18T09:16:42Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-35457",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2020-35457"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libgnutls30",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "3.6.7-4+deb10u6"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:56:32Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": -1,
+            "exploitability_score": -1,
+            "impact_score": -1
+          },
+          "id": "CVE-2011-3389"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:56:32Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2011-3389",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2011-3389"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libgssapi-krb5-2",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "1.17-3+deb10u1"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:58:44Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": -1,
+            "exploitability_score": -1,
+            "impact_score": -1
+          },
+          "id": "CVE-2004-0971"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:58:44Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2004-0971",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2004-0971"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libgssapi-krb5-2",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "1.17-3+deb10u1"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:58:44Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5,
+            "exploitability_score": 10,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2018-5709"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:58:44Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2018-5709",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2018-5709"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libldap-common",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.4.47+dfsg-3+deb10u6"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:58:11Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5,
+            "exploitability_score": 10,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": -1,
+            "exploitability_score": -1,
+            "impact_score": -1
+          },
+          "id": "CVE-2015-3276"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:58:11Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2015-3276",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2015-3276"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libldap-common",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.4.47+dfsg-3+deb10u6"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:58:11Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 1.9,
+            "exploitability_score": 3.4,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 4.7,
+            "exploitability_score": 1,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2017-14159"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:58:11Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-14159",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-14159"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libldap-common",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.4.47+dfsg-3+deb10u6"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:58:11Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5,
+            "exploitability_score": 10,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2017-17740"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:58:11Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17740",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-17740"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libldap-common",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.4.47+dfsg-3+deb10u6"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-07-17T09:11:26Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4,
+            "exploitability_score": 4.9,
+            "impact_score": 4.9
+          },
+          "cvss_v3": {
+            "base_score": 4.2,
+            "exploitability_score": 1.6,
+            "impact_score": 2.5
+          },
+          "id": "CVE-2020-15719"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-08-05T09:09:49Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-15719",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2020-15719"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libnss-systemd",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u7"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:58:49Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 3.3,
+            "exploitability_score": 3.4,
+            "impact_score": 4.9
+          },
+          "cvss_v3": {
+            "base_score": -1,
+            "exploitability_score": -1,
+            "impact_score": -1
+          },
+          "id": "CVE-2013-4392"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:58:49Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2013-4392"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libnss-systemd",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u7"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:58:48Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 2.4,
+            "exploitability_score": 0.9,
+            "impact_score": 1.4
+          },
+          "id": "CVE-2019-20386"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-05-12T09:09:42Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-20386"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libnss-systemd",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u7"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-06-04T09:09:58Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 6.2,
+            "exploitability_score": 1.9,
+            "impact_score": 10
+          },
+          "cvss_v3": {
+            "base_score": 6.7,
+            "exploitability_score": 0.8,
+            "impact_score": 5.9
+          },
+          "id": "CVE-2020-13776"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-06-21T09:10:36Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2020-13776"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libpcre3",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2:8.39-12"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:00:01Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 7.8,
+            "exploitability_score": 10,
+            "impact_score": 6.9
+          },
+          "cvss_v3": {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2017-11164"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T23:00:01Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-11164",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-11164"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libpcre3",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2:8.39-12"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:00:01Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 5.5,
+            "exploitability_score": 1.8,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2017-16231"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T23:00:01Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-16231",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-16231"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libpcre3",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2:8.39-12"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:00:01Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 6.8,
+            "exploitability_score": 8.6,
+            "impact_score": 6.4
+          },
+          "cvss_v3": {
+            "base_score": 7.8,
+            "exploitability_score": 1.8,
+            "impact_score": 5.9
+          },
+          "id": "CVE-2017-7245"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T23:00:01Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-7245",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-7245"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libpcre3",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2:8.39-12"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:00:01Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 6.8,
+            "exploitability_score": 8.6,
+            "impact_score": 6.4
+          },
+          "cvss_v3": {
+            "base_score": 7.8,
+            "exploitability_score": 1.8,
+            "impact_score": 5.9
+          },
+          "id": "CVE-2017-7246"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T23:00:01Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-7246",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-7246"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libpcre3",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2:8.39-12"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-06-16T09:09:31Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2019-20838"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-07-02T09:10:45Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20838",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-20838"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libpython2.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.7.16-2+deb10u1"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:00:31Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": -1,
+            "exploitability_score": -1,
+            "impact_score": -1
+          },
+          "id": "CVE-2013-7040"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T23:00:31Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-7040",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2013-7040"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libpython2.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.7.16-2+deb10u1"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:58:28Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 6.8,
+            "exploitability_score": 8.6,
+            "impact_score": 6.4
+          },
+          "cvss_v3": {
+            "base_score": 8.8,
+            "exploitability_score": 2.8,
+            "impact_score": 5.9
+          },
+          "id": "CVE-2017-17522"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:58:28Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-17522"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libpython2.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.7.16-2+deb10u1"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:58:28Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 6.1,
+            "exploitability_score": 2.8,
+            "impact_score": 2.7
+          },
+          "id": "CVE-2019-18348"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:58:28Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-18348"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libpython2.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.7.16-2+deb10u1"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:58:28Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5,
+            "exploitability_score": 10,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2019-9674"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:58:28Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-9674"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libpython2.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.7.16-2+deb10u1"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2021-03-31T17:06:44Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4,
+            "exploitability_score": 4.9,
+            "impact_score": 4.9
+          },
+          "cvss_v3": {
+            "base_score": 5.9,
+            "exploitability_score": 1.6,
+            "impact_score": 4.2
+          },
+          "id": "CVE-2021-23336"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2021-03-31T17:06:44Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2021-23336",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2021-23336"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libpython3.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "3.7.3-2+deb10u3"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:58:28Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 6.8,
+            "exploitability_score": 8.6,
+            "impact_score": 6.4
+          },
+          "cvss_v3": {
+            "base_score": 8.8,
+            "exploitability_score": 2.8,
+            "impact_score": 5.9
+          },
+          "id": "CVE-2017-17522"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:58:28Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-17522"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libpython3.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "3.7.3-2+deb10u3"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:58:28Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 6.1,
+            "exploitability_score": 2.8,
+            "impact_score": 2.7
+          },
+          "id": "CVE-2019-18348"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:58:28Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-18348"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libpython3.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "3.7.3-2+deb10u3"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:58:28Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5,
+            "exploitability_score": 10,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2019-9674"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:58:28Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-9674"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libpython3.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "3.7.3-2+deb10u3"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-10-23T09:09:58Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 7.5,
+            "exploitability_score": 10,
+            "impact_score": 6.4
+          },
+          "cvss_v3": {
+            "base_score": 9.8,
+            "exploitability_score": 3.9,
+            "impact_score": 5.9
+          },
+          "id": "CVE-2020-27619"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-11-04T09:11:01Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-27619",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2020-27619"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libseccomp2",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.3.3-4"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:56:22Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 7.5,
+            "exploitability_score": 10,
+            "impact_score": 6.4
+          },
+          "cvss_v3": {
+            "base_score": 9.8,
+            "exploitability_score": 3.9,
+            "impact_score": 5.9
+          },
+          "id": "CVE-2019-9893"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:56:22Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9893",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-9893"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libssl1.1",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "1.1.1d-0+deb10u6"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:56:38Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5.8,
+            "exploitability_score": 8.6,
+            "impact_score": 4.9
+          },
+          "cvss_v3": {
+            "base_score": -1,
+            "exploitability_score": -1,
+            "impact_score": -1
+          },
+          "id": "CVE-2007-6755"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:56:38Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2007-6755",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2007-6755"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libssl1.1",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "1.1.1d-0+deb10u6"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:56:38Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4,
+            "exploitability_score": 1.9,
+            "impact_score": 6.9
+          },
+          "cvss_v3": {
+            "base_score": -1,
+            "exploitability_score": -1,
+            "impact_score": -1
+          },
+          "id": "CVE-2010-0928"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:56:38Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-0928",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2010-0928"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libsystemd0",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u7"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:58:49Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 3.3,
+            "exploitability_score": 3.4,
+            "impact_score": 4.9
+          },
+          "cvss_v3": {
+            "base_score": -1,
+            "exploitability_score": -1,
+            "impact_score": -1
+          },
+          "id": "CVE-2013-4392"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:58:49Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2013-4392"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libsystemd0",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u7"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:58:48Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 2.4,
+            "exploitability_score": 0.9,
+            "impact_score": 1.4
+          },
+          "id": "CVE-2019-20386"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-05-12T09:09:42Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-20386"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libsystemd0",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u7"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-06-04T09:09:58Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 6.2,
+            "exploitability_score": 1.9,
+            "impact_score": 10
+          },
+          "cvss_v3": {
+            "base_score": 6.7,
+            "exploitability_score": 0.8,
+            "impact_score": 5.9
+          },
+          "id": "CVE-2020-13776"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-06-21T09:10:36Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2020-13776"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libtasn1-6",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "4.13-3"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:57:42Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 7.1,
+            "exploitability_score": 8.6,
+            "impact_score": 6.9
+          },
+          "cvss_v3": {
+            "base_score": 5.5,
+            "exploitability_score": 1.8,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2018-1000654"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:57:42Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2018-1000654",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2018-1000654"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libudev1",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u6"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:58:49Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 3.3,
+            "exploitability_score": 3.4,
+            "impact_score": 4.9
+          },
+          "cvss_v3": {
+            "base_score": -1,
+            "exploitability_score": -1,
+            "impact_score": -1
+          },
+          "id": "CVE-2013-4392"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:58:49Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2013-4392"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libudev1",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u6"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:58:48Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 2.4,
+            "exploitability_score": 0.9,
+            "impact_score": 1.4
+          },
+          "id": "CVE-2019-20386"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-05-12T09:09:42Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-20386"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libudev1",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u6"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-06-04T09:09:58Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 6.2,
+            "exploitability_score": 1.9,
+            "impact_score": 10
+          },
+          "cvss_v3": {
+            "base_score": 6.7,
+            "exploitability_score": 0.8,
+            "impact_score": 5.9
+          },
+          "id": "CVE-2020-13776"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-06-21T09:10:36Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2020-13776"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "login",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "1:4.5-1.1"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:57:11Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.9,
+            "exploitability_score": 3.9,
+            "impact_score": 6.9
+          },
+          "cvss_v3": {
+            "base_score": -1,
+            "exploitability_score": -1,
+            "impact_score": -1
+          },
+          "id": "CVE-2007-5686"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:57:11Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2007-5686",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2007-5686"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "login",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "1:4.5-1.1"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:57:12Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 3.3,
+            "exploitability_score": 3.4,
+            "impact_score": 4.9
+          },
+          "cvss_v3": {
+            "base_score": 4.7,
+            "exploitability_score": 1,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2013-4235"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:57:12Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4235",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2013-4235"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "login",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "1:4.5-1.1"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:57:12Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 6.9,
+            "exploitability_score": 3.4,
+            "impact_score": 10
+          },
+          "cvss_v3": {
+            "base_score": 7.8,
+            "exploitability_score": 1.8,
+            "impact_score": 5.9
+          },
+          "id": "CVE-2019-19882"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:57:12Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-19882",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-19882"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "openssl",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "1.1.1d-0+deb10u6"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:56:38Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5.8,
+            "exploitability_score": 8.6,
+            "impact_score": 4.9
+          },
+          "cvss_v3": {
+            "base_score": -1,
+            "exploitability_score": -1,
+            "impact_score": -1
+          },
+          "id": "CVE-2007-6755"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:56:38Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2007-6755",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2007-6755"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "openssl",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "1.1.1d-0+deb10u6"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:56:38Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4,
+            "exploitability_score": 1.9,
+            "impact_score": 6.9
+          },
+          "cvss_v3": {
+            "base_score": -1,
+            "exploitability_score": -1,
+            "impact_score": -1
+          },
+          "id": "CVE-2010-0928"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:56:38Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-0928",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2010-0928"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "passwd",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "1:4.5-1.1"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:57:11Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.9,
+            "exploitability_score": 3.9,
+            "impact_score": 6.9
+          },
+          "cvss_v3": {
+            "base_score": -1,
+            "exploitability_score": -1,
+            "impact_score": -1
+          },
+          "id": "CVE-2007-5686"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:57:11Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2007-5686",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2007-5686"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "passwd",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "1:4.5-1.1"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:57:12Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 3.3,
+            "exploitability_score": 3.4,
+            "impact_score": 4.9
+          },
+          "cvss_v3": {
+            "base_score": 4.7,
+            "exploitability_score": 1,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2013-4235"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:57:12Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4235",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2013-4235"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "passwd",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "1:4.5-1.1"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:57:12Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 6.9,
+            "exploitability_score": 3.4,
+            "impact_score": 10
+          },
+          "cvss_v3": {
+            "base_score": 7.8,
+            "exploitability_score": 1.8,
+            "impact_score": 5.9
+          },
+          "id": "CVE-2019-19882"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:57:12Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-19882",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-19882"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "perl",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "5.28.1-6+deb10u1"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:57:40Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5,
+            "exploitability_score": 10,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2011-4116"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:57:40Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2011-4116",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2011-4116"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "perl-base",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "5.28.1-6+deb10u1"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:57:40Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5,
+            "exploitability_score": 10,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2011-4116"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:57:40Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2011-4116",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2011-4116"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "python",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.7.16-1"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:57:42Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 7.2,
+            "exploitability_score": 3.9,
+            "impact_score": 10
+          },
+          "cvss_v3": {
+            "base_score": -1,
+            "exploitability_score": -1,
+            "impact_score": -1
+          },
+          "id": "CVE-2008-4108"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:57:42Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2008-4108",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2008-4108"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "python2.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.7.16-2+deb10u1"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:00:31Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": -1,
+            "exploitability_score": -1,
+            "impact_score": -1
+          },
+          "id": "CVE-2013-7040"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T23:00:31Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-7040",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2013-7040"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "python2.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.7.16-2+deb10u1"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:58:28Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 6.8,
+            "exploitability_score": 8.6,
+            "impact_score": 6.4
+          },
+          "cvss_v3": {
+            "base_score": 8.8,
+            "exploitability_score": 2.8,
+            "impact_score": 5.9
+          },
+          "id": "CVE-2017-17522"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:58:28Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-17522"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "python2.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.7.16-2+deb10u1"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:58:28Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 6.1,
+            "exploitability_score": 2.8,
+            "impact_score": 2.7
+          },
+          "id": "CVE-2019-18348"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:58:28Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-18348"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "python2.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.7.16-2+deb10u1"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:58:28Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5,
+            "exploitability_score": 10,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2019-9674"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:58:28Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-9674"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "python2.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "2.7.16-2+deb10u1"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2021-03-31T17:06:44Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4,
+            "exploitability_score": 4.9,
+            "impact_score": 4.9
+          },
+          "cvss_v3": {
+            "base_score": 5.9,
+            "exploitability_score": 1.6,
+            "impact_score": 4.2
+          },
+          "id": "CVE-2021-23336"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2021-03-31T17:06:44Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2021-23336",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2021-23336"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "python3.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "3.7.3-2+deb10u3"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:58:28Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 6.8,
+            "exploitability_score": 8.6,
+            "impact_score": 6.4
+          },
+          "cvss_v3": {
+            "base_score": 8.8,
+            "exploitability_score": 2.8,
+            "impact_score": 5.9
+          },
+          "id": "CVE-2017-17522"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:58:28Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-17522"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "python3.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "3.7.3-2+deb10u3"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:58:28Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 6.1,
+            "exploitability_score": 2.8,
+            "impact_score": 2.7
+          },
+          "id": "CVE-2019-18348"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:58:28Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-18348"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "python3.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "3.7.3-2+deb10u3"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:58:28Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5,
+            "exploitability_score": 10,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2019-9674"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:58:28Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-9674"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "python3.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "3.7.3-2+deb10u3"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-10-23T09:09:58Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 7.5,
+            "exploitability_score": 10,
+            "impact_score": 6.4
+          },
+          "cvss_v3": {
+            "base_score": 9.8,
+            "exploitability_score": 3.9,
+            "impact_score": 5.9
+          },
+          "id": "CVE-2020-27619"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-11-04T09:11:01Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-27619",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2020-27619"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "systemd",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u7"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:58:49Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 3.3,
+            "exploitability_score": 3.4,
+            "impact_score": 4.9
+          },
+          "cvss_v3": {
+            "base_score": -1,
+            "exploitability_score": -1,
+            "impact_score": -1
+          },
+          "id": "CVE-2013-4392"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:58:49Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2013-4392"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "systemd",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u7"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:58:48Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 2.4,
+            "exploitability_score": 0.9,
+            "impact_score": 1.4
+          },
+          "id": "CVE-2019-20386"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-05-12T09:09:42Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-20386"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "systemd",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u7"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-06-04T09:09:58Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 6.2,
+            "exploitability_score": 1.9,
+            "impact_score": 10
+          },
+          "cvss_v3": {
+            "base_score": 6.7,
+            "exploitability_score": 0.8,
+            "impact_score": 5.9
+          },
+          "id": "CVE-2020-13776"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-06-21T09:10:36Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2020-13776"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "tar",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "1.30+dfsg-6"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:00:35Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 10,
+            "exploitability_score": 10,
+            "impact_score": 10
+          },
+          "cvss_v3": {
+            "base_score": -1,
+            "exploitability_score": -1,
+            "impact_score": -1
+          },
+          "id": "CVE-2005-2541"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T23:00:35Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2005-2541",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2005-2541"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "tar",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "1.30+dfsg-6"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:00:35Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5,
+            "exploitability_score": 10,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2019-9923"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T23:00:35Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9923",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-9923"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "tar",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "1.30+dfsg-6"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2021-01-20T09:16:47Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": -1,
+            "exploitability_score": -1,
+            "impact_score": -1
+          },
+          "cvss_v3": {
+            "base_score": -1,
+            "exploitability_score": -1,
+            "impact_score": -1
+          },
+          "id": "CVE-2021-20193"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2021-01-21T09:16:38Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2021-20193",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2021-20193"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "xdg-user-dirs",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg",
+      "version": "0.17-2"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T22:56:32Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.6,
+            "exploitability_score": 3.9,
+            "impact_score": 6.4
+          },
+          "cvss_v3": {
+            "base_score": 7.8,
+            "exploitability_score": 1.8,
+            "impact_score": 5.9
+          },
+          "id": "CVE-2017-15131"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "last_modified": "2020-03-27T22:56:32Z",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-15131",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-15131"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "xmldom",
+      "pkg_path": "/sandbox/node_modules/xmldom/package.json",
+      "pkg_type": "npm",
+      "version": "0.4.0"
+    },
+    "fixes": [
+      {
+        "observed_at": "2021-03-31T17:30:47Z",
+        "version": "0.5.0",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "created_at": "2021-03-31T17:30:47Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 4.3,
+            "exploitability_score": 2.8,
+            "impact_score": 1.4
+          },
+          "id": "CVE-2021-21366"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "github:npm",
+      "last_modified": "2021-03-31T17:30:47Z",
+      "link": "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv",
+      "severity": "Low",
+      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "cpe:a:python-aiohttp:aiohttp:3.7.3:*:*",
+      "cpe23": "cpe:2.3:a:python-aiohttp:aiohttp:3.7.3:*:-:-:-:-:-:*",
+      "name": "aiohttp",
+      "pkg_path": "/usr/local/lib/python3.7/dist-packages/aiohttp",
+      "pkg_type": "python",
+      "version": "3.7.3"
+    },
+    "fixes": [],
+    "match": {
+      "detected_at": "2021-03-31T17:29:49Z"
+    },
+    "vulnerability": {
+      "created_at": "2021-03-31T17:29:49Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5.8,
+            "exploitability_score": 8.6,
+            "impact_score": 4.9
+          },
+          "cvss_v3": {
+            "base_score": 6.1,
+            "exploitability_score": 2.8,
+            "impact_score": 2.7
+          },
+          "id": "CVE-2021-21330"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "nvdv2",
+      "feed_group": "nvdv2:cves",
+      "last_modified": "2021-03-31T17:29:49Z",
+      "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21330",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2021-21330"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "cpe:a:guava:guava:23.0:*:*",
+      "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*",
+      "name": "guava",
+      "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fixes": [],
+    "match": {
+      "detected_at": "2021-03-31T17:25:26Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-28T02:59:42Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 5.9,
+            "exploitability_score": 2.2,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2018-10237"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "nvdv2",
+      "feed_group": "nvdv2:cves",
+      "last_modified": "2021-03-31T17:25:26Z",
+      "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2018-10237"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "cpe:a:guava:guava:23.0:*:*",
+      "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*",
+      "name": "guava",
+      "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fixes": [],
+    "match": {
+      "detected_at": "2021-03-31T17:24:25Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-12-12T09:17:33Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 3.3,
+            "exploitability_score": 1.8,
+            "impact_score": 1.4
+          },
+          "id": "CVE-2020-8908"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "nvdv2",
+      "feed_group": "nvdv2:cves",
+      "last_modified": "2021-03-31T17:24:25Z",
+      "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
+      "severity": "Low",
+      "vulnerability_id": "CVE-2020-8908"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "cpe:a:guava:guava:23.0:*:*",
+      "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*",
+      "name": "guava",
+      "pkg_path": "/sandbox/target/my-app-1.jar:guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fixes": [],
+    "match": {
+      "detected_at": "2021-03-31T17:25:26Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-28T02:59:42Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 5.9,
+            "exploitability_score": 2.2,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2018-10237"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "nvdv2",
+      "feed_group": "nvdv2:cves",
+      "last_modified": "2021-03-31T17:25:26Z",
+      "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2018-10237"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "cpe:a:guava:guava:23.0:*:*",
+      "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*",
+      "name": "guava",
+      "pkg_path": "/sandbox/target/my-app-1.jar:guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fixes": [],
+    "match": {
+      "detected_at": "2021-03-31T17:24:25Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-12-12T09:17:33Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 3.3,
+            "exploitability_score": 1.8,
+            "impact_score": 1.4
+          },
+          "id": "CVE-2020-8908"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "nvdv2",
+      "feed_group": "nvdv2:cves",
+      "last_modified": "2021-03-31T17:24:25Z",
+      "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
+      "severity": "Low",
+      "vulnerability_id": "CVE-2020-8908"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "cpe:a:ftpd:ftpd:0.2.1:*:*",
+      "cpe23": "cpe:2.3:a:ftpd:ftpd:0.2.1:*:-:-:-:-:-:*",
+      "name": "ftpd",
+      "pkg_path": "/var/lib/gems/2.5.0/specifications/ftpd-0.2.1.gemspec",
+      "pkg_type": "gem",
+      "version": "0.2.1"
+    },
+    "fixes": [],
+    "match": {
+      "detected_at": "2021-03-31T17:11:12Z"
+    },
+    "vulnerability": {
+      "created_at": "2021-03-31T17:11:12Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 10,
+            "exploitability_score": 10,
+            "impact_score": 10
+          },
+          "cvss_v3": {
+            "base_score": 9.8,
+            "exploitability_score": 3.9,
+            "impact_score": 5.9
+          },
+          "id": "CVE-2013-2512"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "nvdv2",
+      "feed_group": "nvdv2:cves",
+      "last_modified": "2021-03-31T17:11:12Z",
+      "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
+      "severity": "Critical",
+      "vulnerability_id": "CVE-2013-2512"
+    }
+  }
+]

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:80a31c3ce2e99c3691c27ac3b1753163214494e9b2ca07bfdccf29a5cca2bfbe.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:80a31c3ce2e99c3691c27ac3b1753163214494e9b2ca07bfdccf29a5cca2bfbe.json
@@ -1,1 +1,518 @@
-{"cpe_report": [{"cpe": "cpe:a:ftpd:ftpd:0.2.1:*:*", "cpe23": "cpe:2.3:a:ftpd:ftpd:0.2.1:*:-:-:-:-:-:*", "feed_name": "nvdv2", "feed_namespace": "nvdv2:cves", "fixed_in": [], "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512", "name": "ftpd", "nvd_data": [{"cvss_v2": {"additional_information": {"ac_insuf_info": false, "obtain_all_privilege": false, "obtain_other_privilege": false, "obtain_user_privilege": false, "user_interaction_required": false}, "base_metrics": {"access_complexity": "LOW", "access_vector": "NETWORK", "authentication": "NONE", "availability_impact": "COMPLETE", "base_score": 10.0, "confidentiality_impact": "COMPLETE", "exploitability_score": 10.0, "impact_score": 10.0, "integrity_impact": "COMPLETE"}, "severity": "High", "vector_string": "AV:N/AC:L/Au:N/C:C/I:C/A:C", "version": "2.0"}, "cvss_v3": {"base_metrics": {"attack_complexity": "LOW", "attack_vector": "NETWORK", "availability_impact": "HIGH", "base_score": 9.8, "base_severity": "Critical", "confidentiality_impact": "HIGH", "exploitability_score": 3.9, "impact_score": 5.9, "integrity_impact": "HIGH", "privileges_required": "NONE", "scope": "UNCHANGED", "user_interaction": "NONE"}, "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", "version": "3.1"}, "id": "CVE-2013-2512"}], "pkg_path": "/usr/lib/ruby/gems/2.7.0/specifications/ftpd-0.2.1.gemspec", "pkg_type": "gem", "severity": "Critical", "vendor_data": [], "version": "0.2.1", "vulnerability_id": "CVE-2013-2512"}, {"cpe": "cpe:a:python-aiohttp:aiohttp:3.7.3:*:*", "cpe23": "cpe:2.3:a:python-aiohttp:aiohttp:3.7.3:*:-:-:-:-:-:*", "feed_name": "nvdv2", "feed_namespace": "nvdv2:cves", "fixed_in": [], "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21330", "name": "aiohttp", "nvd_data": [{"cvss_v2": {"additional_information": {"ac_insuf_info": false, "obtain_all_privilege": false, "obtain_other_privilege": false, "obtain_user_privilege": false, "user_interaction_required": true}, "base_metrics": {"access_complexity": "MEDIUM", "access_vector": "NETWORK", "authentication": "NONE", "availability_impact": "NONE", "base_score": 5.8, "confidentiality_impact": "PARTIAL", "exploitability_score": 8.6, "impact_score": 4.9, "integrity_impact": "PARTIAL"}, "severity": "Medium", "vector_string": "AV:N/AC:M/Au:N/C:P/I:P/A:N", "version": "2.0"}, "cvss_v3": {"base_metrics": {"attack_complexity": "LOW", "attack_vector": "NETWORK", "availability_impact": "NONE", "base_score": 6.1, "base_severity": "Medium", "confidentiality_impact": "LOW", "exploitability_score": 2.8, "impact_score": 2.7, "integrity_impact": "LOW", "privileges_required": "NONE", "scope": "CHANGED", "user_interaction": "REQUIRED"}, "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N", "version": "3.1"}, "id": "CVE-2021-21330"}], "pkg_path": "/usr/lib/python3.8/site-packages/aiohttp", "pkg_type": "python", "severity": "Medium", "vendor_data": [], "version": "3.7.3", "vulnerability_id": "CVE-2021-21330"}, {"cpe": "cpe:a:guava:guava:23.0:*:*", "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*", "feed_name": "nvdv2", "feed_namespace": "nvdv2:cves", "fixed_in": [], "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237", "name": "guava", "nvd_data": [{"cvss_v2": {"additional_information": {"ac_insuf_info": false, "obtain_all_privilege": false, "obtain_other_privilege": false, "obtain_user_privilege": false, "user_interaction_required": false}, "base_metrics": {"access_complexity": "MEDIUM", "access_vector": "NETWORK", "authentication": "NONE", "availability_impact": "PARTIAL", "base_score": 4.3, "confidentiality_impact": "NONE", "exploitability_score": 8.6, "impact_score": 2.9, "integrity_impact": "NONE"}, "severity": "Medium", "vector_string": "AV:N/AC:M/Au:N/C:N/I:N/A:P", "version": "2.0"}, "cvss_v3": {"base_metrics": {"attack_complexity": "HIGH", "attack_vector": "NETWORK", "availability_impact": "HIGH", "base_score": 5.9, "base_severity": "Medium", "confidentiality_impact": "NONE", "exploitability_score": 2.2, "impact_score": 3.6, "integrity_impact": "NONE", "privileges_required": "NONE", "scope": "UNCHANGED", "user_interaction": "NONE"}, "vector_string": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H", "version": "3.1"}, "id": "CVE-2018-10237"}], "pkg_path": "/sandbox/target/original-my-app-1.jar:guava", "pkg_type": "java", "severity": "Medium", "vendor_data": [], "version": "23.0", "vulnerability_id": "CVE-2018-10237"}, {"cpe": "cpe:a:guava:guava:23.0:*:*", "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*", "feed_name": "nvdv2", "feed_namespace": "nvdv2:cves", "fixed_in": [], "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908", "name": "guava", "nvd_data": [{"cvss_v2": {"additional_information": {"ac_insuf_info": false, "obtain_all_privilege": false, "obtain_other_privilege": false, "obtain_user_privilege": false, "user_interaction_required": false}, "base_metrics": {"access_complexity": "LOW", "access_vector": "LOCAL", "authentication": "NONE", "availability_impact": "NONE", "base_score": 2.1, "confidentiality_impact": "PARTIAL", "exploitability_score": 3.9, "impact_score": 2.9, "integrity_impact": "NONE"}, "severity": "Low", "vector_string": "AV:L/AC:L/Au:N/C:P/I:N/A:N", "version": "2.0"}, "cvss_v3": {"base_metrics": {"attack_complexity": "LOW", "attack_vector": "LOCAL", "availability_impact": "NONE", "base_score": 3.3, "base_severity": "Low", "confidentiality_impact": "LOW", "exploitability_score": 1.8, "impact_score": 1.4, "integrity_impact": "NONE", "privileges_required": "LOW", "scope": "UNCHANGED", "user_interaction": "NONE"}, "vector_string": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N", "version": "3.1"}, "id": "CVE-2020-8908"}], "pkg_path": "/sandbox/target/original-my-app-1.jar:guava", "pkg_type": "java", "severity": "Low", "vendor_data": [], "version": "23.0", "vulnerability_id": "CVE-2020-8908"}, {"cpe": "cpe:a:guava:guava:23.0:*:*", "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*", "feed_name": "nvdv2", "feed_namespace": "nvdv2:cves", "fixed_in": [], "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237", "name": "guava", "nvd_data": [{"cvss_v2": {"additional_information": {"ac_insuf_info": false, "obtain_all_privilege": false, "obtain_other_privilege": false, "obtain_user_privilege": false, "user_interaction_required": false}, "base_metrics": {"access_complexity": "MEDIUM", "access_vector": "NETWORK", "authentication": "NONE", "availability_impact": "PARTIAL", "base_score": 4.3, "confidentiality_impact": "NONE", "exploitability_score": 8.6, "impact_score": 2.9, "integrity_impact": "NONE"}, "severity": "Medium", "vector_string": "AV:N/AC:M/Au:N/C:N/I:N/A:P", "version": "2.0"}, "cvss_v3": {"base_metrics": {"attack_complexity": "HIGH", "attack_vector": "NETWORK", "availability_impact": "HIGH", "base_score": 5.9, "base_severity": "Medium", "confidentiality_impact": "NONE", "exploitability_score": 2.2, "impact_score": 3.6, "integrity_impact": "NONE", "privileges_required": "NONE", "scope": "UNCHANGED", "user_interaction": "NONE"}, "vector_string": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H", "version": "3.1"}, "id": "CVE-2018-10237"}], "pkg_path": "/sandbox/target/my-app-1.jar:guava", "pkg_type": "java", "severity": "Medium", "vendor_data": [], "version": "23.0", "vulnerability_id": "CVE-2018-10237"}, {"cpe": "cpe:a:guava:guava:23.0:*:*", "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*", "feed_name": "nvdv2", "feed_namespace": "nvdv2:cves", "fixed_in": [], "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908", "name": "guava", "nvd_data": [{"cvss_v2": {"additional_information": {"ac_insuf_info": false, "obtain_all_privilege": false, "obtain_other_privilege": false, "obtain_user_privilege": false, "user_interaction_required": false}, "base_metrics": {"access_complexity": "LOW", "access_vector": "LOCAL", "authentication": "NONE", "availability_impact": "NONE", "base_score": 2.1, "confidentiality_impact": "PARTIAL", "exploitability_score": 3.9, "impact_score": 2.9, "integrity_impact": "NONE"}, "severity": "Low", "vector_string": "AV:L/AC:L/Au:N/C:P/I:N/A:N", "version": "2.0"}, "cvss_v3": {"base_metrics": {"attack_complexity": "LOW", "attack_vector": "LOCAL", "availability_impact": "NONE", "base_score": 3.3, "base_severity": "Low", "confidentiality_impact": "LOW", "exploitability_score": 1.8, "impact_score": 1.4, "integrity_impact": "NONE", "privileges_required": "LOW", "scope": "UNCHANGED", "user_interaction": "NONE"}, "vector_string": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N", "version": "3.1"}, "id": "CVE-2020-8908"}], "pkg_path": "/sandbox/target/my-app-1.jar:guava", "pkg_type": "java", "severity": "Low", "vendor_data": [], "version": "23.0", "vulnerability_id": "CVE-2020-8908"}], "image_id": "8d4db62fbc412dd3a19f55bdf3d15bed65a7cdf9a3cf00630da685af565e2d25", "legacy_report": {"multi": {"result": {"colcount": 15, "header": ["CVE_ID", "Severity", "*Total_Affected", "Vulnerable_Package", "Fix_Available", "Fix_Images", "Rebuild_Images", "URL", "Package_Type", "Feed", "Feed_Group", "Package_Name", "Package_Path", "Package_Version", "CVES"], "rowcount": 6, "rows": [["GHSA-v6wp-4m6f-gcjg", "Low", 1, "aiohttp-3.7.3", "3.7.4", "8d4db62fbc412dd3a19f55bdf3d15bed65a7cdf9a3cf00630da685af565e2d25", "None", "https://github.com/advisories/GHSA-v6wp-4m6f-gcjg", "python", "vulnerabilities", "github:python", "aiohttp", "/usr/lib/python3.8/site-packages/aiohttp", "3.7.3", "{\"nvd_data\": [{\"id\": \"CVE-2021-21330\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": true}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 5.8, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 8.6, \"impact_score\": 4.9, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:P/I:P/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"NONE\", \"base_score\": 6.1, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"LOW\", \"exploitability_score\": 2.8, \"impact_score\": 2.7, \"integrity_impact\": \"LOW\", \"privileges_required\": \"NONE\", \"scope\": \"CHANGED\", \"user_interaction\": \"REQUIRED\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["GHSA-5mg8-w23w-74h3", "Medium", 1, "guava-23.0", "30.0-jre", "8d4db62fbc412dd3a19f55bdf3d15bed65a7cdf9a3cf00630da685af565e2d25", "None", "https://github.com/advisories/GHSA-5mg8-w23w-74h3", "java", "vulnerabilities", "github:java", "guava", "/sandbox/target/my-app-1.jar:guava", "23.0", "{\"nvd_data\": [{\"id\": \"CVE-2020-8908\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 2.1, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 3.9, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Low\", \"vector_string\": \"AV:L/AC:L/Au:N/C:P/I:N/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"LOCAL\", \"availability_impact\": \"NONE\", \"base_score\": 3.3, \"base_severity\": \"Low\", \"confidentiality_impact\": \"LOW\", \"exploitability_score\": 1.8, \"impact_score\": 1.4, \"integrity_impact\": \"NONE\", \"privileges_required\": \"LOW\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["GHSA-mvr2-9pj6-7w5j", "Medium", 1, "guava-23.0", "24.1.1-jre", "8d4db62fbc412dd3a19f55bdf3d15bed65a7cdf9a3cf00630da685af565e2d25", "None", "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j", "java", "vulnerabilities", "github:java", "guava", "/sandbox/target/my-app-1.jar:guava", "23.0", "{\"nvd_data\": [{\"id\": \"CVE-2018-10237\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 4.3, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 8.6, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"HIGH\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 5.9, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 2.2, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["GHSA-5mg8-w23w-74h3", "Medium", 1, "guava-23.0", "30.0-jre", "8d4db62fbc412dd3a19f55bdf3d15bed65a7cdf9a3cf00630da685af565e2d25", "None", "https://github.com/advisories/GHSA-5mg8-w23w-74h3", "java", "vulnerabilities", "github:java", "guava", "/sandbox/target/original-my-app-1.jar:guava", "23.0", "{\"nvd_data\": [{\"id\": \"CVE-2020-8908\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 2.1, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 3.9, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Low\", \"vector_string\": \"AV:L/AC:L/Au:N/C:P/I:N/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"LOCAL\", \"availability_impact\": \"NONE\", \"base_score\": 3.3, \"base_severity\": \"Low\", \"confidentiality_impact\": \"LOW\", \"exploitability_score\": 1.8, \"impact_score\": 1.4, \"integrity_impact\": \"NONE\", \"privileges_required\": \"LOW\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["GHSA-mvr2-9pj6-7w5j", "Medium", 1, "guava-23.0", "24.1.1-jre", "8d4db62fbc412dd3a19f55bdf3d15bed65a7cdf9a3cf00630da685af565e2d25", "None", "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j", "java", "vulnerabilities", "github:java", "guava", "/sandbox/target/original-my-app-1.jar:guava", "23.0", "{\"nvd_data\": [{\"id\": \"CVE-2018-10237\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 4.3, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 8.6, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"HIGH\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 5.9, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 2.2, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["GHSA-h6q6-9hqw-rwfv", "Low", 1, "xmldom-0.4.0", "0.5.0", "8d4db62fbc412dd3a19f55bdf3d15bed65a7cdf9a3cf00630da685af565e2d25", "None", "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv", "npm", "vulnerabilities", "github:npm", "xmldom", "/sandbox/node_modules/xmldom/package.json", "0.4.0", "{\"nvd_data\": [{\"id\": \"CVE-2021-21366\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": true}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 4.3, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 8.6, \"impact_score\": 2.9, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:N/I:P/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"NONE\", \"base_score\": 4.3, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 2.8, \"impact_score\": 1.4, \"integrity_impact\": \"LOW\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"REQUIRED\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N\", \"version\": \"3.1\"}}], \"vendor_data\": []}"]]}, "url_column_index": 7, "warns": []}}, "user_id": "admin"}
+[
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "aiohttp",
+      "pkg_path": "/usr/lib/python3.8/site-packages/aiohttp",
+      "pkg_type": "python",
+      "version": "3.7.3"
+    },
+    "fixes": [
+      {
+        "observed_at": "2021-03-31T17:30:49Z",
+        "version": "3.7.4",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:01Z"
+    },
+    "vulnerability": {
+      "created_at": "2021-03-31T17:30:49Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5.8,
+            "exploitability_score": 8.6,
+            "impact_score": 4.9
+          },
+          "cvss_v3": {
+            "base_score": 6.1,
+            "exploitability_score": 2.8,
+            "impact_score": 2.7
+          },
+          "id": "CVE-2021-21330"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "github:python",
+      "last_modified": "2021-03-31T17:30:49Z",
+      "link": "https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
+      "severity": "Low",
+      "vulnerability_id": "GHSA-v6wp-4m6f-gcjg"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "guava",
+      "pkg_path": "/sandbox/target/my-app-1.jar:guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fixes": [
+      {
+        "observed_at": "2021-03-31T17:30:52Z",
+        "version": "30.0-jre",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:01Z"
+    },
+    "vulnerability": {
+      "created_at": "2021-03-31T17:30:52Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 3.3,
+            "exploitability_score": 1.8,
+            "impact_score": 1.4
+          },
+          "id": "CVE-2020-8908"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "last_modified": "2021-03-31T17:30:52Z",
+      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "guava",
+      "pkg_path": "/sandbox/target/my-app-1.jar:guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fixes": [
+      {
+        "observed_at": "2020-06-16T09:10:15Z",
+        "version": "24.1.1-jre",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:01Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-06-16T09:10:15Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 5.9,
+            "exploitability_score": 2.2,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2018-10237"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "last_modified": "2020-06-16T09:10:15Z",
+      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "guava",
+      "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fixes": [
+      {
+        "observed_at": "2021-03-31T17:30:52Z",
+        "version": "30.0-jre",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:01Z"
+    },
+    "vulnerability": {
+      "created_at": "2021-03-31T17:30:52Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 3.3,
+            "exploitability_score": 1.8,
+            "impact_score": 1.4
+          },
+          "id": "CVE-2020-8908"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "last_modified": "2021-03-31T17:30:52Z",
+      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "guava",
+      "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fixes": [
+      {
+        "observed_at": "2020-06-16T09:10:15Z",
+        "version": "24.1.1-jre",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:01Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-06-16T09:10:15Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 5.9,
+            "exploitability_score": 2.2,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2018-10237"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "last_modified": "2020-06-16T09:10:15Z",
+      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "xmldom",
+      "pkg_path": "/sandbox/node_modules/xmldom/package.json",
+      "pkg_type": "npm",
+      "version": "0.4.0"
+    },
+    "fixes": [
+      {
+        "observed_at": "2021-03-31T17:30:47Z",
+        "version": "0.5.0",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T07:31:01Z"
+    },
+    "vulnerability": {
+      "created_at": "2021-03-31T17:30:47Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 4.3,
+            "exploitability_score": 2.8,
+            "impact_score": 1.4
+          },
+          "id": "CVE-2021-21366"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "github:npm",
+      "last_modified": "2021-03-31T17:30:47Z",
+      "link": "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv",
+      "severity": "Low",
+      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "cpe:a:ftpd:ftpd:0.2.1:*:*",
+      "cpe23": "cpe:2.3:a:ftpd:ftpd:0.2.1:*:-:-:-:-:-:*",
+      "name": "ftpd",
+      "pkg_path": "/usr/lib/ruby/gems/2.7.0/specifications/ftpd-0.2.1.gemspec",
+      "pkg_type": "gem",
+      "version": "0.2.1"
+    },
+    "fixes": [],
+    "match": {
+      "detected_at": "2021-03-31T17:11:12Z"
+    },
+    "vulnerability": {
+      "created_at": "2021-03-31T17:11:12Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 10,
+            "exploitability_score": 10,
+            "impact_score": 10
+          },
+          "cvss_v3": {
+            "base_score": 9.8,
+            "exploitability_score": 3.9,
+            "impact_score": 5.9
+          },
+          "id": "CVE-2013-2512"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "nvdv2",
+      "feed_group": "nvdv2:cves",
+      "last_modified": "2021-03-31T17:11:12Z",
+      "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
+      "severity": "Critical",
+      "vulnerability_id": "CVE-2013-2512"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "cpe:a:python-aiohttp:aiohttp:3.7.3:*:*",
+      "cpe23": "cpe:2.3:a:python-aiohttp:aiohttp:3.7.3:*:-:-:-:-:-:*",
+      "name": "aiohttp",
+      "pkg_path": "/usr/lib/python3.8/site-packages/aiohttp",
+      "pkg_type": "python",
+      "version": "3.7.3"
+    },
+    "fixes": [],
+    "match": {
+      "detected_at": "2021-03-31T17:29:49Z"
+    },
+    "vulnerability": {
+      "created_at": "2021-03-31T17:29:49Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5.8,
+            "exploitability_score": 8.6,
+            "impact_score": 4.9
+          },
+          "cvss_v3": {
+            "base_score": 6.1,
+            "exploitability_score": 2.8,
+            "impact_score": 2.7
+          },
+          "id": "CVE-2021-21330"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "nvdv2",
+      "feed_group": "nvdv2:cves",
+      "last_modified": "2021-03-31T17:29:49Z",
+      "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21330",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2021-21330"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "cpe:a:guava:guava:23.0:*:*",
+      "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*",
+      "name": "guava",
+      "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fixes": [],
+    "match": {
+      "detected_at": "2021-03-31T17:25:26Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-28T02:59:42Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 5.9,
+            "exploitability_score": 2.2,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2018-10237"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "nvdv2",
+      "feed_group": "nvdv2:cves",
+      "last_modified": "2021-03-31T17:25:26Z",
+      "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2018-10237"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "cpe:a:guava:guava:23.0:*:*",
+      "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*",
+      "name": "guava",
+      "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fixes": [],
+    "match": {
+      "detected_at": "2021-03-31T17:24:25Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-12-12T09:17:33Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 3.3,
+            "exploitability_score": 1.8,
+            "impact_score": 1.4
+          },
+          "id": "CVE-2020-8908"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "nvdv2",
+      "feed_group": "nvdv2:cves",
+      "last_modified": "2021-03-31T17:24:25Z",
+      "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
+      "severity": "Low",
+      "vulnerability_id": "CVE-2020-8908"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "cpe:a:guava:guava:23.0:*:*",
+      "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*",
+      "name": "guava",
+      "pkg_path": "/sandbox/target/my-app-1.jar:guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fixes": [],
+    "match": {
+      "detected_at": "2021-03-31T17:25:26Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-28T02:59:42Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 5.9,
+            "exploitability_score": 2.2,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2018-10237"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "nvdv2",
+      "feed_group": "nvdv2:cves",
+      "last_modified": "2021-03-31T17:25:26Z",
+      "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2018-10237"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "cpe:a:guava:guava:23.0:*:*",
+      "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*",
+      "name": "guava",
+      "pkg_path": "/sandbox/target/my-app-1.jar:guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fixes": [],
+    "match": {
+      "detected_at": "2021-03-31T17:24:25Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-12-12T09:17:33Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 3.3,
+            "exploitability_score": 1.8,
+            "impact_score": 1.4
+          },
+          "id": "CVE-2020-8908"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "nvdv2",
+      "feed_group": "nvdv2:cves",
+      "last_modified": "2021-03-31T17:24:25Z",
+      "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
+      "severity": "Low",
+      "vulnerability_id": "CVE-2020-8908"
+    }
+  }
+]

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:fe3ca35038008b0eac0fa4e686bd072c9430000ab7d7853001bde5f5b8ccf60c.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:fe3ca35038008b0eac0fa4e686bd072c9430000ab7d7853001bde5f5b8ccf60c.json
@@ -1,1 +1,1622 @@
-{"cpe_report": [{"cpe": "cpe:a:guava:guava:23.0:*:*", "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*", "feed_name": "nvdv2", "feed_namespace": "nvdv2:cves", "fixed_in": [], "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237", "name": "guava", "nvd_data": [{"cvss_v2": {"additional_information": {"ac_insuf_info": false, "obtain_all_privilege": false, "obtain_other_privilege": false, "obtain_user_privilege": false, "user_interaction_required": false}, "base_metrics": {"access_complexity": "MEDIUM", "access_vector": "NETWORK", "authentication": "NONE", "availability_impact": "PARTIAL", "base_score": 4.3, "confidentiality_impact": "NONE", "exploitability_score": 8.6, "impact_score": 2.9, "integrity_impact": "NONE"}, "severity": "Medium", "vector_string": "AV:N/AC:M/Au:N/C:N/I:N/A:P", "version": "2.0"}, "cvss_v3": {"base_metrics": {"attack_complexity": "HIGH", "attack_vector": "NETWORK", "availability_impact": "HIGH", "base_score": 5.9, "base_severity": "Medium", "confidentiality_impact": "NONE", "exploitability_score": 2.2, "impact_score": 3.6, "integrity_impact": "NONE", "privileges_required": "NONE", "scope": "UNCHANGED", "user_interaction": "NONE"}, "vector_string": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H", "version": "3.1"}, "id": "CVE-2018-10237"}], "pkg_path": "/sandbox/target/my-app-1.jar:guava", "pkg_type": "java", "severity": "Medium", "vendor_data": [], "version": "23.0", "vulnerability_id": "CVE-2018-10237"}, {"cpe": "cpe:a:guava:guava:23.0:*:*", "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*", "feed_name": "nvdv2", "feed_namespace": "nvdv2:cves", "fixed_in": [], "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908", "name": "guava", "nvd_data": [{"cvss_v2": {"additional_information": {"ac_insuf_info": false, "obtain_all_privilege": false, "obtain_other_privilege": false, "obtain_user_privilege": false, "user_interaction_required": false}, "base_metrics": {"access_complexity": "LOW", "access_vector": "LOCAL", "authentication": "NONE", "availability_impact": "NONE", "base_score": 2.1, "confidentiality_impact": "PARTIAL", "exploitability_score": 3.9, "impact_score": 2.9, "integrity_impact": "NONE"}, "severity": "Low", "vector_string": "AV:L/AC:L/Au:N/C:P/I:N/A:N", "version": "2.0"}, "cvss_v3": {"base_metrics": {"attack_complexity": "LOW", "attack_vector": "LOCAL", "availability_impact": "NONE", "base_score": 3.3, "base_severity": "Low", "confidentiality_impact": "LOW", "exploitability_score": 1.8, "impact_score": 1.4, "integrity_impact": "NONE", "privileges_required": "LOW", "scope": "UNCHANGED", "user_interaction": "NONE"}, "vector_string": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N", "version": "3.1"}, "id": "CVE-2020-8908"}], "pkg_path": "/sandbox/target/my-app-1.jar:guava", "pkg_type": "java", "severity": "Low", "vendor_data": [], "version": "23.0", "vulnerability_id": "CVE-2020-8908"}, {"cpe": "cpe:a:guava:guava:23.0:*:*", "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*", "feed_name": "nvdv2", "feed_namespace": "nvdv2:cves", "fixed_in": [], "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237", "name": "guava", "nvd_data": [{"cvss_v2": {"additional_information": {"ac_insuf_info": false, "obtain_all_privilege": false, "obtain_other_privilege": false, "obtain_user_privilege": false, "user_interaction_required": false}, "base_metrics": {"access_complexity": "MEDIUM", "access_vector": "NETWORK", "authentication": "NONE", "availability_impact": "PARTIAL", "base_score": 4.3, "confidentiality_impact": "NONE", "exploitability_score": 8.6, "impact_score": 2.9, "integrity_impact": "NONE"}, "severity": "Medium", "vector_string": "AV:N/AC:M/Au:N/C:N/I:N/A:P", "version": "2.0"}, "cvss_v3": {"base_metrics": {"attack_complexity": "HIGH", "attack_vector": "NETWORK", "availability_impact": "HIGH", "base_score": 5.9, "base_severity": "Medium", "confidentiality_impact": "NONE", "exploitability_score": 2.2, "impact_score": 3.6, "integrity_impact": "NONE", "privileges_required": "NONE", "scope": "UNCHANGED", "user_interaction": "NONE"}, "vector_string": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H", "version": "3.1"}, "id": "CVE-2018-10237"}], "pkg_path": "/sandbox/target/original-my-app-1.jar:guava", "pkg_type": "java", "severity": "Medium", "vendor_data": [], "version": "23.0", "vulnerability_id": "CVE-2018-10237"}, {"cpe": "cpe:a:guava:guava:23.0:*:*", "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*", "feed_name": "nvdv2", "feed_namespace": "nvdv2:cves", "fixed_in": [], "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908", "name": "guava", "nvd_data": [{"cvss_v2": {"additional_information": {"ac_insuf_info": false, "obtain_all_privilege": false, "obtain_other_privilege": false, "obtain_user_privilege": false, "user_interaction_required": false}, "base_metrics": {"access_complexity": "LOW", "access_vector": "LOCAL", "authentication": "NONE", "availability_impact": "NONE", "base_score": 2.1, "confidentiality_impact": "PARTIAL", "exploitability_score": 3.9, "impact_score": 2.9, "integrity_impact": "NONE"}, "severity": "Low", "vector_string": "AV:L/AC:L/Au:N/C:P/I:N/A:N", "version": "2.0"}, "cvss_v3": {"base_metrics": {"attack_complexity": "LOW", "attack_vector": "LOCAL", "availability_impact": "NONE", "base_score": 3.3, "base_severity": "Low", "confidentiality_impact": "LOW", "exploitability_score": 1.8, "impact_score": 1.4, "integrity_impact": "NONE", "privileges_required": "LOW", "scope": "UNCHANGED", "user_interaction": "NONE"}, "vector_string": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N", "version": "3.1"}, "id": "CVE-2020-8908"}], "pkg_path": "/sandbox/target/original-my-app-1.jar:guava", "pkg_type": "java", "severity": "Low", "vendor_data": [], "version": "23.0", "vulnerability_id": "CVE-2020-8908"}, {"cpe": "cpe:a:python-aiohttp:aiohttp:3.7.3:*:*", "cpe23": "cpe:2.3:a:python-aiohttp:aiohttp:3.7.3:*:-:-:-:-:-:*", "feed_name": "nvdv2", "feed_namespace": "nvdv2:cves", "fixed_in": [], "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21330", "name": "aiohttp", "nvd_data": [{"cvss_v2": {"additional_information": {"ac_insuf_info": false, "obtain_all_privilege": false, "obtain_other_privilege": false, "obtain_user_privilege": false, "user_interaction_required": true}, "base_metrics": {"access_complexity": "MEDIUM", "access_vector": "NETWORK", "authentication": "NONE", "availability_impact": "NONE", "base_score": 5.8, "confidentiality_impact": "PARTIAL", "exploitability_score": 8.6, "impact_score": 4.9, "integrity_impact": "PARTIAL"}, "severity": "Medium", "vector_string": "AV:N/AC:M/Au:N/C:P/I:P/A:N", "version": "2.0"}, "cvss_v3": {"base_metrics": {"attack_complexity": "LOW", "attack_vector": "NETWORK", "availability_impact": "NONE", "base_score": 6.1, "base_severity": "Medium", "confidentiality_impact": "LOW", "exploitability_score": 2.8, "impact_score": 2.7, "integrity_impact": "LOW", "privileges_required": "NONE", "scope": "CHANGED", "user_interaction": "REQUIRED"}, "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N", "version": "3.1"}, "id": "CVE-2021-21330"}], "pkg_path": "/usr/local/lib64/python3.6/site-packages/aiohttp", "pkg_type": "python", "severity": "Medium", "vendor_data": [], "version": "3.7.3", "vulnerability_id": "CVE-2021-21330"}, {"cpe": "cpe:a:ftpd:ftpd:0.2.1:*:*", "cpe23": "cpe:2.3:a:ftpd:ftpd:0.2.1:*:-:-:-:-:-:*", "feed_name": "nvdv2", "feed_namespace": "nvdv2:cves", "fixed_in": [], "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512", "name": "ftpd", "nvd_data": [{"cvss_v2": {"additional_information": {"ac_insuf_info": false, "obtain_all_privilege": false, "obtain_other_privilege": false, "obtain_user_privilege": false, "user_interaction_required": false}, "base_metrics": {"access_complexity": "LOW", "access_vector": "NETWORK", "authentication": "NONE", "availability_impact": "COMPLETE", "base_score": 10.0, "confidentiality_impact": "COMPLETE", "exploitability_score": 10.0, "impact_score": 10.0, "integrity_impact": "COMPLETE"}, "severity": "High", "vector_string": "AV:N/AC:L/Au:N/C:C/I:C/A:C", "version": "2.0"}, "cvss_v3": {"base_metrics": {"attack_complexity": "LOW", "attack_vector": "NETWORK", "availability_impact": "HIGH", "base_score": 9.8, "base_severity": "Critical", "confidentiality_impact": "HIGH", "exploitability_score": 3.9, "impact_score": 5.9, "integrity_impact": "HIGH", "privileges_required": "NONE", "scope": "UNCHANGED", "user_interaction": "NONE"}, "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", "version": "3.1"}, "id": "CVE-2013-2512"}], "pkg_path": "/usr/local/share/gems/specifications/ftpd-0.2.1.gemspec", "pkg_type": "gem", "severity": "Critical", "vendor_data": [], "version": "0.2.1", "vulnerability_id": "CVE-2013-2512"}], "image_id": "08b3583ff5e85fb755be57d2ae9b14e3b5e4d406a5de55246b2ca84b2035f5da", "legacy_report": {"multi": {"result": {"colcount": 15, "header": ["CVE_ID", "Severity", "*Total_Affected", "Vulnerable_Package", "Fix_Available", "Fix_Images", "Rebuild_Images", "URL", "Package_Type", "Feed", "Feed_Group", "Package_Name", "Package_Path", "Package_Version", "CVES"], "rowcount": 30, "rows": [["CVE-2020-8177", "Medium", 1, "curl-7.29.0-59.el7", "0:7.29.0-59.el7_9.1", "08b3583ff5e85fb755be57d2ae9b14e3b5e4d406a5de55246b2ca84b2035f5da", "None", "https://access.redhat.com/security/cve/CVE-2020-8177", "rpm", "vulnerabilities", "rhel:7", "curl", "pkgdb", "7.29.0-59.el7", "{\"nvd_data\": [{\"id\": \"CVE-2020-8177\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 4.6, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 3.9, \"impact_score\": 6.4, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:L/AC:L/Au:N/C:P/I:P/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"LOCAL\", \"availability_impact\": \"HIGH\", \"base_score\": 7.1, \"base_severity\": \"High\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 1.8, \"impact_score\": 5.2, \"integrity_impact\": \"HIGH\", \"privileges_required\": \"LOW\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2019-17450", "Low", 1, "binutils-2.27-44.base.el7", "None", "08b3583ff5e85fb755be57d2ae9b14e3b5e4d406a5de55246b2ca84b2035f5da", "None", "https://access.redhat.com/security/cve/CVE-2019-17450", "rpm", "vulnerabilities", "rhel:7", "binutils", "pkgdb", "2.27-44.base.el7", "{\"nvd_data\": [{\"id\": \"CVE-2019-17450\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": true}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 4.3, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 8.6, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 6.5, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 2.8, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"REQUIRED\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2014-4043", "Low", 1, "glibc-2.17-323.el7_9", "None", "08b3583ff5e85fb755be57d2ae9b14e3b5e4d406a5de55246b2ca84b2035f5da", "None", "https://access.redhat.com/security/cve/CVE-2014-4043", "rpm", "vulnerabilities", "rhel:7", "glibc", "pkgdb", "2.17-323.el7_9", "{\"nvd_data\": [{\"id\": \"CVE-2014-4043\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 7.5, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 10.0, \"impact_score\": 6.4, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"High\", \"vector_string\": \"AV:N/AC:L/Au:N/C:P/I:P/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": null}], \"vendor_data\": []}"], ["CVE-2014-4043", "Low", 1, "glibc-common-2.17-323.el7_9", "None", "08b3583ff5e85fb755be57d2ae9b14e3b5e4d406a5de55246b2ca84b2035f5da", "None", "https://access.redhat.com/security/cve/CVE-2014-4043", "rpm", "vulnerabilities", "rhel:7", "glibc-common", "pkgdb", "2.17-323.el7_9", "{\"nvd_data\": [{\"id\": \"CVE-2014-4043\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 7.5, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 10.0, \"impact_score\": 6.4, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"High\", \"vector_string\": \"AV:N/AC:L/Au:N/C:P/I:P/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": null}], \"vendor_data\": []}"], ["CVE-2014-3591", "Low", 1, "gnupg2-2.0.22-5.el7_5", "None", "08b3583ff5e85fb755be57d2ae9b14e3b5e4d406a5de55246b2ca84b2035f5da", "None", "https://access.redhat.com/security/cve/CVE-2014-3591", "rpm", "vulnerabilities", "rhel:7", "gnupg2", "pkgdb", "2.0.22-5.el7_5", "{\"nvd_data\": [{\"id\": \"CVE-2014-3591\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 1.9, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 3.4, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Low\", \"vector_string\": \"AV:L/AC:M/Au:N/C:P/I:N/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"HIGH\", \"attack_vector\": \"PHYSICAL\", \"availability_impact\": \"NONE\", \"base_score\": 4.2, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"HIGH\", \"exploitability_score\": 0.5, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:P/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2014-4617", "Medium", 1, "gnupg2-2.0.22-5.el7_5", "None", "08b3583ff5e85fb755be57d2ae9b14e3b5e4d406a5de55246b2ca84b2035f5da", "None", "https://access.redhat.com/security/cve/CVE-2014-4617", "rpm", "vulnerabilities", "rhel:7", "gnupg2", "pkgdb", "2.0.22-5.el7_5", "{\"nvd_data\": [{\"id\": \"CVE-2014-4617\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 5.0, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 10.0, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": null}], \"vendor_data\": []}"], ["CVE-2015-0247", "Medium", 1, "libcom_err-1.42.9-19.el7", "None", "08b3583ff5e85fb755be57d2ae9b14e3b5e4d406a5de55246b2ca84b2035f5da", "None", "https://access.redhat.com/security/cve/CVE-2015-0247", "rpm", "vulnerabilities", "rhel:7", "libcom_err", "pkgdb", "1.42.9-19.el7", "{\"nvd_data\": [{\"id\": \"CVE-2015-0247\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 4.6, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 3.9, \"impact_score\": 6.4, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:L/AC:L/Au:N/C:P/I:P/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": null}], \"vendor_data\": []}"], ["CVE-2020-8177", "Medium", 1, "libcurl-7.29.0-59.el7", "0:7.29.0-59.el7_9.1", "08b3583ff5e85fb755be57d2ae9b14e3b5e4d406a5de55246b2ca84b2035f5da", "None", "https://access.redhat.com/security/cve/CVE-2020-8177", "rpm", "vulnerabilities", "rhel:7", "libcurl", "pkgdb", "7.29.0-59.el7", "{\"nvd_data\": [{\"id\": \"CVE-2020-8177\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 4.6, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 3.9, \"impact_score\": 6.4, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:L/AC:L/Au:N/C:P/I:P/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"LOCAL\", \"availability_impact\": \"HIGH\", \"base_score\": 7.1, \"base_severity\": \"High\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 1.8, \"impact_score\": 5.2, \"integrity_impact\": \"HIGH\", \"privileges_required\": \"LOW\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2014-3591", "Low", 1, "libgcrypt-1.5.3-14.el7", "None", "08b3583ff5e85fb755be57d2ae9b14e3b5e4d406a5de55246b2ca84b2035f5da", "None", "https://access.redhat.com/security/cve/CVE-2014-3591", "rpm", "vulnerabilities", "rhel:7", "libgcrypt", "pkgdb", "1.5.3-14.el7", "{\"nvd_data\": [{\"id\": \"CVE-2014-3591\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 1.9, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 3.4, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Low\", \"vector_string\": \"AV:L/AC:M/Au:N/C:P/I:N/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"HIGH\", \"attack_vector\": \"PHYSICAL\", \"availability_impact\": \"NONE\", \"base_score\": 4.2, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"HIGH\", \"exploitability_score\": 0.5, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:P/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2014-5270", "Medium", 1, "libgcrypt-1.5.3-14.el7", "None", "08b3583ff5e85fb755be57d2ae9b14e3b5e4d406a5de55246b2ca84b2035f5da", "None", "https://access.redhat.com/security/cve/CVE-2014-5270", "rpm", "vulnerabilities", "rhel:7", "libgcrypt", "pkgdb", "1.5.3-14.el7", "{\"nvd_data\": [{\"id\": \"CVE-2014-5270\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 2.1, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 3.9, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Low\", \"vector_string\": \"AV:L/AC:L/Au:N/C:P/I:N/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": null}], \"vendor_data\": []}"], ["CVE-2015-2059", "Low", 1, "libidn-1.28-4.el7", "None", "08b3583ff5e85fb755be57d2ae9b14e3b5e4d406a5de55246b2ca84b2035f5da", "None", "https://access.redhat.com/security/cve/CVE-2015-2059", "rpm", "vulnerabilities", "rhel:7", "libidn", "pkgdb", "1.28-4.el7", "{\"nvd_data\": [{\"id\": \"CVE-2015-2059\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": null, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 7.5, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 10.0, \"impact_score\": 6.4, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"High\", \"vector_string\": \"AV:N/AC:L/Au:N/C:P/I:P/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": null}], \"vendor_data\": []}"], ["CVE-2020-12399", "Medium", 1, "nss-3.53.1-3.el7_9", "None", "08b3583ff5e85fb755be57d2ae9b14e3b5e4d406a5de55246b2ca84b2035f5da", "None", "https://access.redhat.com/security/cve/CVE-2020-12399", "rpm", "vulnerabilities", "rhel:7", "nss", "pkgdb", "3.53.1-3.el7_9", "{\"nvd_data\": [{\"id\": \"CVE-2020-12399\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": true}, \"base_metrics\": {\"access_complexity\": \"HIGH\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 1.2, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 1.9, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Low\", \"vector_string\": \"AV:L/AC:H/Au:N/C:P/I:N/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"HIGH\", \"attack_vector\": \"LOCAL\", \"availability_impact\": \"NONE\", \"base_score\": 4.4, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"HIGH\", \"exploitability_score\": 0.8, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"LOW\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"REQUIRED\"}, \"vector_string\": \"CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:N/A:N\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2020-25648", "Medium", 1, "nss-3.53.1-3.el7_9", "None", "08b3583ff5e85fb755be57d2ae9b14e3b5e4d406a5de55246b2ca84b2035f5da", "None", "https://access.redhat.com/security/cve/CVE-2020-25648", "rpm", "vulnerabilities", "rhel:7", "nss", "pkgdb", "3.53.1-3.el7_9", "{\"nvd_data\": [{\"id\": \"CVE-2020-25648\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 5.0, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 10.0, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 7.5, \"base_severity\": \"High\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 3.9, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2020-12399", "Medium", 1, "nss-sysinit-3.53.1-3.el7_9", "None", "08b3583ff5e85fb755be57d2ae9b14e3b5e4d406a5de55246b2ca84b2035f5da", "None", "https://access.redhat.com/security/cve/CVE-2020-12399", "rpm", "vulnerabilities", "rhel:7", "nss-sysinit", "pkgdb", "3.53.1-3.el7_9", "{\"nvd_data\": [{\"id\": \"CVE-2020-12399\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": true}, \"base_metrics\": {\"access_complexity\": \"HIGH\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 1.2, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 1.9, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Low\", \"vector_string\": \"AV:L/AC:H/Au:N/C:P/I:N/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"HIGH\", \"attack_vector\": \"LOCAL\", \"availability_impact\": \"NONE\", \"base_score\": 4.4, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"HIGH\", \"exploitability_score\": 0.8, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"LOW\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"REQUIRED\"}, \"vector_string\": \"CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:N/A:N\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2020-25648", "Medium", 1, "nss-sysinit-3.53.1-3.el7_9", "None", "08b3583ff5e85fb755be57d2ae9b14e3b5e4d406a5de55246b2ca84b2035f5da", "None", "https://access.redhat.com/security/cve/CVE-2020-25648", "rpm", "vulnerabilities", "rhel:7", "nss-sysinit", "pkgdb", "3.53.1-3.el7_9", "{\"nvd_data\": [{\"id\": \"CVE-2020-25648\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 5.0, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 10.0, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 7.5, \"base_severity\": \"High\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 3.9, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2020-12399", "Medium", 1, "nss-tools-3.53.1-3.el7_9", "None", "08b3583ff5e85fb755be57d2ae9b14e3b5e4d406a5de55246b2ca84b2035f5da", "None", "https://access.redhat.com/security/cve/CVE-2020-12399", "rpm", "vulnerabilities", "rhel:7", "nss-tools", "pkgdb", "3.53.1-3.el7_9", "{\"nvd_data\": [{\"id\": \"CVE-2020-12399\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": true}, \"base_metrics\": {\"access_complexity\": \"HIGH\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 1.2, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 1.9, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Low\", \"vector_string\": \"AV:L/AC:H/Au:N/C:P/I:N/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"HIGH\", \"attack_vector\": \"LOCAL\", \"availability_impact\": \"NONE\", \"base_score\": 4.4, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"HIGH\", \"exploitability_score\": 0.8, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"LOW\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"REQUIRED\"}, \"vector_string\": \"CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:N/A:N\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2020-25648", "Medium", 1, "nss-tools-3.53.1-3.el7_9", "None", "08b3583ff5e85fb755be57d2ae9b14e3b5e4d406a5de55246b2ca84b2035f5da", "None", "https://access.redhat.com/security/cve/CVE-2020-25648", "rpm", "vulnerabilities", "rhel:7", "nss-tools", "pkgdb", "3.53.1-3.el7_9", "{\"nvd_data\": [{\"id\": \"CVE-2020-25648\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 5.0, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 10.0, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 7.5, \"base_severity\": \"High\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 3.9, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2020-25692", "Medium", 1, "openldap-2.4.44-22.el7", "None", "08b3583ff5e85fb755be57d2ae9b14e3b5e4d406a5de55246b2ca84b2035f5da", "None", "https://access.redhat.com/security/cve/CVE-2020-25692", "rpm", "vulnerabilities", "rhel:7", "openldap", "pkgdb", "2.4.44-22.el7", "{\"nvd_data\": [{\"id\": \"CVE-2020-25692\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 5.0, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 10.0, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 7.5, \"base_severity\": \"High\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 3.9, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2020-1971", "High", 1, "openssl-libs-1.0.2k-19.el7", "1:1.0.2k-21.el7_9", "08b3583ff5e85fb755be57d2ae9b14e3b5e4d406a5de55246b2ca84b2035f5da", "None", "https://access.redhat.com/security/cve/CVE-2020-1971", "rpm", "vulnerabilities", "rhel:7", "openssl-libs", "pkgdb", "1.0.2k-19.el7", "{\"nvd_data\": [{\"id\": \"CVE-2020-1971\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 4.3, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 8.6, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"HIGH\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 5.9, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 2.2, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2021-23840", "Medium", 1, "openssl-libs-1.0.2k-19.el7", "None", "08b3583ff5e85fb755be57d2ae9b14e3b5e4d406a5de55246b2ca84b2035f5da", "None", "https://access.redhat.com/security/cve/CVE-2021-23840", "rpm", "vulnerabilities", "rhel:7", "openssl-libs", "pkgdb", "1.0.2k-19.el7", "{\"nvd_data\": [{\"id\": \"CVE-2021-23840\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 5.0, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 10.0, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 7.5, \"base_severity\": \"High\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 3.9, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2021-23841", "Medium", 1, "openssl-libs-1.0.2k-19.el7", "None", "08b3583ff5e85fb755be57d2ae9b14e3b5e4d406a5de55246b2ca84b2035f5da", "None", "https://access.redhat.com/security/cve/CVE-2021-23841", "rpm", "vulnerabilities", "rhel:7", "openssl-libs", "pkgdb", "1.0.2k-19.el7", "{\"nvd_data\": [{\"id\": \"CVE-2021-23841\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 4.3, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 8.6, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"HIGH\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 5.9, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 2.2, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2019-20907", "Medium", 1, "python-2.7.5-89.el7", "0:2.7.5-90.el7", "08b3583ff5e85fb755be57d2ae9b14e3b5e4d406a5de55246b2ca84b2035f5da", "None", "https://access.redhat.com/security/cve/CVE-2019-20907", "rpm", "vulnerabilities", "rhel:7", "python", "pkgdb", "2.7.5-89.el7", "{\"nvd_data\": [{\"id\": \"CVE-2019-20907\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 5.0, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 10.0, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 7.5, \"base_severity\": \"High\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 3.9, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["CVE-2019-20907", "Medium", 1, "python-libs-2.7.5-89.el7", "0:2.7.5-90.el7", "08b3583ff5e85fb755be57d2ae9b14e3b5e4d406a5de55246b2ca84b2035f5da", "None", "https://access.redhat.com/security/cve/CVE-2019-20907", "rpm", "vulnerabilities", "rhel:7", "python-libs", "pkgdb", "2.7.5-89.el7", "{\"nvd_data\": [{\"id\": \"CVE-2019-20907\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 5.0, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 10.0, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:L/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 7.5, \"base_severity\": \"High\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 3.9, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["GHSA-h6q6-9hqw-rwfv", "Low", 1, "xmldom-0.4.0", "0.5.0", "08b3583ff5e85fb755be57d2ae9b14e3b5e4d406a5de55246b2ca84b2035f5da", "None", "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv", "npm", "vulnerabilities", "github:npm", "xmldom", "/root/.npm/xmldom/0.4.0/package/package.json", "0.4.0", "{\"nvd_data\": [{\"id\": \"CVE-2021-21366\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": true}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 4.3, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 8.6, \"impact_score\": 2.9, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:N/I:P/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"NONE\", \"base_score\": 4.3, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 2.8, \"impact_score\": 1.4, \"integrity_impact\": \"LOW\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"REQUIRED\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["GHSA-h6q6-9hqw-rwfv", "Low", 1, "xmldom-0.4.0", "0.5.0", "08b3583ff5e85fb755be57d2ae9b14e3b5e4d406a5de55246b2ca84b2035f5da", "None", "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv", "npm", "vulnerabilities", "github:npm", "xmldom", "/sandbox/node_modules/xmldom/package.json", "0.4.0", "{\"nvd_data\": [{\"id\": \"CVE-2021-21366\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": true}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 4.3, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 8.6, \"impact_score\": 2.9, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:N/I:P/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"NONE\", \"base_score\": 4.3, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 2.8, \"impact_score\": 1.4, \"integrity_impact\": \"LOW\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"REQUIRED\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["GHSA-v6wp-4m6f-gcjg", "Low", 1, "aiohttp-3.7.3", "3.7.4", "08b3583ff5e85fb755be57d2ae9b14e3b5e4d406a5de55246b2ca84b2035f5da", "None", "https://github.com/advisories/GHSA-v6wp-4m6f-gcjg", "python", "vulnerabilities", "github:python", "aiohttp", "/usr/local/lib64/python3.6/site-packages/aiohttp", "3.7.3", "{\"nvd_data\": [{\"id\": \"CVE-2021-21330\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": true}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 5.8, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 8.6, \"impact_score\": 4.9, \"integrity_impact\": \"PARTIAL\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:P/I:P/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"NONE\", \"base_score\": 6.1, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"LOW\", \"exploitability_score\": 2.8, \"impact_score\": 2.7, \"integrity_impact\": \"LOW\", \"privileges_required\": \"NONE\", \"scope\": \"CHANGED\", \"user_interaction\": \"REQUIRED\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["GHSA-5mg8-w23w-74h3", "Medium", 1, "guava-23.0", "30.0-jre", "08b3583ff5e85fb755be57d2ae9b14e3b5e4d406a5de55246b2ca84b2035f5da", "None", "https://github.com/advisories/GHSA-5mg8-w23w-74h3", "java", "vulnerabilities", "github:java", "guava", "/sandbox/target/my-app-1.jar:guava", "23.0", "{\"nvd_data\": [{\"id\": \"CVE-2020-8908\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 2.1, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 3.9, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Low\", \"vector_string\": \"AV:L/AC:L/Au:N/C:P/I:N/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"LOCAL\", \"availability_impact\": \"NONE\", \"base_score\": 3.3, \"base_severity\": \"Low\", \"confidentiality_impact\": \"LOW\", \"exploitability_score\": 1.8, \"impact_score\": 1.4, \"integrity_impact\": \"NONE\", \"privileges_required\": \"LOW\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["GHSA-mvr2-9pj6-7w5j", "Medium", 1, "guava-23.0", "24.1.1-jre", "08b3583ff5e85fb755be57d2ae9b14e3b5e4d406a5de55246b2ca84b2035f5da", "None", "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j", "java", "vulnerabilities", "github:java", "guava", "/sandbox/target/my-app-1.jar:guava", "23.0", "{\"nvd_data\": [{\"id\": \"CVE-2018-10237\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 4.3, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 8.6, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"HIGH\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 5.9, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 2.2, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["GHSA-5mg8-w23w-74h3", "Medium", 1, "guava-23.0", "30.0-jre", "08b3583ff5e85fb755be57d2ae9b14e3b5e4d406a5de55246b2ca84b2035f5da", "None", "https://github.com/advisories/GHSA-5mg8-w23w-74h3", "java", "vulnerabilities", "github:java", "guava", "/sandbox/target/original-my-app-1.jar:guava", "23.0", "{\"nvd_data\": [{\"id\": \"CVE-2020-8908\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"LOW\", \"access_vector\": \"LOCAL\", \"authentication\": \"NONE\", \"availability_impact\": \"NONE\", \"base_score\": 2.1, \"confidentiality_impact\": \"PARTIAL\", \"exploitability_score\": 3.9, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Low\", \"vector_string\": \"AV:L/AC:L/Au:N/C:P/I:N/A:N\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"LOW\", \"attack_vector\": \"LOCAL\", \"availability_impact\": \"NONE\", \"base_score\": 3.3, \"base_severity\": \"Low\", \"confidentiality_impact\": \"LOW\", \"exploitability_score\": 1.8, \"impact_score\": 1.4, \"integrity_impact\": \"NONE\", \"privileges_required\": \"LOW\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N\", \"version\": \"3.1\"}}], \"vendor_data\": []}"], ["GHSA-mvr2-9pj6-7w5j", "Medium", 1, "guava-23.0", "24.1.1-jre", "08b3583ff5e85fb755be57d2ae9b14e3b5e4d406a5de55246b2ca84b2035f5da", "None", "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j", "java", "vulnerabilities", "github:java", "guava", "/sandbox/target/original-my-app-1.jar:guava", "23.0", "{\"nvd_data\": [{\"id\": \"CVE-2018-10237\", \"cvss_v2\": {\"additional_information\": {\"ac_insuf_info\": false, \"obtain_all_privilege\": false, \"obtain_other_privilege\": false, \"obtain_user_privilege\": false, \"user_interaction_required\": false}, \"base_metrics\": {\"access_complexity\": \"MEDIUM\", \"access_vector\": \"NETWORK\", \"authentication\": \"NONE\", \"availability_impact\": \"PARTIAL\", \"base_score\": 4.3, \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 8.6, \"impact_score\": 2.9, \"integrity_impact\": \"NONE\"}, \"severity\": \"Medium\", \"vector_string\": \"AV:N/AC:M/Au:N/C:N/I:N/A:P\", \"version\": \"2.0\"}, \"cvss_v3\": {\"base_metrics\": {\"attack_complexity\": \"HIGH\", \"attack_vector\": \"NETWORK\", \"availability_impact\": \"HIGH\", \"base_score\": 5.9, \"base_severity\": \"Medium\", \"confidentiality_impact\": \"NONE\", \"exploitability_score\": 2.2, \"impact_score\": 3.6, \"integrity_impact\": \"NONE\", \"privileges_required\": \"NONE\", \"scope\": \"UNCHANGED\", \"user_interaction\": \"NONE\"}, \"vector_string\": \"CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"version\": \"3.1\"}}], \"vendor_data\": []}"]]}, "url_column_index": 7, "warns": []}}, "user_id": "admin"}
+[
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "aiohttp",
+      "pkg_path": "/usr/local/lib64/python3.6/site-packages/aiohttp",
+      "pkg_type": "python",
+      "version": "3.7.3"
+    },
+    "fixes": [
+      {
+        "observed_at": "2021-03-31T17:30:49Z",
+        "version": "3.7.4",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
+    },
+    "vulnerability": {
+      "created_at": "2021-03-31T17:30:49Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5.8,
+            "exploitability_score": 8.6,
+            "impact_score": 4.9
+          },
+          "cvss_v3": {
+            "base_score": 6.1,
+            "exploitability_score": 2.8,
+            "impact_score": 2.7
+          },
+          "id": "CVE-2021-21330"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "github:python",
+      "last_modified": "2021-03-31T17:30:49Z",
+      "link": "https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
+      "severity": "Low",
+      "vulnerability_id": "GHSA-v6wp-4m6f-gcjg"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "binutils",
+      "pkg_path": "pkgdb",
+      "pkg_type": "rpm",
+      "version": "2.27-44.base.el7"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:41:54Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 6.5,
+            "exploitability_score": 2.8,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2019-17450"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "last_modified": "2020-03-27T23:41:54Z",
+      "link": "https://access.redhat.com/security/cve/CVE-2019-17450",
+      "severity": "Low",
+      "vulnerability_id": "CVE-2019-17450"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "curl",
+      "pkg_path": "pkgdb",
+      "pkg_type": "rpm",
+      "version": "7.29.0-59.el7"
+    },
+    "fixes": [
+      {
+        "observed_at": "2020-11-11T09:10:27Z",
+        "version": "0:7.29.0-59.el7_9.1",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-06-27T09:10:53Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.6,
+            "exploitability_score": 3.9,
+            "impact_score": 6.4
+          },
+          "cvss_v3": {
+            "base_score": 7.1,
+            "exploitability_score": 1.8,
+            "impact_score": 5.2
+          },
+          "id": "CVE-2020-8177"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "last_modified": "2020-08-04T09:10:43Z",
+      "link": "https://access.redhat.com/security/cve/CVE-2020-8177",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2020-8177"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "glibc",
+      "pkg_path": "pkgdb",
+      "pkg_type": "rpm",
+      "version": "2.17-323.el7_9"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:42:55Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 7.5,
+            "exploitability_score": 10.0,
+            "impact_score": 6.4
+          },
+          "cvss_v3": {
+            "base_score": -1.0,
+            "exploitability_score": -1.0,
+            "impact_score": -1.0
+          },
+          "id": "CVE-2014-4043"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "last_modified": "2020-03-27T23:42:55Z",
+      "link": "https://access.redhat.com/security/cve/CVE-2014-4043",
+      "severity": "Low",
+      "vulnerability_id": "CVE-2014-4043"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "glibc-common",
+      "pkg_path": "pkgdb",
+      "pkg_type": "rpm",
+      "version": "2.17-323.el7_9"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:42:55Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 7.5,
+            "exploitability_score": 10.0,
+            "impact_score": 6.4
+          },
+          "cvss_v3": {
+            "base_score": -1.0,
+            "exploitability_score": -1.0,
+            "impact_score": -1.0
+          },
+          "id": "CVE-2014-4043"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "last_modified": "2020-03-27T23:42:55Z",
+      "link": "https://access.redhat.com/security/cve/CVE-2014-4043",
+      "severity": "Low",
+      "vulnerability_id": "CVE-2014-4043"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "gnupg2",
+      "pkg_path": "pkgdb",
+      "pkg_type": "rpm",
+      "version": "2.0.22-5.el7_5"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:42:51Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 1.9,
+            "exploitability_score": 3.4,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 4.2,
+            "exploitability_score": 0.5,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2014-3591"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "last_modified": "2020-03-27T23:42:51Z",
+      "link": "https://access.redhat.com/security/cve/CVE-2014-3591",
+      "severity": "Low",
+      "vulnerability_id": "CVE-2014-3591"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "gnupg2",
+      "pkg_path": "pkgdb",
+      "pkg_type": "rpm",
+      "version": "2.0.22-5.el7_5"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:42:00Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": -1.0,
+            "exploitability_score": -1.0,
+            "impact_score": -1.0
+          },
+          "id": "CVE-2014-4617"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "last_modified": "2020-03-27T23:42:00Z",
+      "link": "https://access.redhat.com/security/cve/CVE-2014-4617",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2014-4617"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "guava",
+      "pkg_path": "/sandbox/target/my-app-1.jar:guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fixes": [
+      {
+        "observed_at": "2021-03-31T17:30:52Z",
+        "version": "30.0-jre",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
+    },
+    "vulnerability": {
+      "created_at": "2021-03-31T17:30:52Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 3.3,
+            "exploitability_score": 1.8,
+            "impact_score": 1.4
+          },
+          "id": "CVE-2020-8908"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "last_modified": "2021-03-31T17:30:52Z",
+      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "guava",
+      "pkg_path": "/sandbox/target/my-app-1.jar:guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fixes": [
+      {
+        "observed_at": "2020-06-16T09:10:15Z",
+        "version": "24.1.1-jre",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-06-16T09:10:15Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 5.9,
+            "exploitability_score": 2.2,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2018-10237"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "last_modified": "2020-06-16T09:10:15Z",
+      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "guava",
+      "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fixes": [
+      {
+        "observed_at": "2021-03-31T17:30:52Z",
+        "version": "30.0-jre",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
+    },
+    "vulnerability": {
+      "created_at": "2021-03-31T17:30:52Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 3.3,
+            "exploitability_score": 1.8,
+            "impact_score": 1.4
+          },
+          "id": "CVE-2020-8908"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "last_modified": "2021-03-31T17:30:52Z",
+      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "guava",
+      "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fixes": [
+      {
+        "observed_at": "2020-06-16T09:10:15Z",
+        "version": "24.1.1-jre",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-06-16T09:10:15Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 5.9,
+            "exploitability_score": 2.2,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2018-10237"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "last_modified": "2020-06-16T09:10:15Z",
+      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libcom_err",
+      "pkg_path": "pkgdb",
+      "pkg_type": "rpm",
+      "version": "1.42.9-19.el7"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:41:42Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.6,
+            "exploitability_score": 3.9,
+            "impact_score": 6.4
+          },
+          "cvss_v3": {
+            "base_score": -1.0,
+            "exploitability_score": -1.0,
+            "impact_score": -1.0
+          },
+          "id": "CVE-2015-0247"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "last_modified": "2020-03-27T23:41:42Z",
+      "link": "https://access.redhat.com/security/cve/CVE-2015-0247",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2015-0247"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libcurl",
+      "pkg_path": "pkgdb",
+      "pkg_type": "rpm",
+      "version": "7.29.0-59.el7"
+    },
+    "fixes": [
+      {
+        "observed_at": "2020-11-11T09:10:27Z",
+        "version": "0:7.29.0-59.el7_9.1",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-06-27T09:10:53Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.6,
+            "exploitability_score": 3.9,
+            "impact_score": 6.4
+          },
+          "cvss_v3": {
+            "base_score": 7.1,
+            "exploitability_score": 1.8,
+            "impact_score": 5.2
+          },
+          "id": "CVE-2020-8177"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "last_modified": "2020-08-04T09:10:43Z",
+      "link": "https://access.redhat.com/security/cve/CVE-2020-8177",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2020-8177"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libgcrypt",
+      "pkg_path": "pkgdb",
+      "pkg_type": "rpm",
+      "version": "1.5.3-14.el7"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:42:51Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 1.9,
+            "exploitability_score": 3.4,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 4.2,
+            "exploitability_score": 0.5,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2014-3591"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "last_modified": "2020-03-27T23:42:51Z",
+      "link": "https://access.redhat.com/security/cve/CVE-2014-3591",
+      "severity": "Low",
+      "vulnerability_id": "CVE-2014-3591"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libgcrypt",
+      "pkg_path": "pkgdb",
+      "pkg_type": "rpm",
+      "version": "1.5.3-14.el7"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:43:09Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": -1.0,
+            "exploitability_score": -1.0,
+            "impact_score": -1.0
+          },
+          "id": "CVE-2014-5270"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "last_modified": "2020-03-27T23:43:09Z",
+      "link": "https://access.redhat.com/security/cve/CVE-2014-5270",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2014-5270"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "libidn",
+      "pkg_path": "pkgdb",
+      "pkg_type": "rpm",
+      "version": "1.28-4.el7"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-27T23:42:41Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 7.5,
+            "exploitability_score": 10.0,
+            "impact_score": 6.4
+          },
+          "cvss_v3": {
+            "base_score": -1.0,
+            "exploitability_score": -1.0,
+            "impact_score": -1.0
+          },
+          "id": "CVE-2015-2059"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "last_modified": "2020-03-27T23:42:41Z",
+      "link": "https://access.redhat.com/security/cve/CVE-2015-2059",
+      "severity": "Low",
+      "vulnerability_id": "CVE-2015-2059"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "nss",
+      "pkg_path": "pkgdb",
+      "pkg_type": "rpm",
+      "version": "3.53.1-3.el7_9"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-05-21T09:09:26Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 1.2,
+            "exploitability_score": 1.9,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 4.4,
+            "exploitability_score": 0.8,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2020-12399"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "last_modified": "2020-05-21T09:09:26Z",
+      "link": "https://access.redhat.com/security/cve/CVE-2020-12399",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2020-12399"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "nss",
+      "pkg_path": "pkgdb",
+      "pkg_type": "rpm",
+      "version": "3.53.1-3.el7_9"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-10-20T09:10:21Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2020-25648"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "last_modified": "2020-10-20T09:10:21Z",
+      "link": "https://access.redhat.com/security/cve/CVE-2020-25648",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2020-25648"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "nss-sysinit",
+      "pkg_path": "pkgdb",
+      "pkg_type": "rpm",
+      "version": "3.53.1-3.el7_9"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-05-21T09:09:26Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 1.2,
+            "exploitability_score": 1.9,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 4.4,
+            "exploitability_score": 0.8,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2020-12399"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "last_modified": "2020-05-21T09:09:26Z",
+      "link": "https://access.redhat.com/security/cve/CVE-2020-12399",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2020-12399"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "nss-sysinit",
+      "pkg_path": "pkgdb",
+      "pkg_type": "rpm",
+      "version": "3.53.1-3.el7_9"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-10-20T09:10:21Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2020-25648"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "last_modified": "2020-10-20T09:10:21Z",
+      "link": "https://access.redhat.com/security/cve/CVE-2020-25648",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2020-25648"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "nss-tools",
+      "pkg_path": "pkgdb",
+      "pkg_type": "rpm",
+      "version": "3.53.1-3.el7_9"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-05-21T09:09:26Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 1.2,
+            "exploitability_score": 1.9,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 4.4,
+            "exploitability_score": 0.8,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2020-12399"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "last_modified": "2020-05-21T09:09:26Z",
+      "link": "https://access.redhat.com/security/cve/CVE-2020-12399",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2020-12399"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "nss-tools",
+      "pkg_path": "pkgdb",
+      "pkg_type": "rpm",
+      "version": "3.53.1-3.el7_9"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-10-20T09:10:21Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2020-25648"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "last_modified": "2020-10-20T09:10:21Z",
+      "link": "https://access.redhat.com/security/cve/CVE-2020-25648",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2020-25648"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "openldap",
+      "pkg_path": "pkgdb",
+      "pkg_type": "rpm",
+      "version": "2.4.44-22.el7"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-11-07T09:10:34Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2020-25692"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "last_modified": "2020-12-10T09:15:58Z",
+      "link": "https://access.redhat.com/security/cve/CVE-2020-25692",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2020-25692"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "openssl-libs",
+      "pkg_path": "pkgdb",
+      "pkg_type": "rpm",
+      "version": "1.0.2k-19.el7"
+    },
+    "fixes": [
+      {
+        "observed_at": "2020-12-19T09:16:55Z",
+        "version": "1:1.0.2k-21.el7_9",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-12-09T09:16:50Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 5.9,
+            "exploitability_score": 2.2,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2020-1971"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "last_modified": "2020-12-09T09:16:50Z",
+      "link": "https://access.redhat.com/security/cve/CVE-2020-1971",
+      "severity": "High",
+      "vulnerability_id": "CVE-2020-1971"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "openssl-libs",
+      "pkg_path": "pkgdb",
+      "pkg_type": "rpm",
+      "version": "1.0.2k-19.el7"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
+    },
+    "vulnerability": {
+      "created_at": "2021-03-31T17:05:26Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2021-23840"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "last_modified": "2021-03-31T17:05:26Z",
+      "link": "https://access.redhat.com/security/cve/CVE-2021-23840",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2021-23840"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "openssl-libs",
+      "pkg_path": "pkgdb",
+      "pkg_type": "rpm",
+      "version": "1.0.2k-19.el7"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
+    },
+    "vulnerability": {
+      "created_at": "2021-03-31T17:05:26Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 5.9,
+            "exploitability_score": 2.2,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2021-23841"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "last_modified": "2021-03-31T17:05:26Z",
+      "link": "https://access.redhat.com/security/cve/CVE-2021-23841",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2021-23841"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "python",
+      "pkg_path": "pkgdb",
+      "pkg_type": "rpm",
+      "version": "2.7.5-89.el7"
+    },
+    "fixes": [
+      {
+        "observed_at": "2020-11-11T09:10:28Z",
+        "version": "0:2.7.5-90.el7",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-07-14T09:11:04Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2019-20907"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "last_modified": "2020-07-15T09:10:41Z",
+      "link": "https://access.redhat.com/security/cve/CVE-2019-20907",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2019-20907"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "python-libs",
+      "pkg_path": "pkgdb",
+      "pkg_type": "rpm",
+      "version": "2.7.5-89.el7"
+    },
+    "fixes": [
+      {
+        "observed_at": "2020-11-11T09:10:28Z",
+        "version": "0:2.7.5-90.el7",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-07-14T09:11:04Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2019-20907"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "last_modified": "2020-07-15T09:10:41Z",
+      "link": "https://access.redhat.com/security/cve/CVE-2019-20907",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2019-20907"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "xmldom",
+      "pkg_path": "/root/.npm/xmldom/0.4.0/package/package.json",
+      "pkg_type": "npm",
+      "version": "0.4.0"
+    },
+    "fixes": [
+      {
+        "observed_at": "2021-03-31T17:30:47Z",
+        "version": "0.5.0",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
+    },
+    "vulnerability": {
+      "created_at": "2021-03-31T17:30:47Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 4.3,
+            "exploitability_score": 2.8,
+            "impact_score": 1.4
+          },
+          "id": "CVE-2021-21366"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "github:npm",
+      "last_modified": "2021-03-31T17:30:47Z",
+      "link": "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv",
+      "severity": "Low",
+      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "xmldom",
+      "pkg_path": "/sandbox/node_modules/xmldom/package.json",
+      "pkg_type": "npm",
+      "version": "0.4.0"
+    },
+    "fixes": [
+      {
+        "observed_at": "2021-03-31T17:30:47Z",
+        "version": "0.5.0",
+        "wont_fix": false
+      }
+    ],
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
+    },
+    "vulnerability": {
+      "created_at": "2021-03-31T17:30:47Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 4.3,
+            "exploitability_score": 2.8,
+            "impact_score": 1.4
+          },
+          "id": "CVE-2021-21366"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "github:npm",
+      "last_modified": "2021-03-31T17:30:47Z",
+      "link": "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv",
+      "severity": "Low",
+      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "cpe:a:ftpd:ftpd:0.2.1:*:*",
+      "cpe23": "cpe:2.3:a:ftpd:ftpd:0.2.1:*:-:-:-:-:-:*",
+      "name": "ftpd",
+      "pkg_path": "/usr/local/share/gems/specifications/ftpd-0.2.1.gemspec",
+      "pkg_type": "gem",
+      "version": "0.2.1"
+    },
+    "fixes": [],
+    "match": {
+      "detected_at": "2021-03-31T17:11:12Z"
+    },
+    "vulnerability": {
+      "created_at": "2021-03-31T17:11:12Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 10.0,
+            "exploitability_score": 10.0,
+            "impact_score": 10.0
+          },
+          "cvss_v3": {
+            "base_score": 9.8,
+            "exploitability_score": 3.9,
+            "impact_score": 5.9
+          },
+          "id": "CVE-2013-2512"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "nvdv2",
+      "feed_group": "nvdv2:cves",
+      "last_modified": "2021-03-31T17:11:12Z",
+      "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
+      "severity": "Critical",
+      "vulnerability_id": "CVE-2013-2512"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "cpe:a:python-aiohttp:aiohttp:3.7.3:*:*",
+      "cpe23": "cpe:2.3:a:python-aiohttp:aiohttp:3.7.3:*:-:-:-:-:-:*",
+      "name": "aiohttp",
+      "pkg_path": "/usr/local/lib64/python3.6/site-packages/aiohttp",
+      "pkg_type": "python",
+      "version": "3.7.3"
+    },
+    "fixes": [],
+    "match": {
+      "detected_at": "2021-03-31T17:29:49Z"
+    },
+    "vulnerability": {
+      "created_at": "2021-03-31T17:29:49Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 5.8,
+            "exploitability_score": 8.6,
+            "impact_score": 4.9
+          },
+          "cvss_v3": {
+            "base_score": 6.1,
+            "exploitability_score": 2.8,
+            "impact_score": 2.7
+          },
+          "id": "CVE-2021-21330"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "nvdv2",
+      "feed_group": "nvdv2:cves",
+      "last_modified": "2021-03-31T17:29:49Z",
+      "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21330",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2021-21330"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "cpe:a:guava:guava:23.0:*:*",
+      "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*",
+      "name": "guava",
+      "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fixes": [],
+    "match": {
+      "detected_at": "2021-03-31T17:25:26Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-28T02:59:42Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 5.9,
+            "exploitability_score": 2.2,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2018-10237"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "nvdv2",
+      "feed_group": "nvdv2:cves",
+      "last_modified": "2021-03-31T17:25:26Z",
+      "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2018-10237"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "cpe:a:guava:guava:23.0:*:*",
+      "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*",
+      "name": "guava",
+      "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fixes": [],
+    "match": {
+      "detected_at": "2021-03-31T17:24:25Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-12-12T09:17:33Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 3.3,
+            "exploitability_score": 1.8,
+            "impact_score": 1.4
+          },
+          "id": "CVE-2020-8908"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "nvdv2",
+      "feed_group": "nvdv2:cves",
+      "last_modified": "2021-03-31T17:24:25Z",
+      "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
+      "severity": "Low",
+      "vulnerability_id": "CVE-2020-8908"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "cpe:a:guava:guava:23.0:*:*",
+      "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*",
+      "name": "guava",
+      "pkg_path": "/sandbox/target/my-app-1.jar:guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fixes": [],
+    "match": {
+      "detected_at": "2021-03-31T17:25:26Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-03-28T02:59:42Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 5.9,
+            "exploitability_score": 2.2,
+            "impact_score": 3.6
+          },
+          "id": "CVE-2018-10237"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "nvdv2",
+      "feed_group": "nvdv2:cves",
+      "last_modified": "2021-03-31T17:25:26Z",
+      "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2018-10237"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "cpe:a:guava:guava:23.0:*:*",
+      "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*",
+      "name": "guava",
+      "pkg_path": "/sandbox/target/my-app-1.jar:guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fixes": [],
+    "match": {
+      "detected_at": "2021-03-31T17:24:25Z"
+    },
+    "vulnerability": {
+      "created_at": "2020-12-12T09:17:33Z",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9
+          },
+          "cvss_v3": {
+            "base_score": 3.3,
+            "exploitability_score": 1.8,
+            "impact_score": 1.4
+          },
+          "id": "CVE-2020-8908"
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "description": "NA",
+      "feed": "nvdv2",
+      "feed_group": "nvdv2:cves",
+      "last_modified": "2021-03-31T17:24:25Z",
+      "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
+      "severity": "Low",
+      "vulnerability_id": "CVE-2020-8908"
+    }
+  }
+]

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/schema_files/vulnerability_report.schema.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/schema_files/vulnerability_report.schema.json
@@ -2,306 +2,230 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "vulnerability_report.schema.json",
   "definitions": {
-    "nvd_data_entry": {
-      "type": "object",
+    "report_metadata": {
       "properties": {
-        "cvss_v2": {
-          "type": "object",
-          "properties": {
-            "additional_information": {
-              "type": "object",
-              "properties": {
-                "ac_insuf_info": {
-                  "type": ["null","boolean"]
-                },
-                "obtain_all_privilege": {
-                  "type": "boolean"
-                },
-                "obtain_other_privilege": {
-                  "type": "boolean"
-                },
-                "obtain_user_privilege": {
-                  "type": "boolean"
-                },
-                "user_interaction_required": {
-                  "type": "boolean"
-                }
-              }
-            },
-            "base_metrics": {
-              "type": "object",
-              "properties": {
-                "access_complexity": {
-                  "type": "string"
-                },
-                "access_vector": {
-                  "type": "string"
-                },
-                "authentication": {
-                  "type": "string"
-                },
-                "availability_impact": {
-                  "type": "string"
-                },
-                "base_score": {
-                  "type": "number"
-                },
-                "confidentiality_impact": {
-                  "type": "string"
-                },
-                "exploitability_score": {
-                  "type": "number"
-                },
-                "impact_score": {
-                  "type": "number"
-                },
-                "integrity_impact": {
-                  "type": "string"
-                }
-              }
-            },
-            "severity": {
-              "type": "string"
-            },
-            "vector_string": {
-              "type": "string"
-            },
-            "version": {
-              "type": "string"
-            }
-          }
+        "generated_at": {
+          "title": "generated_at",
+          "type": "string"
         },
-        "cvss_v3": {
-          "type": "object",
-          "properties": {
-            "base_metrics": {
-              "type": "object",
-              "properties": {
-                "attack_complexity": {
-                  "type": "string"
-                },
-                "attack_vector": {
-                  "type": "string"
-                },
-                "availability_impact": {
-                  "type": "string"
-                },
-                "base_score": {
-                  "type": "number"
-                },
-                "base_severity": {
-                  "type": "string"
-                },
-                "confidentiality_impact": {
-                  "type": "string"
-                },
-                "exploitability_score": {
-                  "type": "number"
-                },
-                "impact_score": {
-                  "type": "number"
-                },
-                "integrity_impact": {
-                  "type": "string"
-                },
-                "privileges_required": {
-                  "type": "string"
-                },
-                "scope": {
-                  "type": "string"
-                },
-                "user_interaction": {
-                  "type": "string"
-                }
-              }
-            },
-            "vector_string": {
-              "type": "string"
-            },
-            "version": {
-              "type": "string"
-            }
-          }
+        "generated_by": {
+          "type": "object"
         },
-        "id": {
+        "uuid": {
+          "title": "uuid",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "cpe_entry": {
-      "type": "object",
+    "scan_problem": {
+      "properties": {
+        "details": {
+          "title": "details",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "vulnerability_match": {
+      "properties": {
+        "artifact": {
+          "type": "object",
+          "$ref": "#/definitions/artifact"
+        },
+        "fixes": {
+          "title": "fixes",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/fixed_artifact"
+          }
+        },
+        "match": {
+          "type": "object",
+          "$ref": "#/definitions/match"
+        },
+        "vulnerability": {
+          "type": "object",
+          "$ref": "#/definitions/vulnerability"
+        }
+      },
+      "type": "object"
+    },
+    "artifact": {
       "properties": {
         "cpe": {
+          "title": "cpe",
           "type": "string"
         },
         "cpe23": {
-          "type": "string"
-        },
-        "feed_name": {
-          "type": "string"
-        },
-        "feed_namespace": {
-          "type": "string"
-        },
-        "fixed_in": {
-          "type": "array"
-        },
-        "link": {
+          "title": "cpe23",
           "type": "string"
         },
         "name": {
+          "title": "name",
           "type": "string"
         },
-        "nvd_data": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/nvd_data_entry"
-          }
-        },
         "pkg_path": {
+          "title": "pkg_path",
           "type": "string"
         },
         "pkg_type": {
+          "title": "pkg_type",
+          "type": "string"
+        },
+        "version": {
+          "title": "version",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "fixed_artifact": {
+      "properties": {
+        "observed_at": {
+          "title": "observed_at",
+          "type": ["string", "null"]
+        },
+        "version": {
+          "title": "version",
+          "type": "string"
+        },
+        "wont_fix": {
+          "title": "wont_fix",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "match": {
+      "properties": {
+        "detected_at": {
+          "title": "detected_at",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "vulnerability": {
+      "properties": {
+        "created_at": {
+          "title": "created_at",
+          "type": "string"
+        },
+        "cvss_scores_nvd": {
+          "title": "cvss_scores_nvd",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/cvss_combined"
+          }
+        },
+        "cvss_scores_vendor": {
+          "title": "cvss_scores_vendor",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/cvss_combined"
+          }
+        },
+        "description": {
+          "title": "description",
+          "type": "string"
+        },
+        "feed": {
+          "title": "feed",
+          "type": "string"
+        },
+        "feed_group": {
+          "title": "feed_group",
+          "type": "string"
+        },
+        "last_modified": {
+          "title": "last_modified",
+          "type": "string"
+        },
+        "link": {
+          "title": "link",
           "type": "string"
         },
         "severity": {
-          "type": "string"
-        },
-        "vendor_data": {
-          "type": "array"
-        },
-        "version": {
+          "title": "severity",
           "type": "string"
         },
         "vulnerability_id": {
+          "title": "vulnerability_id",
           "type": "string"
         }
-      }
+      },
+      "type": "object"
     },
-    "cpe_report": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/cpe_entry"
-      }
-    },
-    "legacy_table": {
-      "type": "object",
-      "required": ["colcount", "header", "rowcount", "rows"],
+    "cvss_combined": {
       "properties": {
-        "colcount": {
-          "$ref": "#/definitions/legacy_table_colcount"
-        },
-        "header": {
-          "$ref": "#/definitions/legacy_table_header"
-        },
-        "rowcount": {
-          "$ref": "#/definitions/legacy_table_rowcount"
-        },
-        "rows": {
-          "$ref": "#/definitions/legacy_table_rows"
-        }
-      }
-    },
-    "legacy_table_colcount": {
-      "type": "number"
-    },
-    "legacy_table_header": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "legacy_table_rowcount": {
-      "type": "number"
-    },
-    "legacy_table_rows": {
-      "type": "array",
-      "items": {
-        "type": "array",
-        "items": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string"
-          },
-          {
-            "type": "number"
-          },
-          {
-            "type": "string"
-          },
-          {
-            "type": "string"
-          },
-          {
-            "type": "string"
-          },
-          {
-            "type": "string"
-          },
-          {
-            "type": "string"
-          },
-          {
-            "type": "string"
-          },
-          {
-            "type": "string"
-          },
-          {
-            "type": "string"
-          },
-          {
-            "type": "string"
-          },
-          {
-            "type": "string"
-          },
-          {
-            "type": "string"
-          },
-          {
-            "type": "string"
-          }
-        ]
-      }
-    },
-    "legacy_report": {
-      "type": "object",
-      "required": ["multi"],
-      "properties": {
-        "multi": {
+        "cvss_v2": {
           "type": "object",
-          "required": ["result", "url_column_index", "warns"],
-          "properties": {
-            "result": {
-              "$ref": "#/definitions/legacy_table"
-            },
-            "url_column_index": {
-              "type": "number"
-            },
-            "warns": {
-              "type": "array"
-            }
-          }
+          "$ref": "#/definitions/cvss_score"
+        },
+        "cvss_v3": {
+          "type": "object",
+          "$ref": "#/definitions/cvss_score"
+        },
+        "id": {
+          "title": "id",
+          "type": "string"
         }
-      }
+      },
+      "type": "object"
+    },
+    "cvss_score": {
+      "properties": {
+        "base_score": {
+          "title": "base_score",
+          "type": "number",
+          "format": "float"
+        },
+        "exploitability_score": {
+          "title": "exploitability_score",
+          "type": "number",
+          "format": "float"
+        },
+        "impact_score": {
+          "title": "impact_score",
+          "type": "number",
+          "format": "float"
+        }
+      },
+      "type": "object"
     }
   },
   "type": "object",
-  "required": ["cpe_report", "image_id", "legacy_report", "user_id"],
   "properties": {
-    "cpe_report": {
-      "$ref": "#/definitions/cpe_report"
-    },
     "image_id": {
+      "title": "image_id",
       "type": "string"
     },
-    "legacy_report": {
-      "$ref": "#/definitions/legacy_report"
+    "metadata": {
+      "type": "object",
+      "$ref": "#/definitions/report_metadata"
     },
-    "user_id": {
+    "problems": {
+      "title": "problems",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "#/definitions/scan_problem"
+      }
+    },
+    "results": {
+      "title": "results",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "#/definitions/vulnerability_match"
+      }
+    },
+    "account_id": {
+      "title": "account_id",
       "type": "string"
     }
   }

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/test_vulnerability_scanner.py
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/test_vulnerability_scanner.py
@@ -41,6 +41,7 @@ class TestVulnerabilityScanner:
             policy_engine_api.users.get_image_vulnerabilities(image_id)
         )
         assert images_vuln_resp == http_utils.APIResponse(200)
+
         # check that response schema matches expected format
         vulnerability_schema_validator = schema_validator(
             "vulnerability_report.schema.json"
@@ -76,37 +77,42 @@ class TestVulnerabilityScanner:
             policy_engine_api.users.get_image_vulnerabilities(image_id)
         )
         assert images_vuln_resp == http_utils.APIResponse(200)
-        # get the expected results
-        expected_content = expected_content(image_digest)
-        # check that the row count in the legacy response matches
-        actual_legacy_rowcount = images_vuln_resp.body["legacy_report"]["multi"][
-            "result"
-        ]["rowcount"]
-        expected_legacy_rowcount = expected_content["legacy_report"]["multi"]["result"][
-            "rowcount"
-        ]
-        assert actual_legacy_rowcount == expected_legacy_rowcount
-        # check that the legacy rows match (these are OS pkg vulns usually)
-        expected_legacy_rows = set(
-            [
-                tuple(x)
-                for x in expected_content["legacy_report"]["multi"]["result"]["rows"]
-            ]
+        actual_report = images_vuln_resp.body
+
+        # load the expected results which is just a list of vulnerability matches
+        expected_results = expected_content(image_digest)
+        # impose some order
+        expected_results.sort(
+            key=lambda x: (
+                x["vulnerability"]["vulnerability_id"],
+                x["vulnerability"]["feed_group"],
+                x["artifact"]["name"],
+                x["artifact"]["pkg_path"],
+            )
         )
-        actual_legacy_rows = set(
-            [
-                tuple(x)
-                for x in images_vuln_resp.body["legacy_report"]["multi"]["result"][
-                    "rows"
-                ]
-            ]
+
+        # compare only the vulnerability matches
+        actual_results = actual_report["results"]
+        # impose same order
+        actual_results.sort(
+            key=lambda x: (
+                x["vulnerability"]["vulnerability_id"],
+                x["vulnerability"]["feed_group"],
+                x["artifact"]["name"],
+                x["artifact"]["pkg_path"],
+            )
         )
-        assert (
-            actual_legacy_rows == expected_legacy_rows
-        ), f"Expected vulnerabilities missing:\n{expected_legacy_rows-actual_legacy_rows}"
-        # check that the cpe reports match (non-os pkg vulns)
-        expected_cpes = set([json.dumps(x) for x in expected_content["cpe_report"]])
-        actual_cpes = set([json.dumps(x) for x in images_vuln_resp.body["cpe_report"]])
-        assert (
-            actual_cpes == expected_cpes
-        ), f"Expected vulnerabilities missing:\n{expected_cpes-actual_cpes}"
+
+        # check number of results
+        assert len(expected_results) == len(actual_results)
+
+        # check the actual content
+        for index in range(len(expected_results)):
+            # compare only the vulnerability and artifacts, skip match as it contains a dynamic date
+            assert (
+                expected_results[index]["vulnerability"]
+                == actual_results[index]["vulnerability"]
+            )
+            assert (
+                expected_results[index]["artifact"] == actual_results[index]["artifact"]
+            )


### PR DESCRIPTION
This PR is part-II of the vulnerabilities refactor effort https://github.com/anchore/anchore-engine/issues/1001
- Gut the existing image vulnerabilities format. Create a richer report-like format that captures existing vulnerability results and new data. The new report format has placeholders for recording metadata for the report generator that may not be currently used by the legacy provider
- Decouple policy evaluation logic from vulnerabilities persistence model and streamlines the consumption of vulnerability results internally within policy engine. Updates policy evaluation vulnerabilities gate to operate on an instance of the new vulnerabilities report class. Gets rid of repetitive logic for os and non-os artifacts
- Update external API consumption (parsing) of image vulnerabilities from policy-engine
- Refactor (move) the get-vulnerabilities and get-images-by-vulnerability logic out of the controller and into the legacy provider 