### PR TITLE
Vulnerabilities refactor continued

### DIFF
--- a/anchore_engine/services/policy_engine/api/controllers/synchronous_operations.py
+++ b/anchore_engine/services/policy_engine/api/controllers/synchronous_operations.py
@@ -850,7 +850,7 @@ def get_image_vulnerabilities(user_id, image_id, force_refresh=False, vendor_onl
             return make_response_error("Image not found", in_httpcode=404), 404
 
         provider = get_vulnerabilities_provider()
-        report = provider.get_image_vulnerabilities(
+        report = provider.get_image_vulnerabilities_json(
             image=img,
             vendor_only=vendor_only,
             db_session=db,
@@ -859,7 +859,7 @@ def get_image_vulnerabilities(user_id, image_id, force_refresh=False, vendor_onl
         )
 
         db.commit()
-        return report.to_json(), 200
+        return report, 200
 
     except HTTPException:
         db.rollback()

--- a/anchore_engine/services/policy_engine/api/models.py
+++ b/anchore_engine/services/policy_engine/api/models.py
@@ -164,9 +164,9 @@ class Image(JsonSerializable):
 
 class CvssScore(JsonSerializable):
     class CvssScoreV1Schema(Schema):
-        base_score = fields.Float()
-        exploitability_score = fields.Float()
-        impact_score = fields.Float()
+        base_score = fields.Float(default=-1.0)
+        exploitability_score = fields.Float(default=-1.0)
+        impact_score = fields.Float(default=-1.0)
 
         @post_load
         def make(self, data, **kwargs):
@@ -183,8 +183,12 @@ class CvssScore(JsonSerializable):
 class CvssCombined(JsonSerializable):
     class CvssCombinedV1Schema(Schema):
         id = fields.Str()
-        cvss_v2 = fields.Nested(CvssScore.CvssScoreV1Schema)
-        cvss_v3 = fields.Nested(CvssScore.CvssScoreV1Schema)
+        cvss_v2 = fields.Nested(
+            CvssScore.CvssScoreV1Schema, allow_none=True, missing=None
+        )
+        cvss_v3 = fields.Nested(
+            CvssScore.CvssScoreV1Schema, allow_none=True, missing=None
+        )
 
         @post_load
         def make(self, data, **kwargs):
@@ -577,7 +581,7 @@ class PolicyValidationResponse(JsonSerializable):
 class Vulnerability(JsonSerializable):
     class VulnerabilityV1Schema(Schema):
         vulnerability_id = fields.Str()
-        description = fields.Str()
+        description = fields.Str(allow_none=True, missing=None)
         severity = fields.Str()
         link = fields.Str()
         feed = fields.Str()
@@ -656,7 +660,10 @@ class FixedArtifact(JsonSerializable):
     class FixedArtifactV1Schema(Schema):
         version = fields.Str()
         wont_fix = fields.Bool()
-        observed_at = RFC3339DateTime()
+        observed_at = RFC3339DateTime(
+            allow_none=True,
+            missing=None,
+        )
 
         @post_load
         def make(self, data, **kwargs):
@@ -710,9 +717,9 @@ class VulnerabilitiesReportMetadata(JsonSerializable):
         uuid = fields.Str()
         generated_by = fields.Dict()
 
-    @post_load
-    def make(self, data, **kwargs):
-        return VulnerabilitiesReportMetadata(**data)
+        @post_load
+        def make(self, data, **kwargs):
+            return VulnerabilitiesReportMetadata(**data)
 
     __schema__ = VulnerabilitiesReportMetadataV1Schema()
 

--- a/anchore_engine/services/policy_engine/engine/vulns/dedup.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/dedup.py
@@ -1,0 +1,174 @@
+from dataclasses import dataclass, field
+from typing import List
+
+from anchore_engine.services.policy_engine.api.models import VulnerabilityMatch
+from anchore_engine.subsys import logger
+
+
+class FeedGroupRank:
+    """
+    Feed groups ranked by an integer value. Rank defaults to pre-defined value if the group is not not explicitly ranked
+
+    This is a very simplistic ranking strategy that handles three categories - nvdv2, github and all others.
+    The strategy translates to any-group is ranked > github >  nvdv2
+    """
+
+    __ranks__ = {"nvdv2": 1, "github": 10}
+    __default__ = 100
+
+    def get(self, feed_group: str):
+        group_prefix = feed_group.split(":", 1)[0]
+
+        return self.__ranks__.get(group_prefix, self.__default__)
+
+
+# eq=True and frozen=True required for making the instance hashable
+@dataclass(eq=True, frozen=True)
+class VulnerabilityIdentity:
+    vuln_id: str
+    pkg_name: str
+    pkg_version: str
+    pkg_type: str
+    pkg_path: str
+
+    @classmethod
+    def from_match(cls, vuln_match: VulnerabilityMatch):
+        """
+        Returns a list of identities from nvd references if available or a single identity with the vulnerability ID otherwise
+        """
+        if vuln_match.vulnerability.cvss_scores_nvd:
+            # generate identity tuples using the nvd refs
+            results = [
+                VulnerabilityIdentity(
+                    vuln_id=nvd_score.id,
+                    pkg_name=vuln_match.artifact.name,
+                    pkg_version=vuln_match.artifact.version,
+                    pkg_type=vuln_match.artifact.pkg_type,
+                    pkg_path=vuln_match.artifact.pkg_path,
+                )
+                for nvd_score in vuln_match.vulnerability.cvss_scores_nvd
+            ]
+        else:
+            # no nvd refs, generate the identity tuple using the vulnerability id
+            results = [
+                VulnerabilityIdentity(
+                    vuln_id=vuln_match.vulnerability.vulnerability_id,
+                    pkg_name=vuln_match.artifact.name,
+                    pkg_version=vuln_match.artifact.version,
+                    pkg_type=vuln_match.artifact.pkg_type,
+                    pkg_path=vuln_match.artifact.pkg_path,
+                )
+            ]
+
+        return results
+
+
+@dataclass(eq=True, frozen=True)
+class RankedVulnerabilityMatch:
+    vuln_id: str
+    vuln_namespace: str
+    pkg_name: str
+    pkg_version: str
+    pkg_type: str
+    pkg_path: str
+    rank: int
+
+    # leave the match out from hashing and equals comparison
+    match_obj: VulnerabilityMatch = field(compare=False, repr=False)
+
+    @classmethod
+    def from_match(cls, match: VulnerabilityMatch, rank_strategy: FeedGroupRank):
+        """
+        Computes and returns the rank for the vulnerability match
+        """
+        return RankedVulnerabilityMatch(
+            vuln_id=match.vulnerability.vulnerability_id,
+            vuln_namespace=match.vulnerability.feed_group,
+            pkg_name=match.artifact.name,
+            pkg_version=match.artifact.version,
+            pkg_type=match.artifact.pkg_type,
+            pkg_path=match.artifact.pkg_path,
+            rank=rank_strategy.get(match.vulnerability.feed_group),
+            match_obj=match,
+        )
+
+
+class ImageVulnerabilitiesDeduplicator:
+    """
+    A mechanism for finding and removing duplicates from a list of vulnerability matches for an image
+
+    Employs a configurable strategy to compute the rank of a given record and picks the record with the highest rank when there are duplicates
+    """
+
+    __rank_strategy__ = FeedGroupRank
+
+    def __init__(self, strategy):
+        if not strategy:
+            self.rank_strategy = self.__rank_strategy__()
+        else:
+            self.rank_strategy = strategy
+
+    def execute(
+        self, vulnerability_matches: List[VulnerabilityMatch]
+    ) -> List[VulnerabilityMatch]:
+        """
+        Finds duplicate records (for a specific definition of duplicate) in the provided list of vulnerability matches.
+        Uses a defined strategy to rank such records and selects the highest ranking record to de-duplicate.
+
+        Matches are considered duplicate when they affect the same package - identified by its name and location, and
+        seemingly refer to the same vulnerability. The latter is explained by the following examples
+
+        1. Match A contains vulnerability x with an nvd reference to vulnerability y in namespace z.
+        Match B contains vulnerability y in the nvdv2 namespace. Matches A and B are duplicates.
+        This is observed in feeds that don't use CVE IDs such as GHSA, ELSA, ALAS etc
+        2. Match A contains vulnerability x in namespace y. Match B contains vulnerability x in namespace z.
+        Matches A and B are duplicates.
+        """
+
+        if not vulnerability_matches:
+            return []
+
+        # de-dup is centered around nvd references. so pivot the data set first and create an identity
+        # using nvd identifiers when available. map this nvd identity to the vulnerability
+        # VulnerabilityIdentity -> RankedVulnerabilityMatch
+        identity_map = dict()
+
+        for vuln_match in vulnerability_matches:
+            # get the rank tuple first
+            ranked_match_object = RankedVulnerabilityMatch.from_match(
+                vuln_match, self.rank_strategy
+            )
+
+            # get identity objects
+            identity_objects = VulnerabilityIdentity.from_match(vuln_match)
+
+            # now map each identity to the vulnerability. Rank and select as you go
+            for identity_object in identity_objects:
+                existing = identity_map.get(identity_object)
+                if existing:
+                    # identity is already mapped to a match, get the mapped vulnerability and compare ranks
+                    if ranked_match_object.rank > existing.rank:
+                        # current vulnerability rank is higher than existing, re-map
+                        identity_map[identity_object] = ranked_match_object
+                else:
+                    # identity encountered first time, create a mapping to the vulnerability
+                    identity_map[identity_object] = ranked_match_object
+
+        # At this point identity_map contains unique nvd identities, each mapped to a vulnerability.
+        # Mapped values may be repeated because of the initial data pivot.
+        # So pivot back and gather unique vulnerabilities
+
+        # set operation over a list of RankedVulnerabilityMatch removes duplicates by comparing everything but match object
+        final_matches = [item.match_obj for item in set(identity_map.values())]
+
+        logger.debug(
+            "Deduplicated %d matches to %d",
+            len(vulnerability_matches),
+            len(final_matches),
+        )
+
+        return final_matches
+
+
+def get_image_vulnerabilities_deduper():
+    return ImageVulnerabilitiesDeduplicator(FeedGroupRank())

--- a/anchore_engine/services/policy_engine/engine/vulns/scanners.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/scanners.py
@@ -125,10 +125,3 @@ class LegacyScanner:
         final_results = list(dedup_hash.values())
 
         return final_results
-
-
-default_type = LegacyScanner
-
-
-def get_scanner():
-    return default_type()

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:406413437f26223183d133ccc7186f24c827729e1b21adc7330dd43fcdc030b3.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:406413437f26223183d133ccc7186f24c827729e1b21adc7330dd43fcdc030b3.json
@@ -1,12 +1,41 @@
 [
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "aiohttp",
-      "pkg_path": "/usr/local/lib/python3.7/dist-packages/aiohttp",
       "pkg_type": "python",
-      "version": "3.7.3"
+      "pkg_path": "/usr/local/lib/python3.7/dist-packages/aiohttp",
+      "version": "3.7.3",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "GHSA-v6wp-4m6f-gcjg",
+      "created_at": "2021-03-31T17:30:49Z",
+      "feed_group": "github:python",
+      "link": "https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 2.8,
+            "impact_score": 2.7,
+            "base_score": 6.1
+          },
+          "id": "CVE-2021-21330",
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 4.9,
+            "base_score": 5.8
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Low",
+      "last_modified": "2021-03-31T17:30:49Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
     },
     "fixes": [
       {
@@ -14,45 +43,45 @@
         "version": "3.7.4",
         "wont_fix": false
       }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2021-03-31T17:30:49Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 5.8,
-            "exploitability_score": 8.6,
-            "impact_score": 4.9
-          },
-          "cvss_v3": {
-            "base_score": 6.1,
-            "exploitability_score": 2.8,
-            "impact_score": 2.7
-          },
-          "id": "CVE-2021-21330"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "github:python",
-      "last_modified": "2021-03-31T17:30:49Z",
-      "link": "https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
-      "severity": "Low",
-      "vulnerability_id": "GHSA-v6wp-4m6f-gcjg"
-    }
+    ]
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "apt",
-      "pkg_path": "pkgdb",
       "pkg_type": "dpkg",
-      "version": "1.8.2.2"
+      "pkg_path": "pkgdb",
+      "version": "1.8.2.2",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2011-3374",
+      "created_at": "2020-03-27T23:00:32Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2011-3374",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 2.2,
+            "impact_score": 1.4,
+            "base_score": 3.7
+          },
+          "id": "CVE-2011-3374",
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "base_score": 4.3
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T23:00:32Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
     },
     "fixes": [
       {
@@ -60,137 +89,137 @@
         "version": "None",
         "wont_fix": false
       }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T23:00:32Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 3.7,
-            "exploitability_score": 2.2,
-            "impact_score": 1.4
-          },
-          "id": "CVE-2011-3374"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T23:00:32Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2011-3374",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2011-3374"
-    }
+    ]
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "bash",
-      "pkg_path": "pkgdb",
       "pkg_type": "dpkg",
-      "version": "5.0-4"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
+      "pkg_path": "pkgdb",
+      "version": "5.0-4",
+      "cpe23": "None",
+      "cpe": "None"
     },
     "vulnerability": {
+      "vulnerability_id": "CVE-2019-18276",
       "created_at": "2020-03-27T22:58:42Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 7.2,
-            "exploitability_score": 3.9,
-            "impact_score": 10
-          },
-          "cvss_v3": {
-            "base_score": 7.8,
-            "exploitability_score": 1.8,
-            "impact_score": 5.9
-          },
-          "id": "CVE-2019-18276"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "last_modified": "2020-07-05T09:12:19Z",
       "link": "https://security-tracker.debian.org/tracker/CVE-2019-18276",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 1.8,
+            "impact_score": 5.9,
+            "base_score": 7.8
+          },
+          "id": "CVE-2019-18276",
+          "cvss_v2": {
+            "exploitability_score": 3.9,
+            "impact_score": 10.0,
+            "base_score": 7.2
+          }
+        }
+      ],
+      "description": "NA",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-18276"
-    }
+      "last_modified": "2020-07-05T09:12:19Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "coreutils",
-      "pkg_path": "pkgdb",
       "pkg_type": "dpkg",
-      "version": "8.30-3"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
+      "pkg_path": "pkgdb",
+      "version": "8.30-3",
+      "cpe23": "None",
+      "cpe": "None"
     },
     "vulnerability": {
+      "vulnerability_id": "CVE-2017-18018",
       "created_at": "2020-03-27T22:59:57Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 1.9,
-            "exploitability_score": 3.4,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 4.7,
-            "exploitability_score": 1,
-            "impact_score": 3.6
-          },
-          "id": "CVE-2017-18018"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:59:57Z",
       "link": "https://security-tracker.debian.org/tracker/CVE-2017-18018",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 1.0,
+            "impact_score": 3.6,
+            "base_score": 4.7
+          },
+          "id": "CVE-2017-18018",
+          "cvss_v2": {
+            "exploitability_score": 3.4,
+            "impact_score": 2.9,
+            "base_score": 1.9
+          }
+        }
+      ],
+      "description": "NA",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-18018"
-    }
+      "last_modified": "2020-03-27T22:59:57Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "guava",
-      "pkg_path": "/sandbox/target/my-app-1.jar:guava",
       "pkg_type": "java",
-      "version": "23.0"
+      "pkg_path": "/sandbox/target/my-app-1.jar:guava",
+      "version": "23.0",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "GHSA-5mg8-w23w-74h3",
+      "created_at": "2021-03-31T17:30:52Z",
+      "feed_group": "github:java",
+      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 1.8,
+            "impact_score": 1.4,
+            "base_score": 3.3
+          },
+          "id": "CVE-2020-8908",
+          "cvss_v2": {
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "base_score": 2.1
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Medium",
+      "last_modified": "2021-03-31T17:30:52Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
     },
     "fixes": [
       {
@@ -198,45 +227,45 @@
         "version": "30.0-jre",
         "wont_fix": false
       }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2021-03-31T17:30:52Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 3.3,
-            "exploitability_score": 1.8,
-            "impact_score": 1.4
-          },
-          "id": "CVE-2020-8908"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "github:java",
-      "last_modified": "2021-03-31T17:30:52Z",
-      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
-      "severity": "Medium",
-      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
-    }
+    ]
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "guava",
-      "pkg_path": "/sandbox/target/my-app-1.jar:guava",
       "pkg_type": "java",
-      "version": "23.0"
+      "pkg_path": "/sandbox/target/my-app-1.jar:guava",
+      "version": "23.0",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j",
+      "created_at": "2020-06-16T09:10:15Z",
+      "feed_group": "github:java",
+      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 2.2,
+            "impact_score": 3.6,
+            "base_score": 5.9
+          },
+          "id": "CVE-2018-10237",
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "base_score": 4.3
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Medium",
+      "last_modified": "2020-06-16T09:10:15Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
     },
     "fixes": [
       {
@@ -244,45 +273,45 @@
         "version": "24.1.1-jre",
         "wont_fix": false
       }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-06-16T09:10:15Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6
-          },
-          "id": "CVE-2018-10237"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "github:java",
-      "last_modified": "2020-06-16T09:10:15Z",
-      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
-      "severity": "Medium",
-      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
-    }
+    ]
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "guava",
-      "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
       "pkg_type": "java",
-      "version": "23.0"
+      "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
+      "version": "23.0",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "GHSA-5mg8-w23w-74h3",
+      "created_at": "2021-03-31T17:30:52Z",
+      "feed_group": "github:java",
+      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 1.8,
+            "impact_score": 1.4,
+            "base_score": 3.3
+          },
+          "id": "CVE-2020-8908",
+          "cvss_v2": {
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "base_score": 2.1
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Medium",
+      "last_modified": "2021-03-31T17:30:52Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
     },
     "fixes": [
       {
@@ -290,45 +319,45 @@
         "version": "30.0-jre",
         "wont_fix": false
       }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2021-03-31T17:30:52Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 3.3,
-            "exploitability_score": 1.8,
-            "impact_score": 1.4
-          },
-          "id": "CVE-2020-8908"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "github:java",
-      "last_modified": "2021-03-31T17:30:52Z",
-      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
-      "severity": "Medium",
-      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
-    }
+    ]
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "guava",
-      "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
       "pkg_type": "java",
-      "version": "23.0"
+      "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
+      "version": "23.0",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j",
+      "created_at": "2020-06-16T09:10:15Z",
+      "feed_group": "github:java",
+      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 2.2,
+            "impact_score": 3.6,
+            "base_score": 5.9
+          },
+          "id": "CVE-2018-10237",
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "base_score": 4.3
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Medium",
+      "last_modified": "2020-06-16T09:10:15Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
     },
     "fixes": [
       {
@@ -336,551 +365,91 @@
         "version": "24.1.1-jre",
         "wont_fix": false
       }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-06-16T09:10:15Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6
-          },
-          "id": "CVE-2018-10237"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "github:java",
-      "last_modified": "2020-06-16T09:10:15Z",
-      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
-      "severity": "Medium",
-      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
-    }
+    ]
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "libapt-pkg5.0",
-      "pkg_path": "pkgdb",
       "pkg_type": "dpkg",
-      "version": "1.8.2.2"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
+      "pkg_path": "pkgdb",
+      "version": "1.8.2.2",
+      "cpe23": "None",
+      "cpe": "None"
     },
     "vulnerability": {
+      "vulnerability_id": "CVE-2011-3374",
       "created_at": "2020-03-27T23:00:32Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 3.7,
-            "exploitability_score": 2.2,
-            "impact_score": 1.4
-          },
-          "id": "CVE-2011-3374"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "last_modified": "2020-03-27T23:00:32Z",
       "link": "https://security-tracker.debian.org/tracker/CVE-2011-3374",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2011-3374"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libc6",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T23:00:05Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 5,
-            "exploitability_score": 10,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": -1,
-            "exploitability_score": -1,
-            "impact_score": -1
-          },
-          "id": "CVE-2010-4051"
-        }
-      ],
       "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T23:00:05Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4051",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2010-4051"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libc6",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T23:00:05Z",
       "cvss_scores_nvd": [
         {
-          "cvss_v2": {
-            "base_score": 5,
-            "exploitability_score": 10,
-            "impact_score": 2.9
-          },
           "cvss_v3": {
-            "base_score": -1,
-            "exploitability_score": -1,
-            "impact_score": -1
+            "exploitability_score": 2.2,
+            "impact_score": 1.4,
+            "base_score": 3.7
           },
-          "id": "CVE-2010-4052"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T23:00:05Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4052",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2010-4052"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libc6",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T23:00:06Z",
-      "cvss_scores_nvd": [
-        {
+          "id": "CVE-2011-3374",
           "cvss_v2": {
-            "base_score": 4,
-            "exploitability_score": 8,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": -1,
-            "exploitability_score": -1,
-            "impact_score": -1
-          },
-          "id": "CVE-2010-4756"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T23:00:06Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4756",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2010-4756"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libc6",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T23:00:05Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 5,
-            "exploitability_score": 10,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6
-          },
-          "id": "CVE-2018-20796"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T23:00:05Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2018-20796",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2018-20796"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libc6",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T23:00:06Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 7.5,
-            "exploitability_score": 10,
-            "impact_score": 6.4
-          },
-          "cvss_v3": {
-            "base_score": 9.8,
-            "exploitability_score": 3.9,
-            "impact_score": 5.9
-          },
-          "id": "CVE-2019-1010022"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T23:00:06Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010022",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-1010022"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libc6",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T23:00:05Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 6.8,
             "exploitability_score": 8.6,
-            "impact_score": 6.4
-          },
-          "cvss_v3": {
-            "base_score": 8.8,
-            "exploitability_score": 2.8,
-            "impact_score": 5.9
-          },
-          "id": "CVE-2019-1010023"
+            "impact_score": 2.9,
+            "base_score": 4.3
+          }
         }
       ],
-      "cvss_scores_vendor": [],
       "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T23:00:05Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010023",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-1010023"
-    }
+      "last_modified": "2020-03-27T23:00:32Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "libc6",
-      "pkg_path": "pkgdb",
       "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T23:00:05Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 5,
-            "exploitability_score": 10,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 5.3,
-            "exploitability_score": 3.9,
-            "impact_score": 1.4
-          },
-          "id": "CVE-2019-1010024"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T23:00:05Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010024",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-1010024"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
+      "pkg_path": "pkgdb",
+      "version": "2.28-10",
       "cpe23": "None",
-      "name": "libc6",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
+      "cpe": "None"
     },
     "vulnerability": {
+      "vulnerability_id": "CVE-2010-4051",
       "created_at": "2020-03-27T23:00:05Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 5,
-            "exploitability_score": 10,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 5.3,
-            "exploitability_score": 3.9,
-            "impact_score": 1.4
-          },
-          "id": "CVE-2019-1010025"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "last_modified": "2020-03-27T23:00:05Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010025",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-1010025"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libc6",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T23:00:05Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 5,
-            "exploitability_score": 10,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6
-          },
-          "id": "CVE-2019-9192"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T23:00:05Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9192",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-9192"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libc-bin",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T23:00:05Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 5,
-            "exploitability_score": 10,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": -1,
-            "exploitability_score": -1,
-            "impact_score": -1
-          },
-          "id": "CVE-2010-4051"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T23:00:05Z",
       "link": "https://security-tracker.debian.org/tracker/CVE-2010-4051",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          },
+          "id": "CVE-2010-4051",
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          }
+        }
+      ],
+      "description": "NA",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2010-4051"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libc-bin",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
+      "last_modified": "2020-03-27T23:00:05Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
     },
     "fixes": [
       {
@@ -888,45 +457,45 @@
         "version": "None",
         "wont_fix": false
       }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libc6",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "cpe": "None"
     },
     "vulnerability": {
+      "vulnerability_id": "CVE-2010-4052",
       "created_at": "2020-03-27T23:00:05Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 5,
-            "exploitability_score": 10,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": -1,
-            "exploitability_score": -1,
-            "impact_score": -1
-          },
-          "id": "CVE-2010-4052"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "last_modified": "2020-03-27T23:00:05Z",
       "link": "https://security-tracker.debian.org/tracker/CVE-2010-4052",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          },
+          "id": "CVE-2010-4052",
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          }
+        }
+      ],
+      "description": "NA",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2010-4052"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libc-bin",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
+      "last_modified": "2020-03-27T23:00:05Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
     },
     "fixes": [
       {
@@ -934,137 +503,137 @@
         "version": "None",
         "wont_fix": false
       }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libc6",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "cpe": "None"
     },
     "vulnerability": {
+      "vulnerability_id": "CVE-2010-4756",
       "created_at": "2020-03-27T23:00:06Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 4,
-            "exploitability_score": 8,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": -1,
-            "exploitability_score": -1,
-            "impact_score": -1
-          },
-          "id": "CVE-2010-4756"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "last_modified": "2020-03-27T23:00:06Z",
       "link": "https://security-tracker.debian.org/tracker/CVE-2010-4756",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2010-4756"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libc-bin",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T23:00:05Z",
+      "cvss_scores_vendor": [],
       "cvss_scores_nvd": [
         {
-          "cvss_v2": {
-            "base_score": 5,
-            "exploitability_score": 10,
-            "impact_score": 2.9
-          },
           "cvss_v3": {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
           },
-          "id": "CVE-2018-20796"
+          "id": "CVE-2010-4756",
+          "cvss_v2": {
+            "exploitability_score": 8.0,
+            "impact_score": 2.9,
+            "base_score": 4.0
+          }
         }
       ],
-      "cvss_scores_vendor": [],
       "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T23:00:05Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2018-20796",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2018-20796"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libc-bin",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T23:00:06Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 7.5,
-            "exploitability_score": 10,
-            "impact_score": 6.4
-          },
-          "cvss_v3": {
-            "base_score": 9.8,
-            "exploitability_score": 3.9,
-            "impact_score": 5.9
-          },
-          "id": "CVE-2019-1010022"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
       "last_modified": "2020-03-27T23:00:06Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libc6",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2018-20796",
+      "created_at": "2020-03-27T23:00:05Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2018-20796",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "base_score": 7.5
+          },
+          "id": "CVE-2018-20796",
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T23:00:05Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libc6",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2019-1010022",
+      "created_at": "2020-03-27T23:00:06Z",
+      "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010022",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 5.9,
+            "base_score": 9.8
+          },
+          "id": "CVE-2019-1010022",
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 6.4,
+            "base_score": 7.5
+          }
+        }
+      ],
+      "description": "NA",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-1010022"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libc-bin",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
+      "last_modified": "2020-03-27T23:00:06Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
     },
     "fixes": [
       {
@@ -1072,45 +641,45 @@
         "version": "None",
         "wont_fix": false
       }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libc6",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "cpe": "None"
     },
     "vulnerability": {
+      "vulnerability_id": "CVE-2019-1010023",
       "created_at": "2020-03-27T23:00:05Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 6.8,
-            "exploitability_score": 8.6,
-            "impact_score": 6.4
-          },
-          "cvss_v3": {
-            "base_score": 8.8,
-            "exploitability_score": 2.8,
-            "impact_score": 5.9
-          },
-          "id": "CVE-2019-1010023"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "last_modified": "2020-03-27T23:00:05Z",
       "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010023",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 2.8,
+            "impact_score": 5.9,
+            "base_score": 8.8
+          },
+          "id": "CVE-2019-1010023",
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 6.4,
+            "base_score": 6.8
+          }
+        }
+      ],
+      "description": "NA",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-1010023"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libc-bin",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
+      "last_modified": "2020-03-27T23:00:05Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
     },
     "fixes": [
       {
@@ -1118,45 +687,45 @@
         "version": "None",
         "wont_fix": false
       }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libc6",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "cpe": "None"
     },
     "vulnerability": {
+      "vulnerability_id": "CVE-2019-1010024",
       "created_at": "2020-03-27T23:00:05Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 5,
-            "exploitability_score": 10,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 5.3,
-            "exploitability_score": 3.9,
-            "impact_score": 1.4
-          },
-          "id": "CVE-2019-1010024"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "last_modified": "2020-03-27T23:00:05Z",
       "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010024",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 1.4,
+            "base_score": 5.3
+          },
+          "id": "CVE-2019-1010024",
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          }
+        }
+      ],
+      "description": "NA",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-1010024"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libc-bin",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
+      "last_modified": "2020-03-27T23:00:05Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
     },
     "fixes": [
       {
@@ -1164,45 +733,45 @@
         "version": "None",
         "wont_fix": false
       }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libc6",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "cpe": "None"
     },
     "vulnerability": {
+      "vulnerability_id": "CVE-2019-1010025",
       "created_at": "2020-03-27T23:00:05Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 5,
-            "exploitability_score": 10,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 5.3,
-            "exploitability_score": 3.9,
-            "impact_score": 1.4
-          },
-          "id": "CVE-2019-1010025"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "last_modified": "2020-03-27T23:00:05Z",
       "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010025",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 1.4,
+            "base_score": 5.3
+          },
+          "id": "CVE-2019-1010025",
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          }
+        }
+      ],
+      "description": "NA",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-1010025"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libc-bin",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
+      "last_modified": "2020-03-27T23:00:05Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
     },
     "fixes": [
       {
@@ -1210,91 +779,505 @@
         "version": "None",
         "wont_fix": false
       }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T23:00:05Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 5,
-            "exploitability_score": 10,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6
-          },
-          "id": "CVE-2019-9192"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T23:00:05Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9192",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-9192"
-    }
+    ]
   },
   {
     "artifact": {
-      "cpe": "None",
+      "name": "libc6",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.28-10",
       "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2019-9192",
+      "created_at": "2020-03-27T23:00:05Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9192",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "base_score": 7.5
+          },
+          "id": "CVE-2019-9192",
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T23:00:05Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libc-bin",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2010-4051",
+      "created_at": "2020-03-27T23:00:05Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4051",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          },
+          "id": "CVE-2010-4051",
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T23:00:05Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libc-bin",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2010-4052",
+      "created_at": "2020-03-27T23:00:05Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4052",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          },
+          "id": "CVE-2010-4052",
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T23:00:05Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libc-bin",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2010-4756",
+      "created_at": "2020-03-27T23:00:06Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4756",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          },
+          "id": "CVE-2010-4756",
+          "cvss_v2": {
+            "exploitability_score": 8.0,
+            "impact_score": 2.9,
+            "base_score": 4.0
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T23:00:06Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libc-bin",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2018-20796",
+      "created_at": "2020-03-27T23:00:05Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2018-20796",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "base_score": 7.5
+          },
+          "id": "CVE-2018-20796",
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T23:00:05Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libc-bin",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2019-1010022",
+      "created_at": "2020-03-27T23:00:06Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010022",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 5.9,
+            "base_score": 9.8
+          },
+          "id": "CVE-2019-1010022",
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 6.4,
+            "base_score": 7.5
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T23:00:06Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libc-bin",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2019-1010023",
+      "created_at": "2020-03-27T23:00:05Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010023",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 2.8,
+            "impact_score": 5.9,
+            "base_score": 8.8
+          },
+          "id": "CVE-2019-1010023",
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 6.4,
+            "base_score": 6.8
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T23:00:05Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libc-bin",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2019-1010024",
+      "created_at": "2020-03-27T23:00:05Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010024",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 1.4,
+            "base_score": 5.3
+          },
+          "id": "CVE-2019-1010024",
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T23:00:05Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libc-bin",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2019-1010025",
+      "created_at": "2020-03-27T23:00:05Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010025",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 1.4,
+            "base_score": 5.3
+          },
+          "id": "CVE-2019-1010025",
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T23:00:05Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libc-bin",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2019-9192",
+      "created_at": "2020-03-27T23:00:05Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9192",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "base_score": 7.5
+          },
+          "id": "CVE-2019-9192",
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T23:00:05Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
       "name": "libgcrypt20",
-      "pkg_path": "pkgdb",
       "pkg_type": "dpkg",
-      "version": "1.8.4-5"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
+      "pkg_path": "pkgdb",
+      "version": "1.8.4-5",
+      "cpe23": "None",
+      "cpe": "None"
     },
     "vulnerability": {
+      "vulnerability_id": "CVE-2018-6829",
       "created_at": "2020-03-27T22:56:27Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 5,
-            "exploitability_score": 10,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6
-          },
-          "id": "CVE-2018-6829"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:56:27Z",
       "link": "https://security-tracker.debian.org/tracker/CVE-2018-6829",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "base_score": 7.5
+          },
+          "id": "CVE-2018-6829",
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          }
+        }
+      ],
+      "description": "NA",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2018-6829"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libglib2.0-0",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.58.3-2+deb10u2"
+      "last_modified": "2020-03-27T22:56:27Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
     },
     "fixes": [
       {
@@ -1302,2897 +1285,2943 @@
         "version": "None",
         "wont_fix": false
       }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libglib2.0-0",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.58.3-2+deb10u2",
+      "cpe23": "None",
+      "cpe": "None"
     },
     "vulnerability": {
+      "vulnerability_id": "CVE-2012-0039",
       "created_at": "2020-03-27T23:01:10Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 5,
-            "exploitability_score": 10,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": -1,
-            "exploitability_score": -1,
-            "impact_score": -1
-          },
-          "id": "CVE-2012-0039"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "last_modified": "2020-03-27T23:01:10Z",
       "link": "https://security-tracker.debian.org/tracker/CVE-2012-0039",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          },
+          "id": "CVE-2012-0039",
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          }
+        }
+      ],
+      "description": "NA",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2012-0039"
-    }
+      "last_modified": "2020-03-27T23:01:10Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "libglib2.0-0",
-      "pkg_path": "pkgdb",
       "pkg_type": "dpkg",
-      "version": "2.58.3-2+deb10u2"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
+      "pkg_path": "pkgdb",
+      "version": "2.58.3-2+deb10u2",
+      "cpe23": "None",
+      "cpe": "None"
     },
     "vulnerability": {
+      "vulnerability_id": "CVE-2020-35457",
       "created_at": "2020-12-16T09:16:22Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 4.6,
-            "exploitability_score": 3.9,
-            "impact_score": 6.4
-          },
-          "cvss_v3": {
-            "base_score": 7.8,
-            "exploitability_score": 1.8,
-            "impact_score": 5.9
-          },
-          "id": "CVE-2020-35457"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "last_modified": "2020-12-18T09:16:42Z",
       "link": "https://security-tracker.debian.org/tracker/CVE-2020-35457",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 1.8,
+            "impact_score": 5.9,
+            "base_score": 7.8
+          },
+          "id": "CVE-2020-35457",
+          "cvss_v2": {
+            "exploitability_score": 3.9,
+            "impact_score": 6.4,
+            "base_score": 4.6
+          }
+        }
+      ],
+      "description": "NA",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-35457"
-    }
+      "last_modified": "2020-12-18T09:16:42Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "libgnutls30",
-      "pkg_path": "pkgdb",
       "pkg_type": "dpkg",
-      "version": "3.6.7-4+deb10u6"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
+      "pkg_path": "pkgdb",
+      "version": "3.6.7-4+deb10u6",
+      "cpe23": "None",
+      "cpe": "None"
     },
     "vulnerability": {
+      "vulnerability_id": "CVE-2011-3389",
       "created_at": "2020-03-27T22:56:32Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": -1,
-            "exploitability_score": -1,
-            "impact_score": -1
-          },
-          "id": "CVE-2011-3389"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:56:32Z",
       "link": "https://security-tracker.debian.org/tracker/CVE-2011-3389",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          },
+          "id": "CVE-2011-3389",
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "base_score": 4.3
+          }
+        }
+      ],
+      "description": "NA",
       "severity": "Medium",
-      "vulnerability_id": "CVE-2011-3389"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libgssapi-krb5-2",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "1.17-3+deb10u1"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:58:44Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": -1,
-            "exploitability_score": -1,
-            "impact_score": -1
-          },
-          "id": "CVE-2004-0971"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:58:44Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2004-0971",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2004-0971"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libgssapi-krb5-2",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "1.17-3+deb10u1"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:58:44Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 5,
-            "exploitability_score": 10,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6
-          },
-          "id": "CVE-2018-5709"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:58:44Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2018-5709",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2018-5709"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libldap-common",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.4.47+dfsg-3+deb10u6"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:58:11Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 5,
-            "exploitability_score": 10,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": -1,
-            "exploitability_score": -1,
-            "impact_score": -1
-          },
-          "id": "CVE-2015-3276"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:58:11Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2015-3276",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2015-3276"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libldap-common",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.4.47+dfsg-3+deb10u6"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:58:11Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 1.9,
-            "exploitability_score": 3.4,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 4.7,
-            "exploitability_score": 1,
-            "impact_score": 3.6
-          },
-          "id": "CVE-2017-14159"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:58:11Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-14159",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-14159"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libldap-common",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.4.47+dfsg-3+deb10u6"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:58:11Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 5,
-            "exploitability_score": 10,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6
-          },
-          "id": "CVE-2017-17740"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:58:11Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17740",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-17740"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libldap-common",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.4.47+dfsg-3+deb10u6"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-07-17T09:11:26Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 4,
-            "exploitability_score": 4.9,
-            "impact_score": 4.9
-          },
-          "cvss_v3": {
-            "base_score": 4.2,
-            "exploitability_score": 1.6,
-            "impact_score": 2.5
-          },
-          "id": "CVE-2020-15719"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-08-05T09:09:49Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-15719",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-15719"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libnss-systemd",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:58:49Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 3.3,
-            "exploitability_score": 3.4,
-            "impact_score": 4.9
-          },
-          "cvss_v3": {
-            "base_score": -1,
-            "exploitability_score": -1,
-            "impact_score": -1
-          },
-          "id": "CVE-2013-4392"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:58:49Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2013-4392"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libnss-systemd",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:58:48Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 2.4,
-            "exploitability_score": 0.9,
-            "impact_score": 1.4
-          },
-          "id": "CVE-2019-20386"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-05-12T09:09:42Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-20386"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libnss-systemd",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-06-04T09:09:58Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 6.2,
-            "exploitability_score": 1.9,
-            "impact_score": 10
-          },
-          "cvss_v3": {
-            "base_score": 6.7,
-            "exploitability_score": 0.8,
-            "impact_score": 5.9
-          },
-          "id": "CVE-2020-13776"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-06-21T09:10:36Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-13776"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libpcre3",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2:8.39-12"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T23:00:01Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 7.8,
-            "exploitability_score": 10,
-            "impact_score": 6.9
-          },
-          "cvss_v3": {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6
-          },
-          "id": "CVE-2017-11164"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T23:00:01Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-11164",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-11164"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libpcre3",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2:8.39-12"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T23:00:01Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 5.5,
-            "exploitability_score": 1.8,
-            "impact_score": 3.6
-          },
-          "id": "CVE-2017-16231"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T23:00:01Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-16231",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-16231"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libpcre3",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2:8.39-12"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T23:00:01Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 6.8,
-            "exploitability_score": 8.6,
-            "impact_score": 6.4
-          },
-          "cvss_v3": {
-            "base_score": 7.8,
-            "exploitability_score": 1.8,
-            "impact_score": 5.9
-          },
-          "id": "CVE-2017-7245"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T23:00:01Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-7245",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-7245"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libpcre3",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2:8.39-12"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T23:00:01Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 6.8,
-            "exploitability_score": 8.6,
-            "impact_score": 6.4
-          },
-          "cvss_v3": {
-            "base_score": 7.8,
-            "exploitability_score": 1.8,
-            "impact_score": 5.9
-          },
-          "id": "CVE-2017-7246"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T23:00:01Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-7246",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-7246"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libpcre3",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2:8.39-12"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-06-16T09:09:31Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6
-          },
-          "id": "CVE-2019-20838"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-07-02T09:10:45Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20838",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-20838"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libpython2.7-minimal",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.7.16-2+deb10u1"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T23:00:31Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": -1,
-            "exploitability_score": -1,
-            "impact_score": -1
-          },
-          "id": "CVE-2013-7040"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T23:00:31Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-7040",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2013-7040"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libpython2.7-minimal",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.7.16-2+deb10u1"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:58:28Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 6.8,
-            "exploitability_score": 8.6,
-            "impact_score": 6.4
-          },
-          "cvss_v3": {
-            "base_score": 8.8,
-            "exploitability_score": 2.8,
-            "impact_score": 5.9
-          },
-          "id": "CVE-2017-17522"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:58:28Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-17522"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libpython2.7-minimal",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.7.16-2+deb10u1"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:58:28Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 6.1,
-            "exploitability_score": 2.8,
-            "impact_score": 2.7
-          },
-          "id": "CVE-2019-18348"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:58:28Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-18348"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libpython2.7-minimal",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.7.16-2+deb10u1"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:58:28Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 5,
-            "exploitability_score": 10,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6
-          },
-          "id": "CVE-2019-9674"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:58:28Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-9674"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libpython2.7-minimal",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.7.16-2+deb10u1"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2021-03-31T17:06:44Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 4,
-            "exploitability_score": 4.9,
-            "impact_score": 4.9
-          },
-          "cvss_v3": {
-            "base_score": 5.9,
-            "exploitability_score": 1.6,
-            "impact_score": 4.2
-          },
-          "id": "CVE-2021-23336"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2021-03-31T17:06:44Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2021-23336",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2021-23336"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libpython3.7-minimal",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "3.7.3-2+deb10u3"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:58:28Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 6.8,
-            "exploitability_score": 8.6,
-            "impact_score": 6.4
-          },
-          "cvss_v3": {
-            "base_score": 8.8,
-            "exploitability_score": 2.8,
-            "impact_score": 5.9
-          },
-          "id": "CVE-2017-17522"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:58:28Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-17522"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libpython3.7-minimal",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "3.7.3-2+deb10u3"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:58:28Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 6.1,
-            "exploitability_score": 2.8,
-            "impact_score": 2.7
-          },
-          "id": "CVE-2019-18348"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:58:28Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-18348"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libpython3.7-minimal",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "3.7.3-2+deb10u3"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:58:28Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 5,
-            "exploitability_score": 10,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6
-          },
-          "id": "CVE-2019-9674"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:58:28Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-9674"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libpython3.7-minimal",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "3.7.3-2+deb10u3"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-10-23T09:09:58Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 7.5,
-            "exploitability_score": 10,
-            "impact_score": 6.4
-          },
-          "cvss_v3": {
-            "base_score": 9.8,
-            "exploitability_score": 3.9,
-            "impact_score": 5.9
-          },
-          "id": "CVE-2020-27619"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-11-04T09:11:01Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-27619",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-27619"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libseccomp2",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.3.3-4"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:56:22Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 7.5,
-            "exploitability_score": 10,
-            "impact_score": 6.4
-          },
-          "cvss_v3": {
-            "base_score": 9.8,
-            "exploitability_score": 3.9,
-            "impact_score": 5.9
-          },
-          "id": "CVE-2019-9893"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:56:22Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9893",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-9893"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libssl1.1",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "1.1.1d-0+deb10u6"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:56:38Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 5.8,
-            "exploitability_score": 8.6,
-            "impact_score": 4.9
-          },
-          "cvss_v3": {
-            "base_score": -1,
-            "exploitability_score": -1,
-            "impact_score": -1
-          },
-          "id": "CVE-2007-6755"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:56:38Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2007-6755",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2007-6755"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libssl1.1",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "1.1.1d-0+deb10u6"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:56:38Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 4,
-            "exploitability_score": 1.9,
-            "impact_score": 6.9
-          },
-          "cvss_v3": {
-            "base_score": -1,
-            "exploitability_score": -1,
-            "impact_score": -1
-          },
-          "id": "CVE-2010-0928"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:56:38Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2010-0928",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2010-0928"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libsystemd0",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:58:49Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 3.3,
-            "exploitability_score": 3.4,
-            "impact_score": 4.9
-          },
-          "cvss_v3": {
-            "base_score": -1,
-            "exploitability_score": -1,
-            "impact_score": -1
-          },
-          "id": "CVE-2013-4392"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:58:49Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2013-4392"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libsystemd0",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:58:48Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 2.4,
-            "exploitability_score": 0.9,
-            "impact_score": 1.4
-          },
-          "id": "CVE-2019-20386"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-05-12T09:09:42Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-20386"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libsystemd0",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-06-04T09:09:58Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 6.2,
-            "exploitability_score": 1.9,
-            "impact_score": 10
-          },
-          "cvss_v3": {
-            "base_score": 6.7,
-            "exploitability_score": 0.8,
-            "impact_score": 5.9
-          },
-          "id": "CVE-2020-13776"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-06-21T09:10:36Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-13776"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libtasn1-6",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "4.13-3"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:57:42Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 7.1,
-            "exploitability_score": 8.6,
-            "impact_score": 6.9
-          },
-          "cvss_v3": {
-            "base_score": 5.5,
-            "exploitability_score": 1.8,
-            "impact_score": 3.6
-          },
-          "id": "CVE-2018-1000654"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:57:42Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2018-1000654",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2018-1000654"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libudev1",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u6"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:58:49Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 3.3,
-            "exploitability_score": 3.4,
-            "impact_score": 4.9
-          },
-          "cvss_v3": {
-            "base_score": -1,
-            "exploitability_score": -1,
-            "impact_score": -1
-          },
-          "id": "CVE-2013-4392"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:58:49Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2013-4392"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libudev1",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u6"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:58:48Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 2.4,
-            "exploitability_score": 0.9,
-            "impact_score": 1.4
-          },
-          "id": "CVE-2019-20386"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-05-12T09:09:42Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-20386"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "libudev1",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u6"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-06-04T09:09:58Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 6.2,
-            "exploitability_score": 1.9,
-            "impact_score": 10
-          },
-          "cvss_v3": {
-            "base_score": 6.7,
-            "exploitability_score": 0.8,
-            "impact_score": 5.9
-          },
-          "id": "CVE-2020-13776"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-06-21T09:10:36Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-13776"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "login",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "1:4.5-1.1"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:57:11Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 4.9,
-            "exploitability_score": 3.9,
-            "impact_score": 6.9
-          },
-          "cvss_v3": {
-            "base_score": -1,
-            "exploitability_score": -1,
-            "impact_score": -1
-          },
-          "id": "CVE-2007-5686"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:57:11Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2007-5686",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2007-5686"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "login",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "1:4.5-1.1"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:57:12Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 3.3,
-            "exploitability_score": 3.4,
-            "impact_score": 4.9
-          },
-          "cvss_v3": {
-            "base_score": 4.7,
-            "exploitability_score": 1,
-            "impact_score": 3.6
-          },
-          "id": "CVE-2013-4235"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:57:12Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4235",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2013-4235"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "login",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "1:4.5-1.1"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:57:12Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 6.9,
-            "exploitability_score": 3.4,
-            "impact_score": 10
-          },
-          "cvss_v3": {
-            "base_score": 7.8,
-            "exploitability_score": 1.8,
-            "impact_score": 5.9
-          },
-          "id": "CVE-2019-19882"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:57:12Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-19882",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-19882"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "openssl",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "1.1.1d-0+deb10u6"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:56:38Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 5.8,
-            "exploitability_score": 8.6,
-            "impact_score": 4.9
-          },
-          "cvss_v3": {
-            "base_score": -1,
-            "exploitability_score": -1,
-            "impact_score": -1
-          },
-          "id": "CVE-2007-6755"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:56:38Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2007-6755",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2007-6755"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "openssl",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "1.1.1d-0+deb10u6"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:56:38Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 4,
-            "exploitability_score": 1.9,
-            "impact_score": 6.9
-          },
-          "cvss_v3": {
-            "base_score": -1,
-            "exploitability_score": -1,
-            "impact_score": -1
-          },
-          "id": "CVE-2010-0928"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:56:38Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2010-0928",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2010-0928"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "passwd",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "1:4.5-1.1"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:57:11Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 4.9,
-            "exploitability_score": 3.9,
-            "impact_score": 6.9
-          },
-          "cvss_v3": {
-            "base_score": -1,
-            "exploitability_score": -1,
-            "impact_score": -1
-          },
-          "id": "CVE-2007-5686"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:57:11Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2007-5686",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2007-5686"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "passwd",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "1:4.5-1.1"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:57:12Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 3.3,
-            "exploitability_score": 3.4,
-            "impact_score": 4.9
-          },
-          "cvss_v3": {
-            "base_score": 4.7,
-            "exploitability_score": 1,
-            "impact_score": 3.6
-          },
-          "id": "CVE-2013-4235"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:57:12Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4235",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2013-4235"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "passwd",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "1:4.5-1.1"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:57:12Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 6.9,
-            "exploitability_score": 3.4,
-            "impact_score": 10
-          },
-          "cvss_v3": {
-            "base_score": 7.8,
-            "exploitability_score": 1.8,
-            "impact_score": 5.9
-          },
-          "id": "CVE-2019-19882"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:57:12Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-19882",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-19882"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "perl",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "5.28.1-6+deb10u1"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:57:40Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 5,
-            "exploitability_score": 10,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6
-          },
-          "id": "CVE-2011-4116"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:57:40Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2011-4116",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2011-4116"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "perl-base",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "5.28.1-6+deb10u1"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:57:40Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 5,
-            "exploitability_score": 10,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6
-          },
-          "id": "CVE-2011-4116"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:57:40Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2011-4116",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2011-4116"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "python",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.7.16-1"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:57:42Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 7.2,
-            "exploitability_score": 3.9,
-            "impact_score": 10
-          },
-          "cvss_v3": {
-            "base_score": -1,
-            "exploitability_score": -1,
-            "impact_score": -1
-          },
-          "id": "CVE-2008-4108"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:57:42Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2008-4108",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2008-4108"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "python2.7-minimal",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.7.16-2+deb10u1"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T23:00:31Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": -1,
-            "exploitability_score": -1,
-            "impact_score": -1
-          },
-          "id": "CVE-2013-7040"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T23:00:31Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-7040",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2013-7040"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "python2.7-minimal",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.7.16-2+deb10u1"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:58:28Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 6.8,
-            "exploitability_score": 8.6,
-            "impact_score": 6.4
-          },
-          "cvss_v3": {
-            "base_score": 8.8,
-            "exploitability_score": 2.8,
-            "impact_score": 5.9
-          },
-          "id": "CVE-2017-17522"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:58:28Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-17522"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "python2.7-minimal",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.7.16-2+deb10u1"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:58:28Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 6.1,
-            "exploitability_score": 2.8,
-            "impact_score": 2.7
-          },
-          "id": "CVE-2019-18348"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:58:28Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-18348"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "python2.7-minimal",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.7.16-2+deb10u1"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:58:28Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 5,
-            "exploitability_score": 10,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6
-          },
-          "id": "CVE-2019-9674"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:58:28Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-9674"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "python2.7-minimal",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "2.7.16-2+deb10u1"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2021-03-31T17:06:44Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 4,
-            "exploitability_score": 4.9,
-            "impact_score": 4.9
-          },
-          "cvss_v3": {
-            "base_score": 5.9,
-            "exploitability_score": 1.6,
-            "impact_score": 4.2
-          },
-          "id": "CVE-2021-23336"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2021-03-31T17:06:44Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2021-23336",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2021-23336"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "python3.7-minimal",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "3.7.3-2+deb10u3"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:58:28Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 6.8,
-            "exploitability_score": 8.6,
-            "impact_score": 6.4
-          },
-          "cvss_v3": {
-            "base_score": 8.8,
-            "exploitability_score": 2.8,
-            "impact_score": 5.9
-          },
-          "id": "CVE-2017-17522"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:58:28Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-17522"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "python3.7-minimal",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "3.7.3-2+deb10u3"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:58:28Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 6.1,
-            "exploitability_score": 2.8,
-            "impact_score": 2.7
-          },
-          "id": "CVE-2019-18348"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:58:28Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-18348"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "python3.7-minimal",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "3.7.3-2+deb10u3"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:58:28Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 5,
-            "exploitability_score": 10,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6
-          },
-          "id": "CVE-2019-9674"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:58:28Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-9674"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "python3.7-minimal",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "3.7.3-2+deb10u3"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-10-23T09:09:58Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 7.5,
-            "exploitability_score": 10,
-            "impact_score": 6.4
-          },
-          "cvss_v3": {
-            "base_score": 9.8,
-            "exploitability_score": 3.9,
-            "impact_score": 5.9
-          },
-          "id": "CVE-2020-27619"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-11-04T09:11:01Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-27619",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-27619"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "systemd",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:58:49Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 3.3,
-            "exploitability_score": 3.4,
-            "impact_score": 4.9
-          },
-          "cvss_v3": {
-            "base_score": -1,
-            "exploitability_score": -1,
-            "impact_score": -1
-          },
-          "id": "CVE-2013-4392"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T22:58:49Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2013-4392"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "systemd",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:58:48Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 2.4,
-            "exploitability_score": 0.9,
-            "impact_score": 1.4
-          },
-          "id": "CVE-2019-20386"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-05-12T09:09:42Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-20386"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "systemd",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-06-04T09:09:58Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 6.2,
-            "exploitability_score": 1.9,
-            "impact_score": 10
-          },
-          "cvss_v3": {
-            "base_score": 6.7,
-            "exploitability_score": 0.8,
-            "impact_score": 5.9
-          },
-          "id": "CVE-2020-13776"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-06-21T09:10:36Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-13776"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "tar",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "1.30+dfsg-6"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T23:00:35Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 10,
-            "exploitability_score": 10,
-            "impact_score": 10
-          },
-          "cvss_v3": {
-            "base_score": -1,
-            "exploitability_score": -1,
-            "impact_score": -1
-          },
-          "id": "CVE-2005-2541"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T23:00:35Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2005-2541",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2005-2541"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "tar",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "1.30+dfsg-6"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T23:00:35Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 5,
-            "exploitability_score": 10,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6
-          },
-          "id": "CVE-2019-9923"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2020-03-27T23:00:35Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9923",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-9923"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "tar",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "1.30+dfsg-6"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2021-01-20T09:16:47Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": -1,
-            "exploitability_score": -1,
-            "impact_score": -1
-          },
-          "cvss_v3": {
-            "base_score": -1,
-            "exploitability_score": -1,
-            "impact_score": -1
-          },
-          "id": "CVE-2021-20193"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "last_modified": "2021-01-21T09:16:38Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2021-20193",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2021-20193"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "xdg-user-dirs",
-      "pkg_path": "pkgdb",
-      "pkg_type": "dpkg",
-      "version": "0.17-2"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-27T22:56:32Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 4.6,
-            "exploitability_score": 3.9,
-            "impact_score": 6.4
-          },
-          "cvss_v3": {
-            "base_score": 7.8,
-            "exploitability_score": 1.8,
-            "impact_score": 5.9
-          },
-          "id": "CVE-2017-15131"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
       "last_modified": "2020-03-27T22:56:32Z",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-15131",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-15131"
-    }
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
   },
   {
     "artifact": {
-      "cpe": "None",
+      "name": "libgssapi-krb5-2",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "1.17-3+deb10u1",
       "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2004-0971",
+      "created_at": "2020-03-27T22:58:44Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2004-0971",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          },
+          "id": "CVE-2004-0971",
+          "cvss_v2": {
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "base_score": 2.1
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:58:44Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libgssapi-krb5-2",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "1.17-3+deb10u1",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2018-5709",
+      "created_at": "2020-03-27T22:58:44Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2018-5709",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "base_score": 7.5
+          },
+          "id": "CVE-2018-5709",
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:58:44Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libldap-common",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.4.47+dfsg-3+deb10u6",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2015-3276",
+      "created_at": "2020-03-27T22:58:11Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2015-3276",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          },
+          "id": "CVE-2015-3276",
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:58:11Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libldap-common",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.4.47+dfsg-3+deb10u6",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2017-14159",
+      "created_at": "2020-03-27T22:58:11Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-14159",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 1.0,
+            "impact_score": 3.6,
+            "base_score": 4.7
+          },
+          "id": "CVE-2017-14159",
+          "cvss_v2": {
+            "exploitability_score": 3.4,
+            "impact_score": 2.9,
+            "base_score": 1.9
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:58:11Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libldap-common",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.4.47+dfsg-3+deb10u6",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2017-17740",
+      "created_at": "2020-03-27T22:58:11Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17740",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "base_score": 7.5
+          },
+          "id": "CVE-2017-17740",
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:58:11Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libldap-common",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.4.47+dfsg-3+deb10u6",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2020-15719",
+      "created_at": "2020-07-17T09:11:26Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-15719",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 1.6,
+            "impact_score": 2.5,
+            "base_score": 4.2
+          },
+          "id": "CVE-2020-15719",
+          "cvss_v2": {
+            "exploitability_score": 4.9,
+            "impact_score": 4.9,
+            "base_score": 4.0
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-08-05T09:09:49Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libnss-systemd",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "241-7~deb10u7",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2013-4392",
+      "created_at": "2020-03-27T22:58:49Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          },
+          "id": "CVE-2013-4392",
+          "cvss_v2": {
+            "exploitability_score": 3.4,
+            "impact_score": 4.9,
+            "base_score": 3.3
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:58:49Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libnss-systemd",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "241-7~deb10u7",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2019-20386",
+      "created_at": "2020-03-27T22:58:48Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 0.9,
+            "impact_score": 1.4,
+            "base_score": 2.4
+          },
+          "id": "CVE-2019-20386",
+          "cvss_v2": {
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "base_score": 2.1
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-05-12T09:09:42Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libnss-systemd",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "241-7~deb10u7",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2020-13776",
+      "created_at": "2020-06-04T09:09:58Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 0.8,
+            "impact_score": 5.9,
+            "base_score": 6.7
+          },
+          "id": "CVE-2020-13776",
+          "cvss_v2": {
+            "exploitability_score": 1.9,
+            "impact_score": 10.0,
+            "base_score": 6.2
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-06-21T09:10:36Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libpcre3",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2:8.39-12",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2017-11164",
+      "created_at": "2020-03-27T23:00:01Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-11164",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "base_score": 7.5
+          },
+          "id": "CVE-2017-11164",
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 6.9,
+            "base_score": 7.8
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T23:00:01Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libpcre3",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2:8.39-12",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2017-16231",
+      "created_at": "2020-03-27T23:00:01Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-16231",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 1.8,
+            "impact_score": 3.6,
+            "base_score": 5.5
+          },
+          "id": "CVE-2017-16231",
+          "cvss_v2": {
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "base_score": 2.1
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T23:00:01Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libpcre3",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2:8.39-12",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2017-7245",
+      "created_at": "2020-03-27T23:00:01Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-7245",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 1.8,
+            "impact_score": 5.9,
+            "base_score": 7.8
+          },
+          "id": "CVE-2017-7245",
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 6.4,
+            "base_score": 6.8
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T23:00:01Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libpcre3",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2:8.39-12",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2017-7246",
+      "created_at": "2020-03-27T23:00:01Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-7246",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 1.8,
+            "impact_score": 5.9,
+            "base_score": 7.8
+          },
+          "id": "CVE-2017-7246",
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 6.4,
+            "base_score": 6.8
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T23:00:01Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libpcre3",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2:8.39-12",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2019-20838",
+      "created_at": "2020-06-16T09:09:31Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20838",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "base_score": 7.5
+          },
+          "id": "CVE-2019-20838",
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "base_score": 4.3
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-07-02T09:10:45Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libpython2.7-minimal",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.7.16-2+deb10u1",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2013-7040",
+      "created_at": "2020-03-27T23:00:31Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-7040",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          },
+          "id": "CVE-2013-7040",
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "base_score": 4.3
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T23:00:31Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libpython2.7-minimal",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.7.16-2+deb10u1",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2017-17522",
+      "created_at": "2020-03-27T22:58:28Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 2.8,
+            "impact_score": 5.9,
+            "base_score": 8.8
+          },
+          "id": "CVE-2017-17522",
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 6.4,
+            "base_score": 6.8
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:58:28Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libpython2.7-minimal",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.7.16-2+deb10u1",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2019-18348",
+      "created_at": "2020-03-27T22:58:28Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 2.8,
+            "impact_score": 2.7,
+            "base_score": 6.1
+          },
+          "id": "CVE-2019-18348",
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "base_score": 4.3
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:58:28Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libpython2.7-minimal",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.7.16-2+deb10u1",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2019-9674",
+      "created_at": "2020-03-27T22:58:28Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "base_score": 7.5
+          },
+          "id": "CVE-2019-9674",
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:58:28Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libpython2.7-minimal",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.7.16-2+deb10u1",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2021-23336",
+      "created_at": "2021-03-31T17:06:44Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2021-23336",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 1.6,
+            "impact_score": 4.2,
+            "base_score": 5.9
+          },
+          "id": "CVE-2021-23336",
+          "cvss_v2": {
+            "exploitability_score": 4.9,
+            "impact_score": 4.9,
+            "base_score": 4.0
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Medium",
+      "last_modified": "2021-03-31T17:06:44Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libpython3.7-minimal",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "3.7.3-2+deb10u3",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2017-17522",
+      "created_at": "2020-03-27T22:58:28Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 2.8,
+            "impact_score": 5.9,
+            "base_score": 8.8
+          },
+          "id": "CVE-2017-17522",
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 6.4,
+            "base_score": 6.8
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:58:28Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libpython3.7-minimal",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "3.7.3-2+deb10u3",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2019-18348",
+      "created_at": "2020-03-27T22:58:28Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 2.8,
+            "impact_score": 2.7,
+            "base_score": 6.1
+          },
+          "id": "CVE-2019-18348",
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "base_score": 4.3
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:58:28Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libpython3.7-minimal",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "3.7.3-2+deb10u3",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2019-9674",
+      "created_at": "2020-03-27T22:58:28Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "base_score": 7.5
+          },
+          "id": "CVE-2019-9674",
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:58:28Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libpython3.7-minimal",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "3.7.3-2+deb10u3",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2020-27619",
+      "created_at": "2020-10-23T09:09:58Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-27619",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 5.9,
+            "base_score": 9.8
+          },
+          "id": "CVE-2020-27619",
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 6.4,
+            "base_score": 7.5
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-11-04T09:11:01Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libseccomp2",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.3.3-4",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2019-9893",
+      "created_at": "2020-03-27T22:56:22Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9893",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 5.9,
+            "base_score": 9.8
+          },
+          "id": "CVE-2019-9893",
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 6.4,
+            "base_score": 7.5
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:56:22Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libssl1.1",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "1.1.1d-0+deb10u6",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2007-6755",
+      "created_at": "2020-03-27T22:56:38Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2007-6755",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          },
+          "id": "CVE-2007-6755",
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 4.9,
+            "base_score": 5.8
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:56:38Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libssl1.1",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "1.1.1d-0+deb10u6",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2010-0928",
+      "created_at": "2020-03-27T22:56:38Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-0928",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          },
+          "id": "CVE-2010-0928",
+          "cvss_v2": {
+            "exploitability_score": 1.9,
+            "impact_score": 6.9,
+            "base_score": 4.0
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:56:38Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libsystemd0",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "241-7~deb10u7",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2013-4392",
+      "created_at": "2020-03-27T22:58:49Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          },
+          "id": "CVE-2013-4392",
+          "cvss_v2": {
+            "exploitability_score": 3.4,
+            "impact_score": 4.9,
+            "base_score": 3.3
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:58:49Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libsystemd0",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "241-7~deb10u7",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2019-20386",
+      "created_at": "2020-03-27T22:58:48Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 0.9,
+            "impact_score": 1.4,
+            "base_score": 2.4
+          },
+          "id": "CVE-2019-20386",
+          "cvss_v2": {
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "base_score": 2.1
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-05-12T09:09:42Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libsystemd0",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "241-7~deb10u7",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2020-13776",
+      "created_at": "2020-06-04T09:09:58Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 0.8,
+            "impact_score": 5.9,
+            "base_score": 6.7
+          },
+          "id": "CVE-2020-13776",
+          "cvss_v2": {
+            "exploitability_score": 1.9,
+            "impact_score": 10.0,
+            "base_score": 6.2
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-06-21T09:10:36Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libtasn1-6",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "4.13-3",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2018-1000654",
+      "created_at": "2020-03-27T22:57:42Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2018-1000654",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 1.8,
+            "impact_score": 3.6,
+            "base_score": 5.5
+          },
+          "id": "CVE-2018-1000654",
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 6.9,
+            "base_score": 7.1
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:57:42Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libudev1",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "241-7~deb10u6",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2013-4392",
+      "created_at": "2020-03-27T22:58:49Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          },
+          "id": "CVE-2013-4392",
+          "cvss_v2": {
+            "exploitability_score": 3.4,
+            "impact_score": 4.9,
+            "base_score": 3.3
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:58:49Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libudev1",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "241-7~deb10u6",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2019-20386",
+      "created_at": "2020-03-27T22:58:48Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 0.9,
+            "impact_score": 1.4,
+            "base_score": 2.4
+          },
+          "id": "CVE-2019-20386",
+          "cvss_v2": {
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "base_score": 2.1
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-05-12T09:09:42Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "libudev1",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "241-7~deb10u6",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2020-13776",
+      "created_at": "2020-06-04T09:09:58Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 0.8,
+            "impact_score": 5.9,
+            "base_score": 6.7
+          },
+          "id": "CVE-2020-13776",
+          "cvss_v2": {
+            "exploitability_score": 1.9,
+            "impact_score": 10.0,
+            "base_score": 6.2
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-06-21T09:10:36Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "login",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "1:4.5-1.1",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2007-5686",
+      "created_at": "2020-03-27T22:57:11Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2007-5686",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          },
+          "id": "CVE-2007-5686",
+          "cvss_v2": {
+            "exploitability_score": 3.9,
+            "impact_score": 6.9,
+            "base_score": 4.9
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:57:11Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "login",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "1:4.5-1.1",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2013-4235",
+      "created_at": "2020-03-27T22:57:12Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4235",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 1.0,
+            "impact_score": 3.6,
+            "base_score": 4.7
+          },
+          "id": "CVE-2013-4235",
+          "cvss_v2": {
+            "exploitability_score": 3.4,
+            "impact_score": 4.9,
+            "base_score": 3.3
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:57:12Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "login",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "1:4.5-1.1",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2019-19882",
+      "created_at": "2020-03-27T22:57:12Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-19882",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 1.8,
+            "impact_score": 5.9,
+            "base_score": 7.8
+          },
+          "id": "CVE-2019-19882",
+          "cvss_v2": {
+            "exploitability_score": 3.4,
+            "impact_score": 10.0,
+            "base_score": 6.9
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:57:12Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "openssl",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "1.1.1d-0+deb10u6",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2007-6755",
+      "created_at": "2020-03-27T22:56:38Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2007-6755",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          },
+          "id": "CVE-2007-6755",
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 4.9,
+            "base_score": 5.8
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:56:38Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "openssl",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "1.1.1d-0+deb10u6",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2010-0928",
+      "created_at": "2020-03-27T22:56:38Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-0928",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          },
+          "id": "CVE-2010-0928",
+          "cvss_v2": {
+            "exploitability_score": 1.9,
+            "impact_score": 6.9,
+            "base_score": 4.0
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:56:38Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "passwd",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "1:4.5-1.1",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2007-5686",
+      "created_at": "2020-03-27T22:57:11Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2007-5686",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          },
+          "id": "CVE-2007-5686",
+          "cvss_v2": {
+            "exploitability_score": 3.9,
+            "impact_score": 6.9,
+            "base_score": 4.9
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:57:11Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "passwd",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "1:4.5-1.1",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2013-4235",
+      "created_at": "2020-03-27T22:57:12Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4235",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 1.0,
+            "impact_score": 3.6,
+            "base_score": 4.7
+          },
+          "id": "CVE-2013-4235",
+          "cvss_v2": {
+            "exploitability_score": 3.4,
+            "impact_score": 4.9,
+            "base_score": 3.3
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:57:12Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "passwd",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "1:4.5-1.1",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2019-19882",
+      "created_at": "2020-03-27T22:57:12Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-19882",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 1.8,
+            "impact_score": 5.9,
+            "base_score": 7.8
+          },
+          "id": "CVE-2019-19882",
+          "cvss_v2": {
+            "exploitability_score": 3.4,
+            "impact_score": 10.0,
+            "base_score": 6.9
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:57:12Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "perl",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "5.28.1-6+deb10u1",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2011-4116",
+      "created_at": "2020-03-27T22:57:40Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2011-4116",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "base_score": 7.5
+          },
+          "id": "CVE-2011-4116",
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:57:40Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "perl-base",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "5.28.1-6+deb10u1",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2011-4116",
+      "created_at": "2020-03-27T22:57:40Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2011-4116",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "base_score": 7.5
+          },
+          "id": "CVE-2011-4116",
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:57:40Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "python",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.7.16-1",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2008-4108",
+      "created_at": "2020-03-27T22:57:42Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2008-4108",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          },
+          "id": "CVE-2008-4108",
+          "cvss_v2": {
+            "exploitability_score": 3.9,
+            "impact_score": 10.0,
+            "base_score": 7.2
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:57:42Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "python2.7-minimal",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.7.16-2+deb10u1",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2013-7040",
+      "created_at": "2020-03-27T23:00:31Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-7040",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          },
+          "id": "CVE-2013-7040",
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "base_score": 4.3
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T23:00:31Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "python2.7-minimal",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.7.16-2+deb10u1",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2017-17522",
+      "created_at": "2020-03-27T22:58:28Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 2.8,
+            "impact_score": 5.9,
+            "base_score": 8.8
+          },
+          "id": "CVE-2017-17522",
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 6.4,
+            "base_score": 6.8
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:58:28Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "python2.7-minimal",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.7.16-2+deb10u1",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2019-18348",
+      "created_at": "2020-03-27T22:58:28Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 2.8,
+            "impact_score": 2.7,
+            "base_score": 6.1
+          },
+          "id": "CVE-2019-18348",
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "base_score": 4.3
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:58:28Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "python2.7-minimal",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.7.16-2+deb10u1",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2019-9674",
+      "created_at": "2020-03-27T22:58:28Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "base_score": 7.5
+          },
+          "id": "CVE-2019-9674",
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:58:28Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "python2.7-minimal",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "2.7.16-2+deb10u1",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2021-23336",
+      "created_at": "2021-03-31T17:06:44Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2021-23336",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 1.6,
+            "impact_score": 4.2,
+            "base_score": 5.9
+          },
+          "id": "CVE-2021-23336",
+          "cvss_v2": {
+            "exploitability_score": 4.9,
+            "impact_score": 4.9,
+            "base_score": 4.0
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Medium",
+      "last_modified": "2021-03-31T17:06:44Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "python3.7-minimal",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "3.7.3-2+deb10u3",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2017-17522",
+      "created_at": "2020-03-27T22:58:28Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 2.8,
+            "impact_score": 5.9,
+            "base_score": 8.8
+          },
+          "id": "CVE-2017-17522",
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 6.4,
+            "base_score": 6.8
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:58:28Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "python3.7-minimal",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "3.7.3-2+deb10u3",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2019-18348",
+      "created_at": "2020-03-27T22:58:28Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 2.8,
+            "impact_score": 2.7,
+            "base_score": 6.1
+          },
+          "id": "CVE-2019-18348",
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "base_score": 4.3
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:58:28Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "python3.7-minimal",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "3.7.3-2+deb10u3",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2019-9674",
+      "created_at": "2020-03-27T22:58:28Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "base_score": 7.5
+          },
+          "id": "CVE-2019-9674",
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:58:28Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "python3.7-minimal",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "3.7.3-2+deb10u3",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2020-27619",
+      "created_at": "2020-10-23T09:09:58Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-27619",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 5.9,
+            "base_score": 9.8
+          },
+          "id": "CVE-2020-27619",
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 6.4,
+            "base_score": 7.5
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-11-04T09:11:01Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "systemd",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "241-7~deb10u7",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2013-4392",
+      "created_at": "2020-03-27T22:58:49Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          },
+          "id": "CVE-2013-4392",
+          "cvss_v2": {
+            "exploitability_score": 3.4,
+            "impact_score": 4.9,
+            "base_score": 3.3
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:58:49Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "systemd",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "241-7~deb10u7",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2019-20386",
+      "created_at": "2020-03-27T22:58:48Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 0.9,
+            "impact_score": 1.4,
+            "base_score": 2.4
+          },
+          "id": "CVE-2019-20386",
+          "cvss_v2": {
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "base_score": 2.1
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-05-12T09:09:42Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "systemd",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "241-7~deb10u7",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2020-13776",
+      "created_at": "2020-06-04T09:09:58Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 0.8,
+            "impact_score": 5.9,
+            "base_score": 6.7
+          },
+          "id": "CVE-2020-13776",
+          "cvss_v2": {
+            "exploitability_score": 1.9,
+            "impact_score": 10.0,
+            "base_score": 6.2
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-06-21T09:10:36Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "tar",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "1.30+dfsg-6",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2005-2541",
+      "created_at": "2020-03-27T23:00:35Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2005-2541",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          },
+          "id": "CVE-2005-2541",
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 10.0,
+            "base_score": 10.0
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T23:00:35Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "tar",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "1.30+dfsg-6",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2019-9923",
+      "created_at": "2020-03-27T23:00:35Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9923",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "base_score": 7.5
+          },
+          "id": "CVE-2019-9923",
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T23:00:35Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "tar",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "1.30+dfsg-6",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2021-20193",
+      "created_at": "2021-01-20T09:16:47Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2021-20193",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          },
+          "id": "CVE-2021-20193",
+          "cvss_v2": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2021-01-21T09:16:38Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
+      "name": "xdg-user-dirs",
+      "pkg_type": "dpkg",
+      "pkg_path": "pkgdb",
+      "version": "0.17-2",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "CVE-2017-15131",
+      "created_at": "2020-03-27T22:56:32Z",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-15131",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 1.8,
+            "impact_score": 5.9,
+            "base_score": 7.8
+          },
+          "id": "CVE-2017-15131",
+          "cvss_v2": {
+            "exploitability_score": 3.9,
+            "impact_score": 6.4,
+            "base_score": 4.6
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Negligible",
+      "last_modified": "2020-03-27T22:56:32Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "fixes": [
+      {
+        "observed_at": null,
+        "version": "None",
+        "wont_fix": false
+      }
+    ]
+  },
+  {
+    "artifact": {
       "name": "xmldom",
-      "pkg_path": "/sandbox/node_modules/xmldom/package.json",
       "pkg_type": "npm",
-      "version": "0.4.0"
+      "pkg_path": "/sandbox/node_modules/xmldom/package.json",
+      "version": "0.4.0",
+      "cpe23": "None",
+      "cpe": "None"
+    },
+    "vulnerability": {
+      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv",
+      "created_at": "2021-03-31T17:30:47Z",
+      "feed_group": "github:npm",
+      "link": "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 2.8,
+            "impact_score": 1.4,
+            "base_score": 4.3
+          },
+          "id": "CVE-2021-21366",
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "base_score": 4.3
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Low",
+      "last_modified": "2021-03-31T17:30:47Z",
+      "feed": "vulnerabilities"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
     },
     "fixes": [
       {
@@ -4200,275 +4229,46 @@
         "version": "0.5.0",
         "wont_fix": false
       }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "vulnerability": {
-      "created_at": "2021-03-31T17:30:47Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 4.3,
-            "exploitability_score": 2.8,
-            "impact_score": 1.4
-          },
-          "id": "CVE-2021-21366"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "github:npm",
-      "last_modified": "2021-03-31T17:30:47Z",
-      "link": "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv",
-      "severity": "Low",
-      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv"
-    }
+    ]
   },
   {
     "artifact": {
-      "cpe": "cpe:a:python-aiohttp:aiohttp:3.7.3:*:*",
-      "cpe23": "cpe:2.3:a:python-aiohttp:aiohttp:3.7.3:*:-:-:-:-:-:*",
-      "name": "aiohttp",
-      "pkg_path": "/usr/local/lib/python3.7/dist-packages/aiohttp",
-      "pkg_type": "python",
-      "version": "3.7.3"
-    },
-    "fixes": [],
-    "match": {
-      "detected_at": "2021-03-31T17:29:49Z"
-    },
-    "vulnerability": {
-      "created_at": "2021-03-31T17:29:49Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 5.8,
-            "exploitability_score": 8.6,
-            "impact_score": 4.9
-          },
-          "cvss_v3": {
-            "base_score": 6.1,
-            "exploitability_score": 2.8,
-            "impact_score": 2.7
-          },
-          "id": "CVE-2021-21330"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "nvdv2",
-      "feed_group": "nvdv2:cves",
-      "last_modified": "2021-03-31T17:29:49Z",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21330",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2021-21330"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "cpe:a:guava:guava:23.0:*:*",
-      "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*",
-      "name": "guava",
-      "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fixes": [],
-    "match": {
-      "detected_at": "2021-03-31T17:25:26Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-28T02:59:42Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6
-          },
-          "id": "CVE-2018-10237"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "nvdv2",
-      "feed_group": "nvdv2:cves",
-      "last_modified": "2021-03-31T17:25:26Z",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2018-10237"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "cpe:a:guava:guava:23.0:*:*",
-      "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*",
-      "name": "guava",
-      "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fixes": [],
-    "match": {
-      "detected_at": "2021-03-31T17:24:25Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-12-12T09:17:33Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 3.3,
-            "exploitability_score": 1.8,
-            "impact_score": 1.4
-          },
-          "id": "CVE-2020-8908"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "nvdv2",
-      "feed_group": "nvdv2:cves",
-      "last_modified": "2021-03-31T17:24:25Z",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2020-8908"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "cpe:a:guava:guava:23.0:*:*",
-      "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*",
-      "name": "guava",
-      "pkg_path": "/sandbox/target/my-app-1.jar:guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fixes": [],
-    "match": {
-      "detected_at": "2021-03-31T17:25:26Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-28T02:59:42Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6
-          },
-          "id": "CVE-2018-10237"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "nvdv2",
-      "feed_group": "nvdv2:cves",
-      "last_modified": "2021-03-31T17:25:26Z",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2018-10237"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "cpe:a:guava:guava:23.0:*:*",
-      "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*",
-      "name": "guava",
-      "pkg_path": "/sandbox/target/my-app-1.jar:guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fixes": [],
-    "match": {
-      "detected_at": "2021-03-31T17:24:25Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-12-12T09:17:33Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 3.3,
-            "exploitability_score": 1.8,
-            "impact_score": 1.4
-          },
-          "id": "CVE-2020-8908"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "nvdv2",
-      "feed_group": "nvdv2:cves",
-      "last_modified": "2021-03-31T17:24:25Z",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2020-8908"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "cpe:a:ftpd:ftpd:0.2.1:*:*",
-      "cpe23": "cpe:2.3:a:ftpd:ftpd:0.2.1:*:-:-:-:-:-:*",
       "name": "ftpd",
-      "pkg_path": "/var/lib/gems/2.5.0/specifications/ftpd-0.2.1.gemspec",
       "pkg_type": "gem",
-      "version": "0.2.1"
+      "pkg_path": "/var/lib/gems/2.5.0/specifications/ftpd-0.2.1.gemspec",
+      "version": "0.2.1",
+      "cpe23": "cpe:2.3:a:ftpd:ftpd:0.2.1:*:-:-:-:-:-:*",
+      "cpe": "cpe:a:ftpd:ftpd:0.2.1:*:*"
     },
-    "fixes": [],
+    "vulnerability": {
+      "vulnerability_id": "CVE-2013-2512",
+      "created_at": "2021-03-31T17:11:12Z",
+      "feed_group": "nvdv2:cves",
+      "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
+      "cvss_scores_vendor": [],
+      "cvss_scores_nvd": [
+        {
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 5.9,
+            "base_score": 9.8
+          },
+          "id": "CVE-2013-2512",
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 10.0,
+            "base_score": 10.0
+          }
+        }
+      ],
+      "description": "NA",
+      "severity": "Critical",
+      "last_modified": "2021-03-31T17:11:12Z",
+      "feed": "nvdv2"
+    },
     "match": {
       "detected_at": "2021-03-31T17:11:12Z"
     },
-    "vulnerability": {
-      "created_at": "2021-03-31T17:11:12Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 10,
-            "exploitability_score": 10,
-            "impact_score": 10
-          },
-          "cvss_v3": {
-            "base_score": 9.8,
-            "exploitability_score": 3.9,
-            "impact_score": 5.9
-          },
-          "id": "CVE-2013-2512"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "nvdv2",
-      "feed_group": "nvdv2:cves",
-      "last_modified": "2021-03-31T17:11:12Z",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
-      "severity": "Critical",
-      "vulnerability_id": "CVE-2013-2512"
-    }
+    "fixes": []
   }
 ]

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:80a31c3ce2e99c3691c27ac3b1753163214494e9b2ca07bfdccf29a5cca2bfbe.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:80a31c3ce2e99c3691c27ac3b1753163214494e9b2ca07bfdccf29a5cca2bfbe.json
@@ -1,5 +1,15 @@
 [
   {
+    "match": {
+      "detected_at": "2021-05-04T07:31:01Z"
+    },
+    "fixes": [
+      {
+        "wont_fix": false,
+        "observed_at": "2021-03-31T17:30:49Z",
+        "version": "3.7.4"
+      }
+    ],
     "artifact": {
       "cpe": "None",
       "cpe23": "None",
@@ -8,44 +18,44 @@
       "pkg_type": "python",
       "version": "3.7.3"
     },
-    "fixes": [
-      {
-        "observed_at": "2021-03-31T17:30:49Z",
-        "version": "3.7.4",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:01Z"
-    },
     "vulnerability": {
-      "created_at": "2021-03-31T17:30:49Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 5.8,
-            "exploitability_score": 8.6,
-            "impact_score": 4.9
-          },
-          "cvss_v3": {
-            "base_score": 6.1,
-            "exploitability_score": 2.8,
-            "impact_score": 2.7
-          },
-          "id": "CVE-2021-21330"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
       "feed_group": "github:python",
-      "last_modified": "2021-03-31T17:30:49Z",
-      "link": "https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
       "severity": "Low",
-      "vulnerability_id": "GHSA-v6wp-4m6f-gcjg"
+      "created_at": "2021-03-31T17:30:49Z",
+      "vulnerability_id": "GHSA-v6wp-4m6f-gcjg",
+      "description": "NA",
+      "cvss_scores_vendor": [],
+      "link": "https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
+      "last_modified": "2021-03-31T17:30:49Z",
+      "cvss_scores_nvd": [
+        {
+          "id": "CVE-2021-21330",
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 4.9,
+            "base_score": 5.8
+          },
+          "cvss_v3": {
+            "exploitability_score": 2.8,
+            "impact_score": 2.7,
+            "base_score": 6.1
+          }
+        }
+      ],
+      "feed": "vulnerabilities"
     }
   },
   {
+    "match": {
+      "detected_at": "2021-05-04T07:31:01Z"
+    },
+    "fixes": [
+      {
+        "wont_fix": false,
+        "observed_at": "2021-03-31T17:30:52Z",
+        "version": "30.0-jre"
+      }
+    ],
     "artifact": {
       "cpe": "None",
       "cpe23": "None",
@@ -54,44 +64,44 @@
       "pkg_type": "java",
       "version": "23.0"
     },
-    "fixes": [
-      {
-        "observed_at": "2021-03-31T17:30:52Z",
-        "version": "30.0-jre",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:01Z"
-    },
     "vulnerability": {
+      "feed_group": "github:java",
+      "severity": "Medium",
       "created_at": "2021-03-31T17:30:52Z",
+      "vulnerability_id": "GHSA-5mg8-w23w-74h3",
+      "description": "NA",
+      "cvss_scores_vendor": [],
+      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
+      "last_modified": "2021-03-31T17:30:52Z",
       "cvss_scores_nvd": [
         {
+          "id": "CVE-2020-8908",
           "cvss_v2": {
-            "base_score": 2.1,
             "exploitability_score": 3.9,
-            "impact_score": 2.9
+            "impact_score": 2.9,
+            "base_score": 2.1
           },
           "cvss_v3": {
-            "base_score": 3.3,
             "exploitability_score": 1.8,
-            "impact_score": 1.4
-          },
-          "id": "CVE-2020-8908"
+            "impact_score": 1.4,
+            "base_score": 3.3
+          }
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "github:java",
-      "last_modified": "2021-03-31T17:30:52Z",
-      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
-      "severity": "Medium",
-      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
+      "feed": "vulnerabilities"
     }
   },
   {
+    "match": {
+      "detected_at": "2021-05-04T07:31:01Z"
+    },
+    "fixes": [
+      {
+        "wont_fix": false,
+        "observed_at": "2020-06-16T09:10:15Z",
+        "version": "24.1.1-jre"
+      }
+    ],
     "artifact": {
       "cpe": "None",
       "cpe23": "None",
@@ -100,90 +110,44 @@
       "pkg_type": "java",
       "version": "23.0"
     },
-    "fixes": [
-      {
-        "observed_at": "2020-06-16T09:10:15Z",
-        "version": "24.1.1-jre",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:01Z"
-    },
     "vulnerability": {
+      "feed_group": "github:java",
+      "severity": "Medium",
       "created_at": "2020-06-16T09:10:15Z",
+      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j",
+      "description": "NA",
+      "cvss_scores_vendor": [],
+      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
+      "last_modified": "2020-06-16T09:10:15Z",
       "cvss_scores_nvd": [
         {
+          "id": "CVE-2018-10237",
           "cvss_v2": {
-            "base_score": 4.3,
             "exploitability_score": 8.6,
-            "impact_score": 2.9
+            "impact_score": 2.9,
+            "base_score": 4.3
           },
           "cvss_v3": {
-            "base_score": 5.9,
             "exploitability_score": 2.2,
-            "impact_score": 3.6
-          },
-          "id": "CVE-2018-10237"
+            "impact_score": 3.6,
+            "base_score": 5.9
+          }
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "github:java",
-      "last_modified": "2020-06-16T09:10:15Z",
-      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
-      "severity": "Medium",
-      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
+      "feed": "vulnerabilities"
     }
   },
   {
-    "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
-      "name": "guava",
-      "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
-      "pkg_type": "java",
-      "version": "23.0"
+    "match": {
+      "detected_at": "2021-05-04T07:31:01Z"
     },
     "fixes": [
       {
+        "wont_fix": false,
         "observed_at": "2021-03-31T17:30:52Z",
-        "version": "30.0-jre",
-        "wont_fix": false
+        "version": "30.0-jre"
       }
     ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:01Z"
-    },
-    "vulnerability": {
-      "created_at": "2021-03-31T17:30:52Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 3.3,
-            "exploitability_score": 1.8,
-            "impact_score": 1.4
-          },
-          "id": "CVE-2020-8908"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "github:java",
-      "last_modified": "2021-03-31T17:30:52Z",
-      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
-      "severity": "Medium",
-      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
-    }
-  },
-  {
     "artifact": {
       "cpe": "None",
       "cpe23": "None",
@@ -192,44 +156,90 @@
       "pkg_type": "java",
       "version": "23.0"
     },
-    "fixes": [
-      {
-        "observed_at": "2020-06-16T09:10:15Z",
-        "version": "24.1.1-jre",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:01Z"
-    },
     "vulnerability": {
-      "created_at": "2020-06-16T09:10:15Z",
+      "feed_group": "github:java",
+      "severity": "Medium",
+      "created_at": "2021-03-31T17:30:52Z",
+      "vulnerability_id": "GHSA-5mg8-w23w-74h3",
+      "description": "NA",
+      "cvss_scores_vendor": [],
+      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
+      "last_modified": "2021-03-31T17:30:52Z",
       "cvss_scores_nvd": [
         {
+          "id": "CVE-2020-8908",
           "cvss_v2": {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "base_score": 2.1
           },
           "cvss_v3": {
-            "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6
-          },
-          "id": "CVE-2018-10237"
+            "exploitability_score": 1.8,
+            "impact_score": 1.4,
+            "base_score": 3.3
+          }
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "github:java",
-      "last_modified": "2020-06-16T09:10:15Z",
-      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
-      "severity": "Medium",
-      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
+      "feed": "vulnerabilities"
     }
   },
   {
+    "match": {
+      "detected_at": "2021-05-04T07:31:01Z"
+    },
+    "fixes": [
+      {
+        "wont_fix": false,
+        "observed_at": "2020-06-16T09:10:15Z",
+        "version": "24.1.1-jre"
+      }
+    ],
+    "artifact": {
+      "cpe": "None",
+      "cpe23": "None",
+      "name": "guava",
+      "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "vulnerability": {
+      "feed_group": "github:java",
+      "severity": "Medium",
+      "created_at": "2020-06-16T09:10:15Z",
+      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j",
+      "description": "NA",
+      "cvss_scores_vendor": [],
+      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
+      "last_modified": "2020-06-16T09:10:15Z",
+      "cvss_scores_nvd": [
+        {
+          "id": "CVE-2018-10237",
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "base_score": 4.3
+          },
+          "cvss_v3": {
+            "exploitability_score": 2.2,
+            "impact_score": 3.6,
+            "base_score": 5.9
+          }
+        }
+      ],
+      "feed": "vulnerabilities"
+    }
+  },
+  {
+    "match": {
+      "detected_at": "2021-05-04T07:31:01Z"
+    },
+    "fixes": [
+      {
+        "wont_fix": false,
+        "observed_at": "2021-03-31T17:30:47Z",
+        "version": "0.5.0"
+      }
+    ],
     "artifact": {
       "cpe": "None",
       "cpe23": "None",
@@ -238,44 +248,38 @@
       "pkg_type": "npm",
       "version": "0.4.0"
     },
-    "fixes": [
-      {
-        "observed_at": "2021-03-31T17:30:47Z",
-        "version": "0.5.0",
-        "wont_fix": false
-      }
-    ],
-    "match": {
-      "detected_at": "2021-05-04T07:31:01Z"
-    },
     "vulnerability": {
+      "feed_group": "github:npm",
+      "severity": "Low",
       "created_at": "2021-03-31T17:30:47Z",
+      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv",
+      "description": "NA",
+      "cvss_scores_vendor": [],
+      "link": "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv",
+      "last_modified": "2021-03-31T17:30:47Z",
       "cvss_scores_nvd": [
         {
+          "id": "CVE-2021-21366",
           "cvss_v2": {
-            "base_score": 4.3,
             "exploitability_score": 8.6,
-            "impact_score": 2.9
+            "impact_score": 2.9,
+            "base_score": 4.3
           },
           "cvss_v3": {
-            "base_score": 4.3,
             "exploitability_score": 2.8,
-            "impact_score": 1.4
-          },
-          "id": "CVE-2021-21366"
+            "impact_score": 1.4,
+            "base_score": 4.3
+          }
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "github:npm",
-      "last_modified": "2021-03-31T17:30:47Z",
-      "link": "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv",
-      "severity": "Low",
-      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv"
+      "feed": "vulnerabilities"
     }
   },
   {
+    "match": {
+      "detected_at": "2021-03-31T17:11:12Z"
+    },
+    "fixes": [],
     "artifact": {
       "cpe": "cpe:a:ftpd:ftpd:0.2.1:*:*",
       "cpe23": "cpe:2.3:a:ftpd:ftpd:0.2.1:*:-:-:-:-:-:*",
@@ -284,235 +288,31 @@
       "pkg_type": "gem",
       "version": "0.2.1"
     },
-    "fixes": [],
-    "match": {
-      "detected_at": "2021-03-31T17:11:12Z"
-    },
     "vulnerability": {
-      "created_at": "2021-03-31T17:11:12Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 10,
-            "exploitability_score": 10,
-            "impact_score": 10
-          },
-          "cvss_v3": {
-            "base_score": 9.8,
-            "exploitability_score": 3.9,
-            "impact_score": 5.9
-          },
-          "id": "CVE-2013-2512"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "nvdv2",
       "feed_group": "nvdv2:cves",
-      "last_modified": "2021-03-31T17:11:12Z",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
       "severity": "Critical",
-      "vulnerability_id": "CVE-2013-2512"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "cpe:a:python-aiohttp:aiohttp:3.7.3:*:*",
-      "cpe23": "cpe:2.3:a:python-aiohttp:aiohttp:3.7.3:*:-:-:-:-:-:*",
-      "name": "aiohttp",
-      "pkg_path": "/usr/lib/python3.8/site-packages/aiohttp",
-      "pkg_type": "python",
-      "version": "3.7.3"
-    },
-    "fixes": [],
-    "match": {
-      "detected_at": "2021-03-31T17:29:49Z"
-    },
-    "vulnerability": {
-      "created_at": "2021-03-31T17:29:49Z",
+      "created_at": "2021-03-31T17:11:12Z",
+      "vulnerability_id": "CVE-2013-2512",
+      "description": "NA",
+      "cvss_scores_vendor": [],
+      "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
+      "last_modified": "2021-03-31T17:11:12Z",
       "cvss_scores_nvd": [
         {
+          "id": "CVE-2013-2512",
           "cvss_v2": {
-            "base_score": 5.8,
-            "exploitability_score": 8.6,
-            "impact_score": 4.9
+            "exploitability_score": 10.0,
+            "impact_score": 10.0,
+            "base_score": 10.0
           },
           "cvss_v3": {
-            "base_score": 6.1,
-            "exploitability_score": 2.8,
-            "impact_score": 2.7
-          },
-          "id": "CVE-2021-21330"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "nvdv2",
-      "feed_group": "nvdv2:cves",
-      "last_modified": "2021-03-31T17:29:49Z",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21330",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2021-21330"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "cpe:a:guava:guava:23.0:*:*",
-      "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*",
-      "name": "guava",
-      "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fixes": [],
-    "match": {
-      "detected_at": "2021-03-31T17:25:26Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-28T02:59:42Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6
-          },
-          "id": "CVE-2018-10237"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "nvdv2",
-      "feed_group": "nvdv2:cves",
-      "last_modified": "2021-03-31T17:25:26Z",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2018-10237"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "cpe:a:guava:guava:23.0:*:*",
-      "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*",
-      "name": "guava",
-      "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fixes": [],
-    "match": {
-      "detected_at": "2021-03-31T17:24:25Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-12-12T09:17:33Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 2.1,
             "exploitability_score": 3.9,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 3.3,
-            "exploitability_score": 1.8,
-            "impact_score": 1.4
-          },
-          "id": "CVE-2020-8908"
+            "impact_score": 5.9,
+            "base_score": 9.8
+          }
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "nvdv2",
-      "feed_group": "nvdv2:cves",
-      "last_modified": "2021-03-31T17:24:25Z",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2020-8908"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "cpe:a:guava:guava:23.0:*:*",
-      "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*",
-      "name": "guava",
-      "pkg_path": "/sandbox/target/my-app-1.jar:guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fixes": [],
-    "match": {
-      "detected_at": "2021-03-31T17:25:26Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-28T02:59:42Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6
-          },
-          "id": "CVE-2018-10237"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "nvdv2",
-      "feed_group": "nvdv2:cves",
-      "last_modified": "2021-03-31T17:25:26Z",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2018-10237"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "cpe:a:guava:guava:23.0:*:*",
-      "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*",
-      "name": "guava",
-      "pkg_path": "/sandbox/target/my-app-1.jar:guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fixes": [],
-    "match": {
-      "detected_at": "2021-03-31T17:24:25Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-12-12T09:17:33Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 3.3,
-            "exploitability_score": 1.8,
-            "impact_score": 1.4
-          },
-          "id": "CVE-2020-8908"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "nvdv2",
-      "feed_group": "nvdv2:cves",
-      "last_modified": "2021-03-31T17:24:25Z",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2020-8908"
+      "feed": "nvdv2"
     }
   }
 ]

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:fe3ca35038008b0eac0fa4e686bd072c9430000ab7d7853001bde5f5b8ccf60c.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:fe3ca35038008b0eac0fa4e686bd072c9430000ab7d7853001bde5f5b8ccf60c.json
@@ -1,1622 +1,1422 @@
 [
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "aiohttp",
       "pkg_path": "/usr/local/lib64/python3.6/site-packages/aiohttp",
+      "version": "3.7.3",
+      "cpe23": "None",
       "pkg_type": "python",
-      "version": "3.7.3"
+      "cpe": "None"
     },
     "fixes": [
       {
+        "wont_fix": false,
         "observed_at": "2021-03-31T17:30:49Z",
-        "version": "3.7.4",
-        "wont_fix": false
+        "version": "3.7.4"
       }
     ],
-    "match": {
-      "detected_at": "2021-05-04T06:22:33Z"
-    },
     "vulnerability": {
-      "created_at": "2021-03-31T17:30:49Z",
+      "cvss_scores_vendor": [],
+      "severity": "Low",
+      "description": "NA",
+      "vulnerability_id": "GHSA-v6wp-4m6f-gcjg",
+      "last_modified": "2021-03-31T17:30:49Z",
+      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
-          "cvss_v2": {
-            "base_score": 5.8,
-            "exploitability_score": 8.6,
-            "impact_score": 4.9
-          },
           "cvss_v3": {
+            "impact_score": 2.7,
             "base_score": 6.1,
-            "exploitability_score": 2.8,
-            "impact_score": 2.7
+            "exploitability_score": 2.8
+          },
+          "cvss_v2": {
+            "impact_score": 4.9,
+            "base_score": 5.8,
+            "exploitability_score": 8.6
           },
           "id": "CVE-2021-21330"
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "github:python",
-      "last_modified": "2021-03-31T17:30:49Z",
+      "created_at": "2021-03-31T17:30:49Z",
       "link": "https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
-      "severity": "Low",
-      "vulnerability_id": "GHSA-v6wp-4m6f-gcjg"
+      "feed_group": "github:python"
+    },
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "binutils",
       "pkg_path": "pkgdb",
+      "version": "2.27-44.base.el7",
+      "cpe23": "None",
       "pkg_type": "rpm",
-      "version": "2.27-44.base.el7"
+      "cpe": "None"
     },
     "fixes": [
       {
+        "wont_fix": false,
         "observed_at": null,
-        "version": "None",
-        "wont_fix": false
+        "version": "None"
       }
     ],
-    "match": {
-      "detected_at": "2021-05-04T06:22:33Z"
-    },
     "vulnerability": {
-      "created_at": "2020-03-27T23:41:54Z",
+      "cvss_scores_vendor": [],
+      "severity": "Low",
+      "description": "NA",
+      "vulnerability_id": "CVE-2019-17450",
+      "last_modified": "2020-03-27T23:41:54Z",
+      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
-          "cvss_v2": {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9
-          },
           "cvss_v3": {
+            "impact_score": 3.6,
             "base_score": 6.5,
-            "exploitability_score": 2.8,
-            "impact_score": 3.6
+            "exploitability_score": 2.8
+          },
+          "cvss_v2": {
+            "impact_score": 2.9,
+            "base_score": 4.3,
+            "exploitability_score": 8.6
           },
           "id": "CVE-2019-17450"
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "last_modified": "2020-03-27T23:41:54Z",
+      "created_at": "2020-03-27T23:41:54Z",
       "link": "https://access.redhat.com/security/cve/CVE-2019-17450",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2019-17450"
+      "feed_group": "rhel:7"
+    },
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "curl",
       "pkg_path": "pkgdb",
+      "version": "7.29.0-59.el7",
+      "cpe23": "None",
       "pkg_type": "rpm",
-      "version": "7.29.0-59.el7"
+      "cpe": "None"
     },
     "fixes": [
       {
+        "wont_fix": false,
         "observed_at": "2020-11-11T09:10:27Z",
-        "version": "0:7.29.0-59.el7_9.1",
-        "wont_fix": false
+        "version": "0:7.29.0-59.el7_9.1"
       }
     ],
-    "match": {
-      "detected_at": "2021-05-04T06:22:33Z"
-    },
     "vulnerability": {
-      "created_at": "2020-06-27T09:10:53Z",
+      "cvss_scores_vendor": [],
+      "severity": "Medium",
+      "description": "NA",
+      "vulnerability_id": "CVE-2020-8177",
+      "last_modified": "2020-08-04T09:10:43Z",
+      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
-          "cvss_v2": {
-            "base_score": 4.6,
-            "exploitability_score": 3.9,
-            "impact_score": 6.4
-          },
           "cvss_v3": {
+            "impact_score": 5.2,
             "base_score": 7.1,
-            "exploitability_score": 1.8,
-            "impact_score": 5.2
+            "exploitability_score": 1.8
+          },
+          "cvss_v2": {
+            "impact_score": 6.4,
+            "base_score": 4.6,
+            "exploitability_score": 3.9
           },
           "id": "CVE-2020-8177"
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "last_modified": "2020-08-04T09:10:43Z",
+      "created_at": "2020-06-27T09:10:53Z",
       "link": "https://access.redhat.com/security/cve/CVE-2020-8177",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2020-8177"
+      "feed_group": "rhel:7"
+    },
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "glibc",
       "pkg_path": "pkgdb",
+      "version": "2.17-323.el7_9",
+      "cpe23": "None",
       "pkg_type": "rpm",
-      "version": "2.17-323.el7_9"
+      "cpe": "None"
     },
     "fixes": [
       {
+        "wont_fix": false,
         "observed_at": null,
-        "version": "None",
-        "wont_fix": false
+        "version": "None"
       }
     ],
-    "match": {
-      "detected_at": "2021-05-04T06:22:33Z"
-    },
     "vulnerability": {
-      "created_at": "2020-03-27T23:42:55Z",
+      "cvss_scores_vendor": [],
+      "severity": "Low",
+      "description": "NA",
+      "vulnerability_id": "CVE-2014-4043",
+      "last_modified": "2020-03-27T23:42:55Z",
+      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
-          "cvss_v2": {
-            "base_score": 7.5,
-            "exploitability_score": 10.0,
-            "impact_score": 6.4
-          },
           "cvss_v3": {
+            "impact_score": -1.0,
             "base_score": -1.0,
-            "exploitability_score": -1.0,
-            "impact_score": -1.0
+            "exploitability_score": -1.0
+          },
+          "cvss_v2": {
+            "impact_score": 6.4,
+            "base_score": 7.5,
+            "exploitability_score": 10.0
           },
           "id": "CVE-2014-4043"
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "last_modified": "2020-03-27T23:42:55Z",
+      "created_at": "2020-03-27T23:42:55Z",
       "link": "https://access.redhat.com/security/cve/CVE-2014-4043",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2014-4043"
+      "feed_group": "rhel:7"
+    },
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "glibc-common",
       "pkg_path": "pkgdb",
+      "version": "2.17-323.el7_9",
+      "cpe23": "None",
       "pkg_type": "rpm",
-      "version": "2.17-323.el7_9"
+      "cpe": "None"
     },
     "fixes": [
       {
+        "wont_fix": false,
         "observed_at": null,
-        "version": "None",
-        "wont_fix": false
+        "version": "None"
       }
     ],
-    "match": {
-      "detected_at": "2021-05-04T06:22:33Z"
-    },
     "vulnerability": {
-      "created_at": "2020-03-27T23:42:55Z",
+      "cvss_scores_vendor": [],
+      "severity": "Low",
+      "description": "NA",
+      "vulnerability_id": "CVE-2014-4043",
+      "last_modified": "2020-03-27T23:42:55Z",
+      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
-          "cvss_v2": {
-            "base_score": 7.5,
-            "exploitability_score": 10.0,
-            "impact_score": 6.4
-          },
           "cvss_v3": {
+            "impact_score": -1.0,
             "base_score": -1.0,
-            "exploitability_score": -1.0,
-            "impact_score": -1.0
+            "exploitability_score": -1.0
+          },
+          "cvss_v2": {
+            "impact_score": 6.4,
+            "base_score": 7.5,
+            "exploitability_score": 10.0
           },
           "id": "CVE-2014-4043"
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "last_modified": "2020-03-27T23:42:55Z",
+      "created_at": "2020-03-27T23:42:55Z",
       "link": "https://access.redhat.com/security/cve/CVE-2014-4043",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2014-4043"
+      "feed_group": "rhel:7"
+    },
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "gnupg2",
       "pkg_path": "pkgdb",
+      "version": "2.0.22-5.el7_5",
+      "cpe23": "None",
       "pkg_type": "rpm",
-      "version": "2.0.22-5.el7_5"
+      "cpe": "None"
     },
     "fixes": [
       {
+        "wont_fix": false,
         "observed_at": null,
-        "version": "None",
-        "wont_fix": false
+        "version": "None"
       }
     ],
-    "match": {
-      "detected_at": "2021-05-04T06:22:33Z"
-    },
     "vulnerability": {
-      "created_at": "2020-03-27T23:42:51Z",
+      "cvss_scores_vendor": [],
+      "severity": "Low",
+      "description": "NA",
+      "vulnerability_id": "CVE-2014-3591",
+      "last_modified": "2020-03-27T23:42:51Z",
+      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
-          "cvss_v2": {
-            "base_score": 1.9,
-            "exploitability_score": 3.4,
-            "impact_score": 2.9
-          },
           "cvss_v3": {
+            "impact_score": 3.6,
             "base_score": 4.2,
-            "exploitability_score": 0.5,
-            "impact_score": 3.6
+            "exploitability_score": 0.5
+          },
+          "cvss_v2": {
+            "impact_score": 2.9,
+            "base_score": 1.9,
+            "exploitability_score": 3.4
           },
           "id": "CVE-2014-3591"
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "last_modified": "2020-03-27T23:42:51Z",
+      "created_at": "2020-03-27T23:42:51Z",
       "link": "https://access.redhat.com/security/cve/CVE-2014-3591",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2014-3591"
+      "feed_group": "rhel:7"
+    },
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "gnupg2",
       "pkg_path": "pkgdb",
+      "version": "2.0.22-5.el7_5",
+      "cpe23": "None",
       "pkg_type": "rpm",
-      "version": "2.0.22-5.el7_5"
+      "cpe": "None"
     },
     "fixes": [
       {
+        "wont_fix": false,
         "observed_at": null,
-        "version": "None",
-        "wont_fix": false
+        "version": "None"
       }
     ],
-    "match": {
-      "detected_at": "2021-05-04T06:22:33Z"
-    },
     "vulnerability": {
-      "created_at": "2020-03-27T23:42:00Z",
+      "cvss_scores_vendor": [],
+      "severity": "Medium",
+      "description": "NA",
+      "vulnerability_id": "CVE-2014-4617",
+      "last_modified": "2020-03-27T23:42:00Z",
+      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
-          "cvss_v2": {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9
-          },
           "cvss_v3": {
+            "impact_score": -1.0,
             "base_score": -1.0,
-            "exploitability_score": -1.0,
-            "impact_score": -1.0
+            "exploitability_score": -1.0
+          },
+          "cvss_v2": {
+            "impact_score": 2.9,
+            "base_score": 5.0,
+            "exploitability_score": 10.0
           },
           "id": "CVE-2014-4617"
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "last_modified": "2020-03-27T23:42:00Z",
+      "created_at": "2020-03-27T23:42:00Z",
       "link": "https://access.redhat.com/security/cve/CVE-2014-4617",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2014-4617"
+      "feed_group": "rhel:7"
+    },
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "guava",
       "pkg_path": "/sandbox/target/my-app-1.jar:guava",
+      "version": "23.0",
+      "cpe23": "None",
       "pkg_type": "java",
-      "version": "23.0"
+      "cpe": "None"
     },
     "fixes": [
       {
+        "wont_fix": false,
         "observed_at": "2021-03-31T17:30:52Z",
-        "version": "30.0-jre",
-        "wont_fix": false
+        "version": "30.0-jre"
       }
     ],
-    "match": {
-      "detected_at": "2021-05-04T06:22:33Z"
-    },
     "vulnerability": {
-      "created_at": "2021-03-31T17:30:52Z",
+      "cvss_scores_vendor": [],
+      "severity": "Medium",
+      "description": "NA",
+      "vulnerability_id": "GHSA-5mg8-w23w-74h3",
+      "last_modified": "2021-03-31T17:30:52Z",
+      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
-          "cvss_v2": {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9
-          },
           "cvss_v3": {
+            "impact_score": 1.4,
             "base_score": 3.3,
-            "exploitability_score": 1.8,
-            "impact_score": 1.4
+            "exploitability_score": 1.8
+          },
+          "cvss_v2": {
+            "impact_score": 2.9,
+            "base_score": 2.1,
+            "exploitability_score": 3.9
           },
           "id": "CVE-2020-8908"
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "github:java",
-      "last_modified": "2021-03-31T17:30:52Z",
+      "created_at": "2021-03-31T17:30:52Z",
       "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
-      "severity": "Medium",
-      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
+      "feed_group": "github:java"
+    },
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "guava",
       "pkg_path": "/sandbox/target/my-app-1.jar:guava",
+      "version": "23.0",
+      "cpe23": "None",
       "pkg_type": "java",
-      "version": "23.0"
+      "cpe": "None"
     },
     "fixes": [
       {
+        "wont_fix": false,
         "observed_at": "2020-06-16T09:10:15Z",
-        "version": "24.1.1-jre",
-        "wont_fix": false
+        "version": "24.1.1-jre"
       }
     ],
-    "match": {
-      "detected_at": "2021-05-04T06:22:33Z"
-    },
     "vulnerability": {
-      "created_at": "2020-06-16T09:10:15Z",
+      "cvss_scores_vendor": [],
+      "severity": "Medium",
+      "description": "NA",
+      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j",
+      "last_modified": "2020-06-16T09:10:15Z",
+      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
-          "cvss_v2": {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9
-          },
           "cvss_v3": {
+            "impact_score": 3.6,
             "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6
+            "exploitability_score": 2.2
+          },
+          "cvss_v2": {
+            "impact_score": 2.9,
+            "base_score": 4.3,
+            "exploitability_score": 8.6
           },
           "id": "CVE-2018-10237"
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "github:java",
-      "last_modified": "2020-06-16T09:10:15Z",
+      "created_at": "2020-06-16T09:10:15Z",
       "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
-      "severity": "Medium",
-      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
+      "feed_group": "github:java"
+    },
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "guava",
       "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
+      "version": "23.0",
+      "cpe23": "None",
       "pkg_type": "java",
-      "version": "23.0"
+      "cpe": "None"
     },
     "fixes": [
       {
+        "wont_fix": false,
         "observed_at": "2021-03-31T17:30:52Z",
-        "version": "30.0-jre",
-        "wont_fix": false
+        "version": "30.0-jre"
       }
     ],
-    "match": {
-      "detected_at": "2021-05-04T06:22:33Z"
-    },
     "vulnerability": {
-      "created_at": "2021-03-31T17:30:52Z",
+      "cvss_scores_vendor": [],
+      "severity": "Medium",
+      "description": "NA",
+      "vulnerability_id": "GHSA-5mg8-w23w-74h3",
+      "last_modified": "2021-03-31T17:30:52Z",
+      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
-          "cvss_v2": {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9
-          },
           "cvss_v3": {
+            "impact_score": 1.4,
             "base_score": 3.3,
-            "exploitability_score": 1.8,
-            "impact_score": 1.4
+            "exploitability_score": 1.8
+          },
+          "cvss_v2": {
+            "impact_score": 2.9,
+            "base_score": 2.1,
+            "exploitability_score": 3.9
           },
           "id": "CVE-2020-8908"
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "github:java",
-      "last_modified": "2021-03-31T17:30:52Z",
+      "created_at": "2021-03-31T17:30:52Z",
       "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
-      "severity": "Medium",
-      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
+      "feed_group": "github:java"
+    },
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "guava",
       "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
+      "version": "23.0",
+      "cpe23": "None",
       "pkg_type": "java",
-      "version": "23.0"
+      "cpe": "None"
     },
     "fixes": [
       {
+        "wont_fix": false,
         "observed_at": "2020-06-16T09:10:15Z",
-        "version": "24.1.1-jre",
-        "wont_fix": false
+        "version": "24.1.1-jre"
       }
     ],
-    "match": {
-      "detected_at": "2021-05-04T06:22:33Z"
-    },
     "vulnerability": {
-      "created_at": "2020-06-16T09:10:15Z",
+      "cvss_scores_vendor": [],
+      "severity": "Medium",
+      "description": "NA",
+      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j",
+      "last_modified": "2020-06-16T09:10:15Z",
+      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
-          "cvss_v2": {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9
-          },
           "cvss_v3": {
+            "impact_score": 3.6,
             "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6
+            "exploitability_score": 2.2
+          },
+          "cvss_v2": {
+            "impact_score": 2.9,
+            "base_score": 4.3,
+            "exploitability_score": 8.6
           },
           "id": "CVE-2018-10237"
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "github:java",
-      "last_modified": "2020-06-16T09:10:15Z",
+      "created_at": "2020-06-16T09:10:15Z",
       "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
-      "severity": "Medium",
-      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
+      "feed_group": "github:java"
+    },
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "libcom_err",
       "pkg_path": "pkgdb",
+      "version": "1.42.9-19.el7",
+      "cpe23": "None",
       "pkg_type": "rpm",
-      "version": "1.42.9-19.el7"
+      "cpe": "None"
     },
     "fixes": [
       {
+        "wont_fix": false,
         "observed_at": null,
-        "version": "None",
-        "wont_fix": false
+        "version": "None"
       }
     ],
-    "match": {
-      "detected_at": "2021-05-04T06:22:33Z"
-    },
     "vulnerability": {
-      "created_at": "2020-03-27T23:41:42Z",
+      "cvss_scores_vendor": [],
+      "severity": "Medium",
+      "description": "NA",
+      "vulnerability_id": "CVE-2015-0247",
+      "last_modified": "2020-03-27T23:41:42Z",
+      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
-          "cvss_v2": {
-            "base_score": 4.6,
-            "exploitability_score": 3.9,
-            "impact_score": 6.4
-          },
           "cvss_v3": {
+            "impact_score": -1.0,
             "base_score": -1.0,
-            "exploitability_score": -1.0,
-            "impact_score": -1.0
+            "exploitability_score": -1.0
+          },
+          "cvss_v2": {
+            "impact_score": 6.4,
+            "base_score": 4.6,
+            "exploitability_score": 3.9
           },
           "id": "CVE-2015-0247"
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "last_modified": "2020-03-27T23:41:42Z",
+      "created_at": "2020-03-27T23:41:42Z",
       "link": "https://access.redhat.com/security/cve/CVE-2015-0247",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2015-0247"
+      "feed_group": "rhel:7"
+    },
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "libcurl",
       "pkg_path": "pkgdb",
+      "version": "7.29.0-59.el7",
+      "cpe23": "None",
       "pkg_type": "rpm",
-      "version": "7.29.0-59.el7"
+      "cpe": "None"
     },
     "fixes": [
       {
+        "wont_fix": false,
         "observed_at": "2020-11-11T09:10:27Z",
-        "version": "0:7.29.0-59.el7_9.1",
-        "wont_fix": false
+        "version": "0:7.29.0-59.el7_9.1"
       }
     ],
-    "match": {
-      "detected_at": "2021-05-04T06:22:33Z"
-    },
     "vulnerability": {
-      "created_at": "2020-06-27T09:10:53Z",
+      "cvss_scores_vendor": [],
+      "severity": "Medium",
+      "description": "NA",
+      "vulnerability_id": "CVE-2020-8177",
+      "last_modified": "2020-08-04T09:10:43Z",
+      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
-          "cvss_v2": {
-            "base_score": 4.6,
-            "exploitability_score": 3.9,
-            "impact_score": 6.4
-          },
           "cvss_v3": {
+            "impact_score": 5.2,
             "base_score": 7.1,
-            "exploitability_score": 1.8,
-            "impact_score": 5.2
+            "exploitability_score": 1.8
+          },
+          "cvss_v2": {
+            "impact_score": 6.4,
+            "base_score": 4.6,
+            "exploitability_score": 3.9
           },
           "id": "CVE-2020-8177"
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "last_modified": "2020-08-04T09:10:43Z",
+      "created_at": "2020-06-27T09:10:53Z",
       "link": "https://access.redhat.com/security/cve/CVE-2020-8177",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2020-8177"
+      "feed_group": "rhel:7"
+    },
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "libgcrypt",
       "pkg_path": "pkgdb",
+      "version": "1.5.3-14.el7",
+      "cpe23": "None",
       "pkg_type": "rpm",
-      "version": "1.5.3-14.el7"
+      "cpe": "None"
     },
     "fixes": [
       {
+        "wont_fix": false,
         "observed_at": null,
-        "version": "None",
-        "wont_fix": false
+        "version": "None"
       }
     ],
-    "match": {
-      "detected_at": "2021-05-04T06:22:33Z"
-    },
     "vulnerability": {
-      "created_at": "2020-03-27T23:42:51Z",
+      "cvss_scores_vendor": [],
+      "severity": "Low",
+      "description": "NA",
+      "vulnerability_id": "CVE-2014-3591",
+      "last_modified": "2020-03-27T23:42:51Z",
+      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
-          "cvss_v2": {
-            "base_score": 1.9,
-            "exploitability_score": 3.4,
-            "impact_score": 2.9
-          },
           "cvss_v3": {
+            "impact_score": 3.6,
             "base_score": 4.2,
-            "exploitability_score": 0.5,
-            "impact_score": 3.6
+            "exploitability_score": 0.5
+          },
+          "cvss_v2": {
+            "impact_score": 2.9,
+            "base_score": 1.9,
+            "exploitability_score": 3.4
           },
           "id": "CVE-2014-3591"
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "last_modified": "2020-03-27T23:42:51Z",
+      "created_at": "2020-03-27T23:42:51Z",
       "link": "https://access.redhat.com/security/cve/CVE-2014-3591",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2014-3591"
+      "feed_group": "rhel:7"
+    },
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "libgcrypt",
       "pkg_path": "pkgdb",
+      "version": "1.5.3-14.el7",
+      "cpe23": "None",
       "pkg_type": "rpm",
-      "version": "1.5.3-14.el7"
+      "cpe": "None"
     },
     "fixes": [
       {
+        "wont_fix": false,
         "observed_at": null,
-        "version": "None",
-        "wont_fix": false
+        "version": "None"
       }
     ],
-    "match": {
-      "detected_at": "2021-05-04T06:22:33Z"
-    },
     "vulnerability": {
-      "created_at": "2020-03-27T23:43:09Z",
+      "cvss_scores_vendor": [],
+      "severity": "Medium",
+      "description": "NA",
+      "vulnerability_id": "CVE-2014-5270",
+      "last_modified": "2020-03-27T23:43:09Z",
+      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
-          "cvss_v2": {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9
-          },
           "cvss_v3": {
+            "impact_score": -1.0,
             "base_score": -1.0,
-            "exploitability_score": -1.0,
-            "impact_score": -1.0
+            "exploitability_score": -1.0
+          },
+          "cvss_v2": {
+            "impact_score": 2.9,
+            "base_score": 2.1,
+            "exploitability_score": 3.9
           },
           "id": "CVE-2014-5270"
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "last_modified": "2020-03-27T23:43:09Z",
+      "created_at": "2020-03-27T23:43:09Z",
       "link": "https://access.redhat.com/security/cve/CVE-2014-5270",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2014-5270"
+      "feed_group": "rhel:7"
+    },
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "libidn",
       "pkg_path": "pkgdb",
+      "version": "1.28-4.el7",
+      "cpe23": "None",
       "pkg_type": "rpm",
-      "version": "1.28-4.el7"
+      "cpe": "None"
     },
     "fixes": [
       {
+        "wont_fix": false,
         "observed_at": null,
-        "version": "None",
-        "wont_fix": false
+        "version": "None"
       }
     ],
-    "match": {
-      "detected_at": "2021-05-04T06:22:33Z"
-    },
     "vulnerability": {
-      "created_at": "2020-03-27T23:42:41Z",
+      "cvss_scores_vendor": [],
+      "severity": "Low",
+      "description": "NA",
+      "vulnerability_id": "CVE-2015-2059",
+      "last_modified": "2020-03-27T23:42:41Z",
+      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
-          "cvss_v2": {
-            "base_score": 7.5,
-            "exploitability_score": 10.0,
-            "impact_score": 6.4
-          },
           "cvss_v3": {
+            "impact_score": -1.0,
             "base_score": -1.0,
-            "exploitability_score": -1.0,
-            "impact_score": -1.0
+            "exploitability_score": -1.0
+          },
+          "cvss_v2": {
+            "impact_score": 6.4,
+            "base_score": 7.5,
+            "exploitability_score": 10.0
           },
           "id": "CVE-2015-2059"
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "last_modified": "2020-03-27T23:42:41Z",
+      "created_at": "2020-03-27T23:42:41Z",
       "link": "https://access.redhat.com/security/cve/CVE-2015-2059",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2015-2059"
+      "feed_group": "rhel:7"
+    },
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "nss",
       "pkg_path": "pkgdb",
+      "version": "3.53.1-3.el7_9",
+      "cpe23": "None",
       "pkg_type": "rpm",
-      "version": "3.53.1-3.el7_9"
+      "cpe": "None"
     },
     "fixes": [
       {
+        "wont_fix": false,
         "observed_at": null,
-        "version": "None",
-        "wont_fix": false
+        "version": "None"
       }
     ],
-    "match": {
-      "detected_at": "2021-05-04T06:22:33Z"
-    },
     "vulnerability": {
-      "created_at": "2020-05-21T09:09:26Z",
+      "cvss_scores_vendor": [],
+      "severity": "Medium",
+      "description": "NA",
+      "vulnerability_id": "CVE-2020-12399",
+      "last_modified": "2020-05-21T09:09:26Z",
+      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
-          "cvss_v2": {
-            "base_score": 1.2,
-            "exploitability_score": 1.9,
-            "impact_score": 2.9
-          },
           "cvss_v3": {
+            "impact_score": 3.6,
             "base_score": 4.4,
-            "exploitability_score": 0.8,
-            "impact_score": 3.6
+            "exploitability_score": 0.8
+          },
+          "cvss_v2": {
+            "impact_score": 2.9,
+            "base_score": 1.2,
+            "exploitability_score": 1.9
           },
           "id": "CVE-2020-12399"
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "last_modified": "2020-05-21T09:09:26Z",
+      "created_at": "2020-05-21T09:09:26Z",
       "link": "https://access.redhat.com/security/cve/CVE-2020-12399",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2020-12399"
+      "feed_group": "rhel:7"
+    },
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "nss",
       "pkg_path": "pkgdb",
+      "version": "3.53.1-3.el7_9",
+      "cpe23": "None",
       "pkg_type": "rpm",
-      "version": "3.53.1-3.el7_9"
+      "cpe": "None"
     },
     "fixes": [
       {
+        "wont_fix": false,
         "observed_at": null,
-        "version": "None",
-        "wont_fix": false
+        "version": "None"
       }
     ],
-    "match": {
-      "detected_at": "2021-05-04T06:22:33Z"
-    },
     "vulnerability": {
-      "created_at": "2020-10-20T09:10:21Z",
+      "cvss_scores_vendor": [],
+      "severity": "Medium",
+      "description": "NA",
+      "vulnerability_id": "CVE-2020-25648",
+      "last_modified": "2020-10-20T09:10:21Z",
+      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
-          "cvss_v2": {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9
-          },
           "cvss_v3": {
+            "impact_score": 3.6,
             "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6
+            "exploitability_score": 3.9
+          },
+          "cvss_v2": {
+            "impact_score": 2.9,
+            "base_score": 5.0,
+            "exploitability_score": 10.0
           },
           "id": "CVE-2020-25648"
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "last_modified": "2020-10-20T09:10:21Z",
+      "created_at": "2020-10-20T09:10:21Z",
       "link": "https://access.redhat.com/security/cve/CVE-2020-25648",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2020-25648"
+      "feed_group": "rhel:7"
+    },
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "nss-sysinit",
       "pkg_path": "pkgdb",
+      "version": "3.53.1-3.el7_9",
+      "cpe23": "None",
       "pkg_type": "rpm",
-      "version": "3.53.1-3.el7_9"
+      "cpe": "None"
     },
     "fixes": [
       {
+        "wont_fix": false,
         "observed_at": null,
-        "version": "None",
-        "wont_fix": false
+        "version": "None"
       }
     ],
-    "match": {
-      "detected_at": "2021-05-04T06:22:33Z"
-    },
     "vulnerability": {
-      "created_at": "2020-05-21T09:09:26Z",
+      "cvss_scores_vendor": [],
+      "severity": "Medium",
+      "description": "NA",
+      "vulnerability_id": "CVE-2020-12399",
+      "last_modified": "2020-05-21T09:09:26Z",
+      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
-          "cvss_v2": {
-            "base_score": 1.2,
-            "exploitability_score": 1.9,
-            "impact_score": 2.9
-          },
           "cvss_v3": {
+            "impact_score": 3.6,
             "base_score": 4.4,
-            "exploitability_score": 0.8,
-            "impact_score": 3.6
+            "exploitability_score": 0.8
+          },
+          "cvss_v2": {
+            "impact_score": 2.9,
+            "base_score": 1.2,
+            "exploitability_score": 1.9
           },
           "id": "CVE-2020-12399"
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "last_modified": "2020-05-21T09:09:26Z",
+      "created_at": "2020-05-21T09:09:26Z",
       "link": "https://access.redhat.com/security/cve/CVE-2020-12399",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2020-12399"
+      "feed_group": "rhel:7"
+    },
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "nss-sysinit",
       "pkg_path": "pkgdb",
+      "version": "3.53.1-3.el7_9",
+      "cpe23": "None",
       "pkg_type": "rpm",
-      "version": "3.53.1-3.el7_9"
+      "cpe": "None"
     },
     "fixes": [
       {
+        "wont_fix": false,
         "observed_at": null,
-        "version": "None",
-        "wont_fix": false
+        "version": "None"
       }
     ],
-    "match": {
-      "detected_at": "2021-05-04T06:22:33Z"
-    },
     "vulnerability": {
-      "created_at": "2020-10-20T09:10:21Z",
+      "cvss_scores_vendor": [],
+      "severity": "Medium",
+      "description": "NA",
+      "vulnerability_id": "CVE-2020-25648",
+      "last_modified": "2020-10-20T09:10:21Z",
+      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
-          "cvss_v2": {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9
-          },
           "cvss_v3": {
+            "impact_score": 3.6,
             "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6
+            "exploitability_score": 3.9
+          },
+          "cvss_v2": {
+            "impact_score": 2.9,
+            "base_score": 5.0,
+            "exploitability_score": 10.0
           },
           "id": "CVE-2020-25648"
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "last_modified": "2020-10-20T09:10:21Z",
+      "created_at": "2020-10-20T09:10:21Z",
       "link": "https://access.redhat.com/security/cve/CVE-2020-25648",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2020-25648"
+      "feed_group": "rhel:7"
+    },
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "nss-tools",
       "pkg_path": "pkgdb",
+      "version": "3.53.1-3.el7_9",
+      "cpe23": "None",
       "pkg_type": "rpm",
-      "version": "3.53.1-3.el7_9"
+      "cpe": "None"
     },
     "fixes": [
       {
+        "wont_fix": false,
         "observed_at": null,
-        "version": "None",
-        "wont_fix": false
+        "version": "None"
       }
     ],
-    "match": {
-      "detected_at": "2021-05-04T06:22:33Z"
-    },
     "vulnerability": {
-      "created_at": "2020-05-21T09:09:26Z",
+      "cvss_scores_vendor": [],
+      "severity": "Medium",
+      "description": "NA",
+      "vulnerability_id": "CVE-2020-12399",
+      "last_modified": "2020-05-21T09:09:26Z",
+      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
-          "cvss_v2": {
-            "base_score": 1.2,
-            "exploitability_score": 1.9,
-            "impact_score": 2.9
-          },
           "cvss_v3": {
+            "impact_score": 3.6,
             "base_score": 4.4,
-            "exploitability_score": 0.8,
-            "impact_score": 3.6
+            "exploitability_score": 0.8
+          },
+          "cvss_v2": {
+            "impact_score": 2.9,
+            "base_score": 1.2,
+            "exploitability_score": 1.9
           },
           "id": "CVE-2020-12399"
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "last_modified": "2020-05-21T09:09:26Z",
+      "created_at": "2020-05-21T09:09:26Z",
       "link": "https://access.redhat.com/security/cve/CVE-2020-12399",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2020-12399"
+      "feed_group": "rhel:7"
+    },
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "nss-tools",
       "pkg_path": "pkgdb",
+      "version": "3.53.1-3.el7_9",
+      "cpe23": "None",
       "pkg_type": "rpm",
-      "version": "3.53.1-3.el7_9"
+      "cpe": "None"
     },
     "fixes": [
       {
+        "wont_fix": false,
         "observed_at": null,
-        "version": "None",
-        "wont_fix": false
+        "version": "None"
       }
     ],
-    "match": {
-      "detected_at": "2021-05-04T06:22:33Z"
-    },
     "vulnerability": {
-      "created_at": "2020-10-20T09:10:21Z",
+      "cvss_scores_vendor": [],
+      "severity": "Medium",
+      "description": "NA",
+      "vulnerability_id": "CVE-2020-25648",
+      "last_modified": "2020-10-20T09:10:21Z",
+      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
-          "cvss_v2": {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9
-          },
           "cvss_v3": {
+            "impact_score": 3.6,
             "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6
+            "exploitability_score": 3.9
+          },
+          "cvss_v2": {
+            "impact_score": 2.9,
+            "base_score": 5.0,
+            "exploitability_score": 10.0
           },
           "id": "CVE-2020-25648"
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "last_modified": "2020-10-20T09:10:21Z",
+      "created_at": "2020-10-20T09:10:21Z",
       "link": "https://access.redhat.com/security/cve/CVE-2020-25648",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2020-25648"
+      "feed_group": "rhel:7"
+    },
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "openldap",
       "pkg_path": "pkgdb",
+      "version": "2.4.44-22.el7",
+      "cpe23": "None",
       "pkg_type": "rpm",
-      "version": "2.4.44-22.el7"
+      "cpe": "None"
     },
     "fixes": [
       {
+        "wont_fix": false,
         "observed_at": null,
-        "version": "None",
-        "wont_fix": false
+        "version": "None"
       }
     ],
-    "match": {
-      "detected_at": "2021-05-04T06:22:33Z"
-    },
     "vulnerability": {
-      "created_at": "2020-11-07T09:10:34Z",
+      "cvss_scores_vendor": [],
+      "severity": "Medium",
+      "description": "NA",
+      "vulnerability_id": "CVE-2020-25692",
+      "last_modified": "2020-12-10T09:15:58Z",
+      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
-          "cvss_v2": {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9
-          },
           "cvss_v3": {
+            "impact_score": 3.6,
             "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6
+            "exploitability_score": 3.9
+          },
+          "cvss_v2": {
+            "impact_score": 2.9,
+            "base_score": 5.0,
+            "exploitability_score": 10.0
           },
           "id": "CVE-2020-25692"
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "last_modified": "2020-12-10T09:15:58Z",
+      "created_at": "2020-11-07T09:10:34Z",
       "link": "https://access.redhat.com/security/cve/CVE-2020-25692",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2020-25692"
+      "feed_group": "rhel:7"
+    },
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "openssl-libs",
       "pkg_path": "pkgdb",
+      "version": "1.0.2k-19.el7",
+      "cpe23": "None",
       "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
+      "cpe": "None"
     },
     "fixes": [
       {
+        "wont_fix": false,
         "observed_at": "2020-12-19T09:16:55Z",
-        "version": "1:1.0.2k-21.el7_9",
-        "wont_fix": false
+        "version": "1:1.0.2k-21.el7_9"
       }
     ],
-    "match": {
-      "detected_at": "2021-05-04T06:22:33Z"
-    },
     "vulnerability": {
-      "created_at": "2020-12-09T09:16:50Z",
+      "cvss_scores_vendor": [],
+      "severity": "High",
+      "description": "NA",
+      "vulnerability_id": "CVE-2020-1971",
+      "last_modified": "2020-12-09T09:16:50Z",
+      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
-          "cvss_v2": {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9
-          },
           "cvss_v3": {
+            "impact_score": 3.6,
             "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6
+            "exploitability_score": 2.2
+          },
+          "cvss_v2": {
+            "impact_score": 2.9,
+            "base_score": 4.3,
+            "exploitability_score": 8.6
           },
           "id": "CVE-2020-1971"
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "last_modified": "2020-12-09T09:16:50Z",
+      "created_at": "2020-12-09T09:16:50Z",
       "link": "https://access.redhat.com/security/cve/CVE-2020-1971",
-      "severity": "High",
-      "vulnerability_id": "CVE-2020-1971"
+      "feed_group": "rhel:7"
+    },
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "openssl-libs",
       "pkg_path": "pkgdb",
+      "version": "1.0.2k-19.el7",
+      "cpe23": "None",
       "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
+      "cpe": "None"
     },
     "fixes": [
       {
+        "wont_fix": false,
         "observed_at": null,
-        "version": "None",
-        "wont_fix": false
+        "version": "None"
       }
     ],
-    "match": {
-      "detected_at": "2021-05-04T06:22:33Z"
-    },
     "vulnerability": {
-      "created_at": "2021-03-31T17:05:26Z",
+      "cvss_scores_vendor": [],
+      "severity": "Medium",
+      "description": "NA",
+      "vulnerability_id": "CVE-2021-23840",
+      "last_modified": "2021-03-31T17:05:26Z",
+      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
-          "cvss_v2": {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9
-          },
           "cvss_v3": {
+            "impact_score": 3.6,
             "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6
+            "exploitability_score": 3.9
+          },
+          "cvss_v2": {
+            "impact_score": 2.9,
+            "base_score": 5.0,
+            "exploitability_score": 10.0
           },
           "id": "CVE-2021-23840"
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "last_modified": "2021-03-31T17:05:26Z",
+      "created_at": "2021-03-31T17:05:26Z",
       "link": "https://access.redhat.com/security/cve/CVE-2021-23840",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2021-23840"
+      "feed_group": "rhel:7"
+    },
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "openssl-libs",
       "pkg_path": "pkgdb",
+      "version": "1.0.2k-19.el7",
+      "cpe23": "None",
       "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
+      "cpe": "None"
     },
     "fixes": [
       {
+        "wont_fix": false,
         "observed_at": null,
-        "version": "None",
-        "wont_fix": false
+        "version": "None"
       }
     ],
-    "match": {
-      "detected_at": "2021-05-04T06:22:33Z"
-    },
     "vulnerability": {
-      "created_at": "2021-03-31T17:05:26Z",
+      "cvss_scores_vendor": [],
+      "severity": "Medium",
+      "description": "NA",
+      "vulnerability_id": "CVE-2021-23841",
+      "last_modified": "2021-03-31T17:05:26Z",
+      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
-          "cvss_v2": {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9
-          },
           "cvss_v3": {
+            "impact_score": 3.6,
             "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6
+            "exploitability_score": 2.2
+          },
+          "cvss_v2": {
+            "impact_score": 2.9,
+            "base_score": 4.3,
+            "exploitability_score": 8.6
           },
           "id": "CVE-2021-23841"
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "last_modified": "2021-03-31T17:05:26Z",
+      "created_at": "2021-03-31T17:05:26Z",
       "link": "https://access.redhat.com/security/cve/CVE-2021-23841",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2021-23841"
+      "feed_group": "rhel:7"
+    },
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "python",
       "pkg_path": "pkgdb",
+      "version": "2.7.5-89.el7",
+      "cpe23": "None",
       "pkg_type": "rpm",
-      "version": "2.7.5-89.el7"
+      "cpe": "None"
     },
     "fixes": [
       {
+        "wont_fix": false,
         "observed_at": "2020-11-11T09:10:28Z",
-        "version": "0:2.7.5-90.el7",
-        "wont_fix": false
+        "version": "0:2.7.5-90.el7"
       }
     ],
-    "match": {
-      "detected_at": "2021-05-04T06:22:33Z"
-    },
     "vulnerability": {
-      "created_at": "2020-07-14T09:11:04Z",
+      "cvss_scores_vendor": [],
+      "severity": "Medium",
+      "description": "NA",
+      "vulnerability_id": "CVE-2019-20907",
+      "last_modified": "2020-07-15T09:10:41Z",
+      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
-          "cvss_v2": {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9
-          },
           "cvss_v3": {
+            "impact_score": 3.6,
             "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6
+            "exploitability_score": 3.9
+          },
+          "cvss_v2": {
+            "impact_score": 2.9,
+            "base_score": 5.0,
+            "exploitability_score": 10.0
           },
           "id": "CVE-2019-20907"
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "last_modified": "2020-07-15T09:10:41Z",
+      "created_at": "2020-07-14T09:11:04Z",
       "link": "https://access.redhat.com/security/cve/CVE-2019-20907",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2019-20907"
+      "feed_group": "rhel:7"
+    },
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "python-libs",
       "pkg_path": "pkgdb",
+      "version": "2.7.5-89.el7",
+      "cpe23": "None",
       "pkg_type": "rpm",
-      "version": "2.7.5-89.el7"
+      "cpe": "None"
     },
     "fixes": [
       {
+        "wont_fix": false,
         "observed_at": "2020-11-11T09:10:28Z",
-        "version": "0:2.7.5-90.el7",
-        "wont_fix": false
+        "version": "0:2.7.5-90.el7"
       }
     ],
-    "match": {
-      "detected_at": "2021-05-04T06:22:33Z"
-    },
     "vulnerability": {
-      "created_at": "2020-07-14T09:11:04Z",
+      "cvss_scores_vendor": [],
+      "severity": "Medium",
+      "description": "NA",
+      "vulnerability_id": "CVE-2019-20907",
+      "last_modified": "2020-07-15T09:10:41Z",
+      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
-          "cvss_v2": {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9
-          },
           "cvss_v3": {
+            "impact_score": 3.6,
             "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6
+            "exploitability_score": 3.9
+          },
+          "cvss_v2": {
+            "impact_score": 2.9,
+            "base_score": 5.0,
+            "exploitability_score": 10.0
           },
           "id": "CVE-2019-20907"
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "last_modified": "2020-07-15T09:10:41Z",
+      "created_at": "2020-07-14T09:11:04Z",
       "link": "https://access.redhat.com/security/cve/CVE-2019-20907",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2019-20907"
+      "feed_group": "rhel:7"
+    },
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "xmldom",
       "pkg_path": "/root/.npm/xmldom/0.4.0/package/package.json",
+      "version": "0.4.0",
+      "cpe23": "None",
       "pkg_type": "npm",
-      "version": "0.4.0"
+      "cpe": "None"
     },
     "fixes": [
       {
+        "wont_fix": false,
         "observed_at": "2021-03-31T17:30:47Z",
-        "version": "0.5.0",
-        "wont_fix": false
+        "version": "0.5.0"
       }
     ],
-    "match": {
-      "detected_at": "2021-05-04T06:22:33Z"
-    },
     "vulnerability": {
-      "created_at": "2021-03-31T17:30:47Z",
+      "cvss_scores_vendor": [],
+      "severity": "Low",
+      "description": "NA",
+      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv",
+      "last_modified": "2021-03-31T17:30:47Z",
+      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
-          "cvss_v2": {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9
-          },
           "cvss_v3": {
+            "impact_score": 1.4,
             "base_score": 4.3,
-            "exploitability_score": 2.8,
-            "impact_score": 1.4
+            "exploitability_score": 2.8
+          },
+          "cvss_v2": {
+            "impact_score": 2.9,
+            "base_score": 4.3,
+            "exploitability_score": 8.6
           },
           "id": "CVE-2021-21366"
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "github:npm",
-      "last_modified": "2021-03-31T17:30:47Z",
+      "created_at": "2021-03-31T17:30:47Z",
       "link": "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv",
-      "severity": "Low",
-      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv"
+      "feed_group": "github:npm"
+    },
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
       "name": "xmldom",
       "pkg_path": "/sandbox/node_modules/xmldom/package.json",
+      "version": "0.4.0",
+      "cpe23": "None",
       "pkg_type": "npm",
-      "version": "0.4.0"
+      "cpe": "None"
     },
     "fixes": [
       {
+        "wont_fix": false,
         "observed_at": "2021-03-31T17:30:47Z",
-        "version": "0.5.0",
-        "wont_fix": false
+        "version": "0.5.0"
       }
     ],
-    "match": {
-      "detected_at": "2021-05-04T06:22:33Z"
-    },
     "vulnerability": {
-      "created_at": "2021-03-31T17:30:47Z",
+      "cvss_scores_vendor": [],
+      "severity": "Low",
+      "description": "NA",
+      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv",
+      "last_modified": "2021-03-31T17:30:47Z",
+      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
-          "cvss_v2": {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9
-          },
           "cvss_v3": {
+            "impact_score": 1.4,
             "base_score": 4.3,
-            "exploitability_score": 2.8,
-            "impact_score": 1.4
+            "exploitability_score": 2.8
+          },
+          "cvss_v2": {
+            "impact_score": 2.9,
+            "base_score": 4.3,
+            "exploitability_score": 8.6
           },
           "id": "CVE-2021-21366"
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "vulnerabilities",
-      "feed_group": "github:npm",
-      "last_modified": "2021-03-31T17:30:47Z",
+      "created_at": "2021-03-31T17:30:47Z",
       "link": "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv",
-      "severity": "Low",
-      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv"
+      "feed_group": "github:npm"
+    },
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
     "artifact": {
-      "cpe": "cpe:a:ftpd:ftpd:0.2.1:*:*",
-      "cpe23": "cpe:2.3:a:ftpd:ftpd:0.2.1:*:-:-:-:-:-:*",
       "name": "ftpd",
       "pkg_path": "/usr/local/share/gems/specifications/ftpd-0.2.1.gemspec",
+      "version": "0.2.1",
+      "cpe23": "cpe:2.3:a:ftpd:ftpd:0.2.1:*:-:-:-:-:-:*",
       "pkg_type": "gem",
-      "version": "0.2.1"
+      "cpe": "cpe:a:ftpd:ftpd:0.2.1:*:*"
     },
     "fixes": [],
-    "match": {
-      "detected_at": "2021-03-31T17:11:12Z"
-    },
     "vulnerability": {
-      "created_at": "2021-03-31T17:11:12Z",
+      "cvss_scores_vendor": [],
+      "severity": "Critical",
+      "description": "NA",
+      "vulnerability_id": "CVE-2013-2512",
+      "last_modified": "2021-03-31T17:11:12Z",
+      "feed": "nvdv2",
       "cvss_scores_nvd": [
         {
-          "cvss_v2": {
-            "base_score": 10.0,
-            "exploitability_score": 10.0,
-            "impact_score": 10.0
-          },
           "cvss_v3": {
+            "impact_score": 5.9,
             "base_score": 9.8,
-            "exploitability_score": 3.9,
-            "impact_score": 5.9
+            "exploitability_score": 3.9
+          },
+          "cvss_v2": {
+            "impact_score": 10.0,
+            "base_score": 10.0,
+            "exploitability_score": 10.0
           },
           "id": "CVE-2013-2512"
         }
       ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "nvdv2",
-      "feed_group": "nvdv2:cves",
-      "last_modified": "2021-03-31T17:11:12Z",
+      "created_at": "2021-03-31T17:11:12Z",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
-      "severity": "Critical",
-      "vulnerability_id": "CVE-2013-2512"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "cpe:a:python-aiohttp:aiohttp:3.7.3:*:*",
-      "cpe23": "cpe:2.3:a:python-aiohttp:aiohttp:3.7.3:*:-:-:-:-:-:*",
-      "name": "aiohttp",
-      "pkg_path": "/usr/local/lib64/python3.6/site-packages/aiohttp",
-      "pkg_type": "python",
-      "version": "3.7.3"
+      "feed_group": "nvdv2:cves"
     },
-    "fixes": [],
     "match": {
-      "detected_at": "2021-03-31T17:29:49Z"
-    },
-    "vulnerability": {
-      "created_at": "2021-03-31T17:29:49Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 5.8,
-            "exploitability_score": 8.6,
-            "impact_score": 4.9
-          },
-          "cvss_v3": {
-            "base_score": 6.1,
-            "exploitability_score": 2.8,
-            "impact_score": 2.7
-          },
-          "id": "CVE-2021-21330"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "nvdv2",
-      "feed_group": "nvdv2:cves",
-      "last_modified": "2021-03-31T17:29:49Z",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21330",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2021-21330"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "cpe:a:guava:guava:23.0:*:*",
-      "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*",
-      "name": "guava",
-      "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fixes": [],
-    "match": {
-      "detected_at": "2021-03-31T17:25:26Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-28T02:59:42Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6
-          },
-          "id": "CVE-2018-10237"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "nvdv2",
-      "feed_group": "nvdv2:cves",
-      "last_modified": "2021-03-31T17:25:26Z",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2018-10237"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "cpe:a:guava:guava:23.0:*:*",
-      "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*",
-      "name": "guava",
-      "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fixes": [],
-    "match": {
-      "detected_at": "2021-03-31T17:24:25Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-12-12T09:17:33Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 3.3,
-            "exploitability_score": 1.8,
-            "impact_score": 1.4
-          },
-          "id": "CVE-2020-8908"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "nvdv2",
-      "feed_group": "nvdv2:cves",
-      "last_modified": "2021-03-31T17:24:25Z",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2020-8908"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "cpe:a:guava:guava:23.0:*:*",
-      "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*",
-      "name": "guava",
-      "pkg_path": "/sandbox/target/my-app-1.jar:guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fixes": [],
-    "match": {
-      "detected_at": "2021-03-31T17:25:26Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-03-28T02:59:42Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6
-          },
-          "id": "CVE-2018-10237"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "nvdv2",
-      "feed_group": "nvdv2:cves",
-      "last_modified": "2021-03-31T17:25:26Z",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2018-10237"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "cpe:a:guava:guava:23.0:*:*",
-      "cpe23": "cpe:2.3:a:guava:guava:23.0:*:-:-:-:-:-:*",
-      "name": "guava",
-      "pkg_path": "/sandbox/target/my-app-1.jar:guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fixes": [],
-    "match": {
-      "detected_at": "2021-03-31T17:24:25Z"
-    },
-    "vulnerability": {
-      "created_at": "2020-12-12T09:17:33Z",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v2": {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9
-          },
-          "cvss_v3": {
-            "base_score": 3.3,
-            "exploitability_score": 1.8,
-            "impact_score": 1.4
-          },
-          "id": "CVE-2020-8908"
-        }
-      ],
-      "cvss_scores_vendor": [],
-      "description": "NA",
-      "feed": "nvdv2",
-      "feed_group": "nvdv2:cves",
-      "last_modified": "2021-03-31T17:24:25Z",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2020-8908"
+      "detected_at": "2021-03-31T17:11:12Z"
     }
   }
 ]

--- a/tests/unit/anchore_engine/services/policy_engine/engine/vulnerabilities/test_deduper.py
+++ b/tests/unit/anchore_engine/services/policy_engine/engine/vulnerabilities/test_deduper.py
@@ -1,0 +1,573 @@
+import pytest
+
+from anchore_engine.services.policy_engine.api.models import (
+    VulnerabilityMatch,
+    Vulnerability,
+    Artifact,
+    CvssCombined,
+)
+from anchore_engine.services.policy_engine.engine.vulns.dedup import (
+    ImageVulnerabilitiesDeduplicator,
+    VulnerabilityIdentity,
+    RankedVulnerabilityMatch,
+    FeedGroupRank,
+)
+
+
+class TestFeedGroupRank:
+    @pytest.mark.parametrize(
+        "test_group, expected_rank",
+        [
+            pytest.param("nvdv2:cves", 1, id="nvdv2"),
+            pytest.param("github:java", 10, id="github"),
+            pytest.param("alpine:3.9", 100, id="os-distro"),
+            pytest.param("foobar", 100, id="random"),
+        ],
+    )
+    def test_get(self, test_group, expected_rank):
+        assert FeedGroupRank().get(test_group) == expected_rank
+
+
+class TestVulnerabilityIdentity:
+    @pytest.mark.parametrize(
+        "test_input",
+        [
+            pytest.param(
+                [CvssCombined(id="CVE-abc")],
+                id="single-cvss",
+            ),
+            pytest.param(
+                [
+                    CvssCombined(id="CVE-abc"),
+                    CvssCombined(id="CVE-def"),
+                    CvssCombined(id="CVE-ghi"),
+                ],
+                id="multiple-cvss",
+            ),
+        ],
+    )
+    def test_from_with_cvss(self, test_input):
+        match = VulnerabilityMatch(
+            artifact=Artifact(
+                name="blah",
+                pkg_path="/usr/local/java/blah",
+                pkg_type="java",
+                version="1.2.3maven",
+            ),
+            vulnerability=Vulnerability(
+                feed="vulnerabilities",
+                feed_group="whatever:hello",
+                vulnerability_id="meh",
+                cvss_scores_nvd=test_input,
+            ),
+        )
+        identity_objects = VulnerabilityIdentity.from_match(match)
+
+        assert identity_objects
+        assert isinstance(identity_objects, list) and len(identity_objects) == len(
+            test_input
+        )
+        for identity_object, input_cvss in zip(identity_objects, test_input):
+            assert identity_object.vuln_id == input_cvss.id
+            assert identity_object.pkg_name == match.artifact.name
+            assert identity_object.pkg_type == match.artifact.pkg_type
+            assert identity_object.pkg_version == match.artifact.version
+            assert identity_object.pkg_path == match.artifact.pkg_path
+
+    def test_from_no_cvss(self):
+        match = VulnerabilityMatch(
+            artifact=Artifact(
+                name="blah",
+                pkg_path="/usr/local/java/blah",
+                pkg_type="java",
+                version="1.2.3maven",
+            ),
+            vulnerability=Vulnerability(
+                feed="vulnerabilities",
+                feed_group="whatever:hello",
+                vulnerability_id="meh",
+                cvss_scores_nvd=[],
+            ),
+        )
+        identity_objects = VulnerabilityIdentity.from_match(match)
+
+        assert identity_objects
+        assert isinstance(identity_objects, list) and len(identity_objects) == 1
+
+        identity_object = identity_objects[0]
+        assert identity_object.vuln_id == match.vulnerability.vulnerability_id
+        assert identity_object.pkg_name == match.artifact.name
+        assert identity_object.pkg_type == match.artifact.pkg_type
+        assert identity_object.pkg_version == match.artifact.version
+        assert identity_object.pkg_path == match.artifact.pkg_path
+
+    @pytest.mark.parametrize(
+        "lhs, rhs, expected",
+        [
+            pytest.param(
+                Vulnerability(
+                    feed="trusty",
+                    feed_group="trusty:chameleon",
+                    vulnerability_id="meh",
+                    cvss_scores_nvd=[CvssCombined(id="CVE-abc")],
+                ),
+                Vulnerability(
+                    feed="hedgehog",
+                    feed_group="hedgy:thorny",
+                    vulnerability_id="foo",
+                    cvss_scores_nvd=[CvssCombined(id="CVE-abc")],
+                ),
+                True,
+                id="equal-different-namespaces",
+            ),
+            pytest.param(
+                Vulnerability(
+                    feed="trusty",
+                    feed_group="trusty:chameleon",
+                    vulnerability_id="meh",
+                    cvss_scores_nvd=[
+                        CvssCombined(id="CVE-abc"),
+                        CvssCombined(id="CVE-def"),
+                        CvssCombined(id="CVE-ghi"),
+                    ],
+                ),
+                Vulnerability(
+                    feed="hedgehog",
+                    feed_group="hedgy:thorny",
+                    vulnerability_id="foo",
+                    cvss_scores_nvd=[
+                        CvssCombined(id="CVE-abc"),
+                        CvssCombined(id="CVE-def"),
+                        CvssCombined(id="CVE-ghi"),
+                    ],
+                ),
+                True,
+                id="equal-multiple-cvss",
+            ),
+            pytest.param(
+                Vulnerability(
+                    feed="trusty",
+                    feed_group="trusty:chameleon",
+                    vulnerability_id="meh",
+                    cvss_scores_nvd=[CvssCombined(id="CVE-abc")],
+                ),
+                Vulnerability(
+                    feed="hedgehog",
+                    feed_group="hedgy:thorny",
+                    vulnerability_id="foo",
+                    cvss_scores_nvd=[CvssCombined(id="CVE-def")],
+                ),
+                False,
+                id="not-equal",
+            ),
+        ],
+    )
+    def test_equality_constant_artifact(self, lhs, rhs, expected):
+        artifact = Artifact(
+            name="blah",
+            pkg_path="/usr/local/java/blah",
+            pkg_type="java",
+            version="1.2.3maven",
+        )
+        lhs_record = VulnerabilityMatch(
+            artifact=artifact,
+            vulnerability=lhs,
+        )
+
+        rhs_record = VulnerabilityMatch(
+            artifact=artifact,
+            vulnerability=rhs,
+        )
+
+        assert (
+            VulnerabilityIdentity.from_match(lhs_record)
+            == VulnerabilityIdentity.from_match(rhs_record)
+        ) == expected
+
+    @pytest.mark.parametrize("count", [1, 2, 3, 4, 5])
+    def test_hash(self, count):
+        record = VulnerabilityIdentity(
+            vuln_id="meh",
+            pkg_name="blah",
+            pkg_version="1.2.3maven",
+            pkg_type="java",
+            pkg_path="blah",
+        )
+
+        test_input = [record for x in range(count)]
+        result = set(test_input)
+        assert result and len(result) == 1
+
+
+class TestRankedVulnerabilityMatch:
+    def test_from(self):
+        match = VulnerabilityMatch(
+            artifact=Artifact(
+                name="blah",
+                pkg_path="/usr/local/java/blah",
+                pkg_type="java",
+                version="1.2.3maven",
+            ),
+            vulnerability=Vulnerability(
+                feed="vulnerabilities",
+                feed_group="whatever:hello",
+                vulnerability_id="meh",
+                cvss_scores_nvd=[CvssCombined(id="CVE-abc")],
+            ),
+        )
+        rank_strategy = FeedGroupRank()
+        ranked_match = RankedVulnerabilityMatch.from_match(match, FeedGroupRank())
+
+        assert ranked_match
+        assert ranked_match.vuln_id == match.vulnerability.vulnerability_id
+        assert ranked_match.vuln_namespace == match.vulnerability.feed_group
+        assert ranked_match.pkg_name == match.artifact.name
+        assert ranked_match.pkg_type == match.artifact.pkg_type
+        assert ranked_match.pkg_version == match.artifact.version
+        assert ranked_match.pkg_path == match.artifact.pkg_path
+        assert ranked_match.rank == rank_strategy.__default__
+
+    @pytest.mark.parametrize(
+        "lhs, rhs, expected",
+        [
+            pytest.param(
+                Vulnerability(
+                    feed="trusty",
+                    feed_group="trusty:chameleon",
+                    vulnerability_id="meh",
+                    cvss_scores_nvd=[CvssCombined(id="CVE-abc")],
+                ),
+                Vulnerability(
+                    feed="hedgehog",
+                    feed_group="hedgy:thorny",
+                    vulnerability_id="foo",
+                    cvss_scores_nvd=[CvssCombined(id="CVE-abc")],
+                ),
+                False,
+                id="not-equal-different-ids",
+            ),
+            pytest.param(
+                Vulnerability(
+                    feed="trusty",
+                    feed_group="trusty:chameleon",
+                    vulnerability_id="meh",
+                    cvss_scores_nvd=[
+                        CvssCombined(id="CVE-abc"),
+                        CvssCombined(id="CVE-def"),
+                        CvssCombined(id="CVE-ghi"),
+                    ],
+                ),
+                Vulnerability(
+                    feed="trusty",
+                    feed_group="trusty:chameleon",
+                    vulnerability_id="meh",
+                    cvss_scores_nvd=[
+                        CvssCombined(id="CVE-abc"),
+                    ],
+                ),
+                True,
+                id="equal-different-cvss",
+            ),
+            pytest.param(
+                Vulnerability(
+                    feed="trusty",
+                    feed_group="trusty:chameleon",
+                    vulnerability_id="meh",
+                    cvss_scores_nvd=[CvssCombined(id="CVE-abc")],
+                ),
+                Vulnerability(
+                    feed="trusty",
+                    feed_group="trusty:python",
+                    vulnerability_id="meh",
+                    cvss_scores_nvd=[CvssCombined(id="CVE-abc")],
+                ),
+                False,
+                id="not-equal-different-namespaces",
+            ),
+        ],
+    )
+    def test_equality_constant_artifact(self, lhs, rhs, expected):
+        artifact = Artifact(
+            name="blah",
+            pkg_path="/usr/local/java/blah",
+            pkg_type="java",
+            version="1.2.3maven",
+        )
+        lhs_record = VulnerabilityMatch(
+            artifact=artifact,
+            vulnerability=lhs,
+        )
+
+        rhs_record = VulnerabilityMatch(
+            artifact=artifact,
+            vulnerability=rhs,
+        )
+
+        assert (
+            RankedVulnerabilityMatch.from_match(lhs_record, FeedGroupRank())
+            == RankedVulnerabilityMatch.from_match(rhs_record, FeedGroupRank())
+        ) == expected
+
+    @pytest.mark.parametrize("count", [1, 2, 3, 4, 5])
+    def test_hash_empty_match(self, count):
+        record = RankedVulnerabilityMatch(
+            vuln_id="meh",
+            vuln_namespace="trusty:chameleon",
+            pkg_name="blah",
+            pkg_version="1.2.3maven",
+            pkg_type="java",
+            pkg_path="blah",
+            rank=100,
+            match_obj=VulnerabilityMatch(),
+        )
+
+        test_input = [record for x in range(count)]
+        result = set(test_input)
+        assert result and len(result) == 1
+
+    @pytest.mark.parametrize(
+        "test_input",
+        [
+            pytest.param(
+                [
+                    VulnerabilityMatch(
+                        artifact=Artifact(
+                            name="blah",
+                            pkg_path="/usr/local/java/blah",
+                            pkg_type="java",
+                            version="1.2.3maven",
+                        ),
+                        vulnerability=Vulnerability(
+                            feed="twisty",
+                            feed_group="twisty:python",
+                            vulnerability_id="meh",
+                            cvss_scores_nvd=[CvssCombined(id="CVE-abc")],
+                        ),
+                    ),
+                    VulnerabilityMatch(
+                        artifact=Artifact(
+                            name="foo",
+                            pkg_path="/usr/local/java/foo",
+                            pkg_type="unknown",
+                            version="1.2.3",
+                        ),
+                        vulnerability=Vulnerability(
+                            feed="tricky",
+                            feed_group="tricky:chameleon",
+                            vulnerability_id="meh",
+                            cvss_scores_nvd=[CvssCombined(id="CVE-def")],
+                        ),
+                    ),
+                ],
+                id="different-matches",
+            ),
+            pytest.param(
+                [
+                    VulnerabilityMatch(
+                        artifact=Artifact(
+                            name="blah",
+                            pkg_path="/usr/local/java/blah",
+                            pkg_type="java",
+                            version="1.2.3maven",
+                        ),
+                        vulnerability=Vulnerability(
+                            feed="twisty",
+                            feed_group="twisty:python",
+                            vulnerability_id="meh",
+                            cvss_scores_nvd=[CvssCombined(id="CVE-abc")],
+                        ),
+                    ),
+                ]
+                * 3,
+                id="same-matches",
+            ),
+        ],
+    )
+    def test_hash(self, test_input):
+        vuln_rank_objects = [
+            RankedVulnerabilityMatch(
+                vuln_id="meh",
+                vuln_namespace="trusty:chameleon",
+                pkg_name="blah",
+                pkg_version="1.2.3maven",
+                pkg_type="java",
+                pkg_path="/usr/local/blah",
+                rank=100,
+                match_obj=item,
+            )
+            for item in test_input
+        ]
+        result = set(vuln_rank_objects)
+        assert result and len(result) == 1
+
+        result = list(result)[0]
+        assert result.vuln_id == "meh"
+        assert result.vuln_namespace == "trusty:chameleon"
+        assert result.pkg_name == "blah"
+        assert result.pkg_type == "java"
+        assert result.pkg_path == "/usr/local/blah"
+        assert result.rank == 100
+
+
+class TestImageVulnerabilitiesDeduplicator:
+    @pytest.mark.parametrize(
+        "test_input, expected_index",
+        [
+            pytest.param(
+                [
+                    Vulnerability(
+                        feed="vulnerabilities",
+                        feed_group="nvdv2:cves",
+                        vulnerability_id="CVE-2019-12904",
+                        cvss_scores_nvd=[CvssCombined(id="CVE-2019-12904")],
+                    ),
+                    Vulnerability(
+                        feed="vulnerabilities",
+                        feed_group="ubuntu:20.04",
+                        vulnerability_id="CVE-2019-12904",
+                        cvss_scores_nvd=[CvssCombined(id="CVE-2019-12904")],
+                    ),
+                ],
+                1,
+                id="different-namespaces",
+            ),
+            pytest.param(
+                [
+                    Vulnerability(
+                        feed="vulnerabilities",
+                        feed_group="nvdv2:cves",
+                        vulnerability_id="CVE-2019-12904",
+                        cvss_scores_nvd=[CvssCombined(id="CVE-2019-12904")],
+                    ),
+                    Vulnerability(
+                        feed="vulnerabilities",
+                        feed_group="github:java",
+                        vulnerability_id="GHSA-foobar",
+                        cvss_scores_nvd=[CvssCombined(id="CVE-2019-12904")],
+                    ),
+                ],
+                1,
+                id="different-identifiers",
+            ),
+            pytest.param(
+                [
+                    Vulnerability(
+                        feed="vulnerabilities",
+                        feed_group="github:java",
+                        vulnerability_id="GHSA-foobar",
+                        cvss_scores_nvd=[CvssCombined(id="CVE-2019-12904")],
+                    ),
+                    Vulnerability(
+                        feed="vulnerabilities",
+                        feed_group="ubuntu:20.04",
+                        vulnerability_id="CVE-2019-12904",
+                        cvss_scores_nvd=[CvssCombined(id="CVE-2019-12904")],
+                    ),
+                ],
+                1,
+                id="non-nvd-namespaces",
+            ),
+            pytest.param(
+                [
+                    Vulnerability(
+                        feed="vulnerabilities",
+                        feed_group="nvdv2:cves",
+                        vulnerability_id="CVE-2019-12904",
+                        cvss_scores_nvd=[CvssCombined(id="CVE-2019-12904")],
+                    ),
+                    Vulnerability(
+                        feed="vulnerabilities",
+                        feed_group="ubuntu:20.04",
+                        vulnerability_id="CVE-2019-12904",
+                        cvss_scores_nvd=[],
+                    ),
+                ],
+                1,
+                id="no-nvd-refs",
+            ),
+            pytest.param(
+                [
+                    Vulnerability(
+                        feed="vulnerabilities",
+                        feed_group="nvdv2:cves",
+                        vulnerability_id="CVE-2019-12904",
+                        cvss_scores_nvd=[CvssCombined(id="CVE-2019-12345")],
+                    ),
+                    Vulnerability(
+                        feed="vulnerabilities",
+                        feed_group="nvdv2:cves",
+                        vulnerability_id="CVE-2019-12904",
+                        cvss_scores_nvd=[CvssCombined(id="CVE-2019-12904")],
+                    ),
+                    Vulnerability(
+                        feed="vulnerabilities",
+                        feed_group="github:java",
+                        vulnerability_id="GHSA-foobar",
+                        cvss_scores_nvd=[
+                            CvssCombined(id="CVE-2019-12904"),
+                            CvssCombined(id="CVE-2019-12345"),
+                        ],
+                    ),
+                ],
+                2,
+                id="multiple-nvd-refs",
+            ),
+        ],
+    )
+    def test_execute(self, test_input, expected_index):
+        matches_input = [
+            VulnerabilityMatch(
+                artifact=Artifact(
+                    name="blah",
+                    pkg_path="/usr/local/java/blah",
+                    pkg_type="java",
+                    version="1.2.3maven",
+                ),
+                vulnerability=item,
+            )
+            for item in test_input
+        ]
+
+        results = ImageVulnerabilitiesDeduplicator(FeedGroupRank()).execute(
+            matches_input
+        )
+        assert len(results) == 1
+
+        actual = results[0].vulnerability
+        expected = test_input[expected_index]
+        assert actual.vulnerability_id == expected.vulnerability_id
+        assert actual.feed_group == expected.feed_group
+
+    @pytest.mark.parametrize("count", [1, 2, 3, 4, 5])
+    def test_execute_absolute_duplicates(self, count):
+        a = VulnerabilityMatch(
+            artifact=Artifact(
+                name="blah",
+                pkg_path="/usr/local/java/blah",
+                pkg_type="java",
+                version="1.2.3maven",
+            ),
+            vulnerability=Vulnerability(
+                feed="vulnerabilities",
+                feed_group="whatever:hello",
+                vulnerability_id="meh",
+                cvss_scores_nvd=[CvssCombined(id="CVE-2019-12904")],
+            ),
+        )
+
+        input_matches = [a for x in range(count)]
+
+        results = ImageVulnerabilitiesDeduplicator(FeedGroupRank()).execute(
+            input_matches
+        )
+        assert len(results) == 1
+
+    @pytest.mark.parametrize(
+        "test_input",
+        [pytest.param([], id="empty-list"), pytest.param(None, id="none")],
+    )
+    def test_execute_invalid_input(self, test_input):
+        assert (
+            ImageVulnerabilitiesDeduplicator(FeedGroupRank()).execute(test_input)
+            == list()
+        )


### PR DESCRIPTION
This PR re-introduces deduping vulnerabilities that was skipped in the refactor PR #1000 One main difference with this addition is the where the dedup is performed. It was originally in external API and slightly differing variants sprinkled through out the system (policy eval, other services). This update fixes the issue by moving the dedup to get-image-vulnerabilities path - this guarantees every client gets the same information without the dedup know-how. Added some unit tests as well