### PR TITLE
fix checksum bug in grype_wrapper::get_current_grype_db_checksum()

### DIFF
--- a/anchore_engine/clients/grype_wrapper.py
+++ b/anchore_engine/clients/grype_wrapper.py
@@ -34,9 +34,9 @@ def get_current_grype_db_checksum():
     """
     Return the checksum for the in-use version of grype db
     """
-    checksums = os.listdir(_get_grype_db_dir())
-    if checksums:
-        grype_db_checksum = checksums[0]
+    grype_db_dir = _get_grype_db_dir()
+    if grype_db_dir and os.path.exists(grype_db_dir):
+        grype_db_checksum = os.path.basename(grype_db_dir)
     else:
         grype_db_checksum = None
     logger.info("Returning current grype_db checksum: {}".format(grype_db_checksum))


### PR DESCRIPTION
Signed-off-by: Vijay Pillai <vijay.pillai@anchore.com>

Fix for issue where checksum returned by grype_wrapper::get_current_grype_db_checksum() is db file name, not checksum

Instead return name of parent dir, which is the name of the extracted tar file, which is the listing.json checksum

based on https://github.com/anchore/anchore-engine/commit/876e1b078ba63b7ff28a079f8816f3861a316196

<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**:


**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #:

**Special notes**:


