### PR TITLE
Ensure python38 used in the Dockerfile build, and set tox tests to py38

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex && \
 RUN set -ex && \
     echo "installing OS dependencies" && \
     yum update -y && \
+    yum module disable -y python36 && yum module enable -y python38 && \
     yum install -y gcc make python38 git python38-wheel python38-devel go
 
 # create anchore binaries
@@ -147,6 +148,7 @@ EXPOSE ${ANCHORE_SERVICE_PORT}
 
 RUN set -ex && \
     yum update -y && \
+    yum module disable -y python36 && yum module enable -y python38 && \
     yum install -y python38 python38-wheel procps psmisc
 
 # Setup container default configs and directories

--- a/scripts/ci/Dockerfile.functional
+++ b/scripts/ci/Dockerfile.functional
@@ -6,7 +6,7 @@ USER root
 RUN set -ex && \
     echo "installing OS dependencies" && \
     yum update -y && \
-    yum install -y gcc make git python3-wheel python36-devel python38-devel
+    yum install -y gcc make git python3-wheel python38-devel
 
 ENV DOCKERVERSION=18.03.1-ce
 RUN curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKERVERSION}.tgz \

--- a/scripts/ci/Dockerfile.functional
+++ b/scripts/ci/Dockerfile.functional
@@ -6,7 +6,7 @@ USER root
 RUN set -ex && \
     echo "installing OS dependencies" && \
     yum update -y && \
-    yum install -y gcc make git python3-wheel python38-devel
+    yum install -y gcc make git python38-wheel python38-devel
 
 ENV DOCKERVERSION=18.03.1-ce
 RUN curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKERVERSION}.tgz \

--- a/tests/functional/local.env
+++ b/tests/functional/local.env
@@ -13,4 +13,4 @@ export ANCHORE_CLI_URL=http://localhost:8228/v1
 export ANCHORE_CLI_USER=admin
 export ANCHORE_CLI_PASS=foobar
 export ANCHORE_TEST_DB_URL=postgresql://postgres:mysecretpassword@localhost:5432/postgres
-export TOX_ENV=py36
+export TOX_ENV=py38

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py38
+envlist = py38
 
 [testenv]
 deps=


### PR DESCRIPTION
Fixes #1025 by updating Dockefile and tox.ini to force python 3.8 use