### PR TITLE
New provider, scanner and cache manager to interact with grype

### DIFF
--- a/anchore_engine/db/__init__.py
+++ b/anchore_engine/db/__init__.py
@@ -68,6 +68,7 @@ from .entities.policy_engine import AnalysisArtifact
 from .entities.policy_engine import ImagePackageManifestEntry
 from .entities.policy_engine import CachedPolicyEvaluation
 from .entities.policy_engine import select_nvd_classes
+from .entities.policy_engine import CachedVulnerabilities
 
 from .entities.catalog import ImageImportContent, ImageImportOperation
 

--- a/anchore_engine/services/policy_engine/api/controllers/synchronous_operations.py
+++ b/anchore_engine/services/policy_engine/api/controllers/synchronous_operations.py
@@ -65,7 +65,9 @@ from anchore_engine.services.policy_engine.engine.vulnerabilities import (
 from anchore_engine.services.policy_engine.engine.vulns.providers import (
     get_vulnerabilities_provider,
 )
+
 from anchore_engine.subsys import logger as log
+
 
 # Leave this here to ensure gates registry is fully loaded
 from anchore_engine.subsys import metrics
@@ -87,6 +89,11 @@ feed_sync_locking_enabled = True
 
 evaluation_cache_enabled = (
     os.getenv("ANCHORE_POLICY_ENGINE_EVALUATION_CACHE_ENABLED", "true").lower()
+    == "true"
+)
+
+vulnerabilities_cache_enabled = (
+    os.getenv("ANCHORE_POLICY_ENGINE_VULNERABILITIES_CACHE_ENABLED", "true").lower()
     == "true"
 )
 
@@ -850,7 +857,7 @@ def get_image_vulnerabilities(user_id, image_id, force_refresh=False, vendor_onl
             return make_response_error("Image not found", in_httpcode=404), 404
 
         provider = get_vulnerabilities_provider()
-        report = provider.get_image_vulnerabilities(
+        report = provider.get_image_vulnerabilities_json(
             image=img,
             vendor_only=vendor_only,
             db_session=db,
@@ -859,7 +866,7 @@ def get_image_vulnerabilities(user_id, image_id, force_refresh=False, vendor_onl
         )
 
         db.commit()
-        return report.to_json(), 200
+        return report, 200
 
     except HTTPException:
         db.rollback()

--- a/anchore_engine/services/policy_engine/api/models.py
+++ b/anchore_engine/services/policy_engine/api/models.py
@@ -183,8 +183,12 @@ class CvssScore(JsonSerializable):
 class CvssCombined(JsonSerializable):
     class CvssCombinedV1Schema(Schema):
         id = fields.Str()
-        cvss_v2 = fields.Nested(CvssScore.CvssScoreV1Schema)
-        cvss_v3 = fields.Nested(CvssScore.CvssScoreV1Schema)
+        cvss_v2 = fields.Nested(
+            CvssScore.CvssScoreV1Schema, allow_none=True, missing=None
+        )
+        cvss_v3 = fields.Nested(
+            CvssScore.CvssScoreV1Schema, allow_none=True, missing=None
+        )
 
         @post_load
         def make(self, data, **kwargs):
@@ -577,7 +581,7 @@ class PolicyValidationResponse(JsonSerializable):
 class Vulnerability(JsonSerializable):
     class VulnerabilityV1Schema(Schema):
         vulnerability_id = fields.Str()
-        description = fields.Str()
+        description = fields.Str(allow_none=True, missing=None)
         severity = fields.Str()
         link = fields.Str()
         feed = fields.Str()
@@ -656,7 +660,10 @@ class FixedArtifact(JsonSerializable):
     class FixedArtifactV1Schema(Schema):
         version = fields.Str()
         wont_fix = fields.Bool()
-        observed_at = RFC3339DateTime()
+        observed_at = RFC3339DateTime(
+            allow_none=True,
+            missing=None,
+        )
 
         @post_load
         def make(self, data, **kwargs):
@@ -710,9 +717,9 @@ class VulnerabilitiesReportMetadata(JsonSerializable):
         uuid = fields.Str()
         generated_by = fields.Dict()
 
-    @post_load
-    def make(self, data, **kwargs):
-        return VulnerabilitiesReportMetadata(**data)
+        @post_load
+        def make(self, data, **kwargs):
+            return VulnerabilitiesReportMetadata(**data)
 
     __schema__ = VulnerabilitiesReportMetadataV1Schema()
 

--- a/anchore_engine/services/policy_engine/engine/vulns/cache_managers.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/cache_managers.py
@@ -1,0 +1,228 @@
+import dataclasses
+import datetime
+import enum
+import hashlib
+import json
+
+from anchore_engine import utils
+from anchore_engine.clients.services import internal_client_for, catalog
+from anchore_engine.db import (
+    Image,
+    get_thread_scoped_session as get_session,
+    CachedVulnerabilities,
+)
+from anchore_engine.services.policy_engine.engine.feeds.db import get_all_feeds
+from anchore_engine.subsys import logger as log, metrics
+from anchore_engine.apis.context import ApiRequestContextProxy
+from dataclasses import dataclass
+from typing import Dict, List
+from anchore_engine.services.policy_engine.api.models import ImageVulnerabilitiesReport
+
+# Disabled by default, can be set in config file. Seconds for connection to cache
+DEFAULT_CACHE_CONN_TIMEOUT = -1
+# Disabled by default, can be set in config file. Seconds for first byte timeout
+DEFAULT_CACHE_READ_TIMEOUT = -1
+
+
+class CacheStatus(enum.Enum):
+    valid = "valid"
+    stale = "stale"
+    invalid = "invalid"
+    missing = "missing"
+
+
+@dataclass
+class CacheRecord:
+    result: Dict
+    status: CacheStatus
+
+
+@dataclass(eq=True)
+class GrypeMetadata:
+    version: str
+    db_version: str
+    db_checksum: str
+
+    @classmethod
+    def from_dict(cls, data):
+        return GrypeMetadata(
+            data.get("version"), data.get("db_version"), data.get("db_checksum")
+        )
+
+    def to_dict(self):
+        return self.__dict__
+
+
+class GrypeCacheManager:
+
+    __cache_bucket__ = "policy-engine-vulns-cache"
+
+    def __init__(
+        self,
+        image_object: Image,
+    ):
+        self.image = image_object
+
+        self._catalog_client = internal_client_for(
+            catalog.CatalogClient, userId=self.image.user_id
+        )
+        self._default_catalog_conn_timeout = (
+            ApiRequestContextProxy.get_service().configuration.get(
+                "catalog_client_conn_timeout",
+                DEFAULT_CACHE_CONN_TIMEOUT,
+            )
+        )
+        self._default_catalog_read_timeout = (
+            ApiRequestContextProxy.get_service().configuration.get(
+                "catalog_client_read_timeout",
+                DEFAULT_CACHE_READ_TIMEOUT,
+            )
+        )
+
+    def fetch(self):
+        """
+        Tries to lookup the cache entry for the image and it's validity if one is available
+
+        """
+        session = get_session()
+        db_record = (
+            session.query(CachedVulnerabilities)
+            .filter_by(account_id=self.image.user_id, image_digest=self.image.digest)
+            .one_or_none()
+        )
+
+        if db_record:
+            if db_record.is_archive_ref():
+                bucket, key = db_record.archive_tuple()
+                try:
+                    with self._catalog_client.timeout_context(
+                        self._default_catalog_conn_timeout,
+                        self._default_catalog_read_timeout,
+                    ) as timeout_client:
+                        data = timeout_client.get_document(bucket, key)
+                except:
+                    log.exception(
+                        "Unexpected error getting document {}/{} from archive".format(
+                            bucket, key
+                        )
+                    )
+                    data = None
+            else:
+                data = db_record.result.get("result")
+
+            return CacheRecord(result=data, status=self._get_cache_status(db_record))
+        else:
+            return None
+
+    def _lookup(self):
+        """
+        Returns all entries for the image
+
+        :return:
+        """
+
+        session = get_session()
+        return (
+            session.query(CachedVulnerabilities)
+            .filter_by(account_id=self.image.user_id, image_digest=self.image.digest)
+            .order_by(CachedVulnerabilities.last_modified.desc())
+            .all()
+        )
+
+    def _get_cache_status(self, cache_record: CachedVulnerabilities):
+        """
+        Decodes the cache key into elements capturing state of the system at the time of report generation and compares
+        them to the current current state of the system.
+        """
+        # TODO polish this
+        report_metadata = GrypeMetadata.from_dict(cache_record.cache_key.get("grype"))
+
+        current_metadata = self._get_current_grype_metadata()
+
+        if report_metadata == current_metadata:
+            return CacheStatus.valid
+        else:
+            return CacheStatus.stale
+
+    @staticmethod
+    def _get_current_grype_metadata():
+        """
+        TODO Invoke the grype_wrapper and generate a grype metadata object, work with dspalmer
+        """
+
+        return GrypeMetadata("foo", "bar", "sha256:blah")
+
+    def _delete_entry(self, entry):
+        session = get_session()
+
+        if entry.is_archive_ref():
+            bucket, key = entry.archive_tuple()
+            retry = 3
+            while retry > 0:
+                try:
+                    with self._catalog_client.timeout_context(
+                        self._default_catalog_conn_timeout,
+                        self._default_catalog_read_timeout,
+                    ) as timeout_client:
+                        resp = timeout_client.delete_document(bucket, key)
+                    break
+                except:
+                    log.exception(
+                        "Could not delete vulnerabilities report from cache, will retry. Bucket={}, Key={}".format(
+                            bucket, key
+                        )
+                    )
+                    retry -= 1
+            else:
+                log.error(
+                    "Could not flush vulnerabilities report from cache after all retries, may be orphaned. Will remove from index."
+                )
+
+        session.delete(entry)
+        session.flush()
+
+    def flush(self):
+        """
+        Flush all cache entries for the given image
+        :return:
+        """
+        session = get_session()
+        for entry in session.query(CachedVulnerabilities).filter_by(
+            account_id=self.image.user_id, image_digest=self.image.digest
+        ):
+            try:
+                self._delete_entry(entry)
+            except:
+                log.exception("Could not delete vuln cache entry: {}".format(entry))
+
+        return True
+
+    def _get_cache_key_from_report(self, report: ImageVulnerabilitiesReport):
+        """
+        Parse the report for grype metadata and generate GrypeMetadata object
+        """
+        # TODO implement this
+        return GrypeMetadata("foo", "bar", "sha256:blah").to_dict()
+
+    def save(self, report: ImageVulnerabilitiesReport):
+        """
+        Persist the new result for this cache entry
+        """
+
+        # delete all previous cached results
+        self.flush()
+
+        # save the new results as a new entry
+        cache_entry = CachedVulnerabilities()
+        cache_entry.account_id = self.image.user_id
+        cache_entry.image_digest = self.image.digest
+        cache_entry.cache_key = {"grype": self._get_cache_key_from_report(report)}
+
+        # save it to db instead of object storage to be able to excute other queries over the data
+        cache_entry.add_raw_result(report.to_json())
+        # report.add_remote_result(self.__cache_bucket__, key, result_digest)
+        cache_entry.last_modified = datetime.datetime.utcnow()
+
+        # Update index
+        session = get_session()
+        return session.merge(cache_entry)

--- a/anchore_engine/services/policy_engine/engine/vulns/mappers.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/mappers.py
@@ -1,0 +1,336 @@
+import datetime
+import json
+from collections import defaultdict
+from anchore_engine.db import Image, ImageCpe, ImagePackage
+from typing import List, Dict
+import uuid
+from anchore_engine.subsys import logger as log
+from anchore_engine.services.policy_engine.api.models import (
+    VulnerabilityMatch,
+    Artifact,
+    Vulnerability,
+    CvssCombined,
+    CvssScore,
+    Match,
+    FixedArtifact,
+)
+
+
+class EngineGrypeMapper:
+    __engine_distro__ = None
+    __grype_os__ = None
+    __grype_like_os__ = None
+    __engine_distro_pkg_type__ = None
+    __grype_os_pkg_type__ = None
+
+    __engine_grype_pkg_type_map__ = {
+        "dpkg": "deb",
+        "rpm": "rpm",
+        "APKG": "apk",
+        "java": "java-archive",
+        "gem": "gem",
+        "npm": "npm",
+        "python": "python",
+    }
+
+    __grype_engine_pkg_type_map__ = {
+        "deb": "dpkg",
+        "rpm": "rpm",
+        "apk": "APKG",
+        "gem": "gem",
+        "npm": "npm",
+        "python": "python",
+        "java-archive": "java",
+        "jenkins-plugin": "java",
+    }
+
+    def _get_grype_os_pkg_metadata(self, pkg: ImagePackage):
+        raise NotImplementedError()
+
+    def transform_image_to_sbom(
+        self,
+        image: Image,
+        image_packages: List[ImagePackage],
+        image_cpes: List[ImageCpe],
+    ):
+        """
+        Generate grype sbom from ImagePackage artifacts
+        """
+        # initialize sbom
+        sbom = dict()
+        sbom["distro"] = {
+            "name": self.__grype_os__,
+            "version": image.distro_version,
+            "idLike": self.__grype_like_os__,
+        }
+        sbom["source"] = {
+            "type": "image",
+            "target": {
+                "scope": "Squashed",
+                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            },
+        }
+
+        # map the package (location) to its list of cpes
+        location_cpes_dict = defaultdict(list)
+        for image_cpe in image_cpes:
+            location_cpes_dict[image_cpe.pkg_path].append(image_cpe)
+
+        artifacts = []
+        sbom["artifacts"] = artifacts
+
+        for pkg in image_packages:
+            grype_pkg_type = self.__engine_grype_pkg_type_map__.get(pkg.pkg_type)
+            if not grype_pkg_type:
+                log.warn(
+                    "Skipping {} since {} package type is not supported by grype".format(
+                        pkg.name, pkg.pkg_type
+                    )
+                )
+                continue
+
+            if pkg.pkg_type == self.__engine_distro_pkg_type__:
+                art = {
+                    "id": str(uuid.uuid4()),
+                    "name": pkg.name,
+                    "version": pkg.fullversion,
+                    "type": grype_pkg_type,
+                    "language": "",
+                    "locations": [
+                        {
+                            "path": pkg.pkg_path,
+                        }
+                    ],
+                    # TODO check with alex on how to format source package and version. Override this method in individual mappers
+                    "metadata": self._get_grype_os_pkg_metadata(pkg),
+                }
+
+            else:
+                grype_cpes = [
+                    # cpe : 2.3 : part : vendor : product : version : update : edition : language : sw_edition : target_sw : target_hw : other
+                    "cpe:2.3:{}".format(
+                        ":".join(
+                            [
+                                item.cpetype,  # part
+                                item.vendor,  # vendor
+                                item.name,  # product
+                                item.version,  # version
+                                item.update,  # update
+                                item.meta,  # edition
+                                "-",  # language
+                                "-",  # sw_edition
+                                "-",  # target_sw
+                                "-",  # target_hw
+                                "-",  # other
+                            ]
+                        )
+                    )
+                    for item in location_cpes_dict.get(pkg.pkg_path)
+                ]
+
+                art = {
+                    "id": str(uuid.uuid4()),
+                    "name": pkg.name,
+                    "version": pkg.fullversion,
+                    "type": grype_pkg_type,
+                    "language": pkg.pkg_type,
+                    "locations": [
+                        {
+                            "path": pkg.pkg_path,
+                        }
+                    ],
+                    "cpes": grype_cpes,
+                }
+
+            artifacts.append(art)
+
+        # log.debug("image sbom: {}".format(json.dumps(sbom, indent=2)))
+
+        return sbom
+
+    def transform_matches_to_vulnerabilities(self, grype_response):
+        """
+        Transform grype results into engine vulnerabilities
+        """
+        # TODO super duper hacky to fit into existing model
+
+        now = datetime.datetime.utcnow()
+        matches = grype_response.get("matches", [])
+
+        unique_results = dict()
+        dup_count = 0
+
+        for item in matches:
+            vuln = item.get("vulnerability")
+            artifact = item.get("artifact")
+
+            vuln_id = vuln.get("id")
+            fix_ver = vuln.get("fixedInVersion")
+            if fix_ver:
+                fix_observed_at = now
+            else:
+                fix_ver = "None"  # barf
+                fix_observed_at = None
+
+            engine_nvd_scores = []
+            engine_vendor_scores = []  # TODO replace with grype data when available
+
+            grype_cvss_v2 = vuln.get("cvssV2")
+            grype_cvss_v3 = vuln.get("cvssV3")
+
+            if grype_cvss_v2 or grype_cvss_v3:
+                engine_score = CvssCombined(id=vuln_id)
+                engine_nvd_scores.append(engine_score)
+
+                if grype_cvss_v2:
+                    engine_score.cvss_v2 = CvssScore(
+                        base_score=grype_cvss_v2.get("baseScore"),
+                        exploitability_score=grype_cvss_v2.get("exploitabilityScore"),
+                        impact_score=grype_cvss_v2.get("impactScore"),
+                    )
+
+                if grype_cvss_v3:
+                    engine_score.cvss_v3 = CvssScore(
+                        base_score=grype_cvss_v3.get("baseScore"),
+                        exploitability_score=grype_cvss_v3.get("exploitabilityScore"),
+                        impact_score=grype_cvss_v3.get("impactScore"),
+                    )
+
+            pkg_type = self.__grype_engine_pkg_type_map__.get(artifact.get("type"))
+            pkg_name = artifact.get("name")
+            pkg_version = artifact.get("version")
+            pkg_path = (
+                artifact.get("locations")[0].get("path")
+                if artifact.get("locations")
+                else "NA"
+            )
+
+            search_key = item.get("matchDetails").get("searchKey")
+
+            # TODO replace with grype data when available
+            is_legacy = False
+            if "distro" in search_key:
+                is_legacy = True
+                feed = "vulnerabilities"
+                distro = search_key.get("distro")
+
+                distro_type = distro.get("type")
+                if distro_type.lower() == "redhat":
+                    feed_group = "rhel:"
+                else:
+                    feed_group = distro_type.lower() + ":"
+
+                distro_version = distro.get("version")
+                group = distro_version.split(".", 1)[0]
+                feed_group += group
+            elif vuln_id.startswith("GHSA"):
+                is_legacy = True
+                feed = "vulnerabilities"
+                feed_group = "github:{}".format(pkg_type)
+            elif vuln_id.startswith("VULNDB"):  # this is absolutely WRONG!!!
+                feed = "vulndb"
+                feed_group = "vulndb:vulnerabilities"
+            else:
+                feed = "nvdv2"
+                feed_group = "nvdv2:cves"
+
+            vuln_tuple = (vuln_id, feed_group, pkg_name, pkg_version, pkg_path)
+            if vuln_tuple in unique_results:
+                log.warn(
+                    "{} in {} namespace detected for {} {}, skipping".format(
+                        vuln_id, vuln_id, pkg_name, pkg_version
+                    )
+                )
+                dup_count += 1
+                continue
+            else:
+                unique_results[vuln_tuple] = VulnerabilityMatch(
+                    vulnerability=Vulnerability(
+                        vulnerability_id=vuln_id,
+                        description="NA",
+                        severity=vuln.get("severity"),
+                        link=vuln.get("links")[0] if vuln.get("links") else None,
+                        feed=feed,
+                        feed_group=feed_group,
+                        cvss_scores_nvd=engine_nvd_scores,
+                        cvss_scores_vendor=[],
+                        created_at=now,  # TODO replace with grype data when available
+                        last_modified=now,  # TODO replace with grype data when available
+                    ),
+                    artifact=Artifact(
+                        name=pkg_name,
+                        version=pkg_version,
+                        pkg_type=pkg_type,
+                        pkg_path=pkg_path,
+                        cpe="None",  # TODO replace with grype data when available
+                        cpe23="None",  # TODO replace with grype data when available
+                    ),
+                    fixes=[
+                        FixedArtifact(
+                            version=fix_ver,
+                            wont_fix=False,  # TODO replace with grype data when available
+                            observed_at=fix_observed_at,
+                        )
+                    ],
+                    match=Match(detected_at=now),
+                )
+
+        log.info(
+            "Number of unique vulnerabilities: {}, duplicates: {}".format(
+                len(unique_results), dup_count
+            )
+        )
+
+        return list(unique_results.values())
+
+
+class RHELMapper(EngineGrypeMapper):
+    __engine_distro__ = "rhel"
+    __engine_distro_pkg_type__ = "rpm"
+    __grype_os__ = "redhat"
+    __grype_os_pkg_type__ = "rpm"
+    __grype_like_os__ = "fedora"
+
+    def _get_grype_os_pkg_metadata(self, pkg: ImagePackage):
+        return {"sourceRpm": pkg.src_pkg} if pkg.src_pkg != "N/A" else dict()
+
+
+class CentOSMapper(RHELMapper):
+    __engine_distro__ = "centos"
+    __grype_os__ = "centos"
+
+
+class DebianMapper(EngineGrypeMapper):
+    __engine_distro__ = "debian"
+    __engine_distro_pkg_type__ = "dpkg"
+    __grype_os__ = "debian"
+    __grype_os_pkg_type__ = "deb"
+    __grype_like_os__ = "debian"
+
+    def _get_grype_os_pkg_metadata(self, pkg: ImagePackage):
+        return dict()
+
+
+class UbuntuMapper(DebianMapper):
+    __engine_distro__ = "ubuntu"
+    __grype_os__ = "ubuntu"
+
+
+class AlpineMapper(EngineGrypeMapper):
+    __engine_distro__ = "alpine"
+    __engine_distro_pkg_type__ = "APKG"
+    __grype_os__ = "alpine"
+    __grype_os_pkg_type__ = "apkg"
+    __grype_like_os__ = "alpine"
+
+    def _get_grype_os_pkg_metadata(self, pkg: ImagePackage):
+        return None
+
+
+DISTRO_MAPPERS = {
+    RHELMapper.__engine_distro__: RHELMapper,
+    CentOSMapper.__engine_distro__: CentOSMapper,
+    DebianMapper.__engine_distro__: DebianMapper,
+    UbuntuMapper.__engine_distro__: UbuntuMapper,
+    AlpineMapper.__engine_distro__: AlpineMapper,
+}

--- a/anchore_engine/services/policy_engine/engine/vulns/scanners.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/scanners.py
@@ -2,10 +2,15 @@
 Scanners are responsible for finding vulnerabilities in an image.
 A scanner may use persistence context or an external tool to match image content with vulnerability data and return those matches
 """
-from anchore_engine.db.entities.policy_engine import ImageCpe
+from anchore_engine.db.entities.policy_engine import ImageCpe, Image
 from anchore_engine.subsys import logger
 from anchore_engine.utils import timer
 from anchore_engine.services.policy_engine.engine import vulnerabilities
+from anchore_engine.utils import run_check
+
+from anchore_engine.clients import grype_wrapper
+import json
+import shlex
 
 
 class LegacyScanner:
@@ -127,8 +132,23 @@ class LegacyScanner:
         return final_results
 
 
-default_type = LegacyScanner
+class GrypeVulnScanner:
+    """
+    The scanner sits a level above the grype_wrapper. It orchestrates dependencies such as grype-db for the wrapper
+    and interacts with the wrapper for all things vulnerabilities
 
+    Scanners are typically used by a provider to serve data They are engine-agnostic components and therefore require
+    higher order functions for transforming input/output to/from underlying tool format
+    """
 
-def get_scanner():
-    return default_type()
+    def get_vulnerabilities(self, image_id, sbom):
+
+        # TODO check if grype db needs to be updated
+
+        # TODO saving sbom for debugging purposes, remove this
+        file_path = "/tmp/e2g_sbom_{}".format(image_id)
+        logger.info("Writing grype sbom to {}".format(image_id))
+        with open(file_path, "w") as fp:
+            json.dump(sbom, fp, indent=2)
+
+        return grype_wrapper.get_vulnerabilities(file_path)


### PR DESCRIPTION
This PR builds on the refactor in https://github.com/anchore/anchore-engine/pull/1000  and introduces a new vulnerabilities provider for grype-integration. It also introduces
- a scanner that can generate a grype sbom from engine artifacts and transform grype output into engine report format
- a cache manager to load and retrieve vulnerability reports for images