### PR TITLE
Removes Dead Code from ImageLoader

### DIFF
--- a/anchore_engine/services/policy_engine/engine/loaders.py
+++ b/anchore_engine/services/policy_engine/engine/loaders.py
@@ -280,20 +280,6 @@ class ImageLoader(object):
 
         return True
 
-        # records = []
-        # for pkg_name, paths in packages.items():
-        #
-        #     r = AnalysisArtifact()
-        #     r.image_user_id = image_obj.user_id
-        #     r.image_id = image_obj.id
-        #     r.analyzer_type = 'base'
-        #     r.analyzer_id = 'file_package_verify'
-        #     r.analyzer_artifact = 'distro.pkgfilemeta'
-        #     r.artifact_key = pkg_name
-        #     r.json_value = paths
-        #     records.append(r)
-        # return records
-
     def load_retrieved_files(self, analysis_report, image_obj):
         """
         Loads the analyzer retrieved files from the image, saves them in the db


### PR DESCRIPTION
Inside the ImageLoader.load_package_verification method at the very
end near the return statement was 13 lines of code commented out with
no explanation as to why they needed to stay.

This patch removes those 13 lines of unused and undocumented code.

Closes: ENTERPRISE-309

Signed-off-by: Ryan Brady <ryan.brady@anchore.com>

<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**:


**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #:

**Special notes**:


