### PR TITLE
Link back to Syft and Grype from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,21 @@ For the most up-to-date information on Anchore Engine, Anchore CLI, and other An
 
 The Anchore Engine is an open-source project that provides a centralized service for inspection, analysis, and certification of container images. The Anchore Engine is provided as a Docker container image that can be run standalone or within an orchestration platform such as Kubernetes, Docker Swarm, Rancher, Amazon ECS, and other container orchestration platforms.
 
+In addition, we also have several modular container tools that can be run standalone or integrated into automated workflows such as CI/CD pipelines.
+
+- **[Syft](https://github.com/anchore/syft)**: a CLI tool and library for **generating a Software Bill of Materials** (SBOM) from container images and filesystems
+
+- **[Grype](https://github.com/anchore/grype)**: a **vulnerability scanner** for container images and filesystems
+
 The Anchore Engine can be accessed directly through a RESTful API or via the Anchore [CLI](https://github.com/anchore/anchore-cli).
 
 With a deployment of Anchore Engine running in your environment, container images are downloaded and analyzed from Docker V2 compatible container registries and then evaluated against user-customizable policies to perform security, compliance, and best practices enforcement checks.
 
 Anchore Engine can be used in several ways:
 
-* Standalone or interactively.
-* As a service integrated with your CI/CD to bring security/compliance/best-practice enforcement to your build pipeline
-* As a component integrated into existing container monitoring and control frameworks via integration with its RESTful API.
+- Standalone or interactively.
+- As a service integrated with your CI/CD to bring security/compliance/best-practice enforcement to your build pipeline
+- As a component integrated into existing container monitoring and control frameworks via integration with its RESTful API.
 
 Anchore Engine is also the OSS foundation for [Anchore Enterprise](https://anchore.com/enterprise), which adds a graphical UI (providing policy management, user management, a summary dashboard, security and policy evaluation reports, and many other graphical client controls), and other back-end features and modules.
 
@@ -28,14 +34,12 @@ Anchore Engine is also the OSS foundation for [Anchore Enterprise](https://ancho
 - Red Hat Universal Base Image (UBI)
 - Ubuntu
 
-
 **Supported Packages**
 
 - GEM
 - Java Archive (jar, war, ear)
 - NPM
 - Python (PIP)
-
 
 ## Installation
 
@@ -62,7 +66,7 @@ Once the Engine is up and running, you can begin to interact with the system usi
 
 The [Anchore CLI](https://github.com/anchore/anchore-cli) is an easy way to control and interact with the Anchore Engine.
 
-The Anchore CLI can be installed using the Python pip command, or by running the CLI from the [Anchore Engine CLI](https://hub.docker.com/r/anchore/engine-cli) container image.  See the [Anchore CLI](https://github.com/anchore/anchore-cli) project on Github for code and more installation options and usage.
+The Anchore CLI can be installed using the Python pip command, or by running the CLI from the [Anchore Engine CLI](https://hub.docker.com/r/anchore/engine-cli) container image. See the [Anchore CLI](https://github.com/anchore/anchore-cli) project on Github for code and more installation options and usage.
 
 ## CLI Quick Start (TLDR)
 
@@ -119,11 +123,10 @@ View other available policies from the [Anchore Policy Hub](https://www.github.c
 
 ## API
 
-For the external API definition (the user-facing service), see [External API Swagger Spec](https://github.com/anchore/anchore-engine/blob/master/anchore_engine/services/apiext/swagger/swagger.yaml).  If you have Anchore Engine running, you can also review the Swagger by directing your browser at http://<your-anchore-engine-api-host>:8228/v1/ui/ (NOTE: the trailing slash is required for the embedded swagger UI browser to be viewed properly).
+For the external API definition (the user-facing service), see [External API Swagger Spec](https://github.com/anchore/anchore-engine/blob/master/anchore_engine/services/apiext/swagger/swagger.yaml). If you have Anchore Engine running, you can also review the Swagger by directing your browser at http://<your-anchore-engine-api-host>:8228/v1/ui/ (NOTE: the trailing slash is required for the embedded swagger UI browser to be viewed properly).
 
 Each service implements its own API, and all APIs are defined in Swagger/OpenAPI spec. You can find each in the _anchore_engine/services/\<servicename\>/api/swagger_ directory.
 
 ## More Information
 
 For further details on the use of the Anchore CLI with the Anchore Engine, please refer to the [Anchore Engine Documentation](https://engine.anchore.io/)
-


### PR DESCRIPTION
Signed-off-by: Dan Luhring <dan.luhring@anchore.com>

**What this PR does / why we need it**: Adds links to Syft and Grype in the README (per [Kim W's suggestions](https://anchore.slack.com/archives/C01S5KSJ68G/p1620502250024300?thread_ts=1620318390.016400&cid=C01S5KSJ68G)) to help alert users to these tools' existence.


**Which issue this PR fixes**: n/a

**Special notes**: You'll see other changes to `README.md` than just the block about Syft and Grype... Prettier did that (i.e. autoformatting) for "consistency", but I can turn that off and remove those changes if needed.


