### PR TITLE
Update logic in grypedb sync manager

### DIFF
--- a/anchore_engine/clients/grype_wrapper.py
+++ b/anchore_engine/clients/grype_wrapper.py
@@ -377,7 +377,10 @@ class GrypeWrapperSingleton(object):
 
             # Store the dir and session variables globally
             # For use during reads and to remove in the next update
-            old_grype_db_dir = self._grype_db_dir
+            try:
+                old_grype_db_dir = self._grype_db_dir
+            except ValueError:
+                old_grype_db_dir = None
             self._grype_db_dir = latest_grype_db_dir
             self._grype_db_session_maker = latest_grype_db_session_maker
 

--- a/anchore_engine/services/policy_engine/engine/feeds/grypedb_sync.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/grypedb_sync.py
@@ -117,7 +117,11 @@ class GrypeDBSyncManager:
         rtype: str
         """
         # get local grypedb checksum
-        return GrypeWrapperSingleton.get_instance().get_current_grype_db_checksum()
+        # Wrapper raises ValueError if grypedb has not been initialized
+        try:
+            return GrypeWrapperSingleton.get_instance().get_current_grype_db_checksum()
+        except ValueError:
+            return None
 
     @classmethod
     def _update_grypedb(

--- a/anchore_engine/services/policy_engine/engine/feeds/grypedb_sync.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/grypedb_sync.py
@@ -1,7 +1,8 @@
 import threading
-from dataclasses import dataclass
 from types import TracebackType
-from typing import Iterable, Optional, Type
+from typing import Optional, Type
+
+import sqlalchemy
 
 from anchore_engine.clients.grype_wrapper import GrypeWrapperSingleton
 from anchore_engine.clients.services import internal_client_for
@@ -13,7 +14,7 @@ from anchore_engine.services.policy_engine.engine.feeds.storage import (
 )
 from anchore_engine.subsys import logger
 
-LOCK_AQUISITION_TIMEOUT = 10
+LOCK_AQUISITION_TIMEOUT = 60
 
 
 class GrypeDBSyncError(Exception):
@@ -24,6 +25,13 @@ class TooManyActiveGrypeDBs(GrypeDBSyncError):
     def __init__(self):
         super().__init__(
             "Could not determine correct grypedb to sync because too many active dbs found in database"
+        )
+
+
+class NoActiveGrypeDB(GrypeDBSyncError):
+    def __init__(self):
+        super().__init__(
+            "Could not determine correct grypedb to sync because no active db found in the database"
         )
 
 
@@ -64,39 +72,41 @@ class GrypeDBSyncManager:
 
     lock = threading.Lock()
 
-    @dataclass
-    class SyncNecessaryResp:
-        sync_necessary: bool
-        active_grypedb: Optional[GrypeDBMetadata] = None
-
     @classmethod
-    def _get_active_grypedb(cls) -> Optional[GrypeDBMetadata]:
+    def _get_active_grypedb(cls) -> GrypeDBMetadata:
         """
-        Returns active grybdb instance from db. Returns None if there are none and raises exception if more than one
+        Returns active grypedb instance from db. Raises NoActiveGrypeDB if there are none and raises
+        TooManyActiveGrypeDBs if more than one
 
-        return: Instance of active GrypeDBMetadata or None
-        rtype: [GrypeDBMetadata, None]
+        return: Active GrypeDBMetadata
+        rtype: GrypeDBMetadata
         """
-        active_grypedbs = cls._query_active_dbs()
-
-        if len(active_grypedbs) == 0:
-            return None
-        elif len(active_grypedbs) > 1:
-            logger.exception("Too many active grypdbs found in db")
+        try:
+            active_grypedb = cls._query_active_dbs()
+        except sqlalchemy.orm.exc.MultipleResultsFound:
+            logger.error("Too many active grype dbs found in db")
             raise TooManyActiveGrypeDBs
-        else:
-            return active_grypedbs[0]
+
+        if not active_grypedb:
+            logger.error("No active grype db found in the database")
+            raise NoActiveGrypeDB
+
+        return active_grypedb
 
     @classmethod
-    def _query_active_dbs(cls) -> Iterable[GrypeDBMetadata]:
+    def _query_active_dbs(cls) -> Optional[GrypeDBMetadata]:
         """
-        Runs query against db to get active dbs
+        Runs query against db to get active dbs. Uses one_or_none so raises error if more than one active db
 
-        return: Array of GrypeDBMetadatas
-        rtype: list
+        return: Instance of GrypeDBMetadata or None
+        rtype: GrypeDBMetadata
         """
         db = get_thread_scoped_session()
-        return db.query(GrypeDBMetadata).filter(GrypeDBMetadata.active == True).all()
+        return (
+            db.query(GrypeDBMetadata)
+            .filter(GrypeDBMetadata.active == True)
+            .one_or_none()
+        )
 
     @classmethod
     def _get_local_grypedb_checksum(cls) -> str:
@@ -108,38 +118,6 @@ class GrypeDBSyncManager:
         """
         # get local grypedb checksum
         return GrypeWrapperSingleton.get_instance().get_current_grype_db_checksum()
-
-    @classmethod
-    def _get_active_grypedb_if_sync_necessary(cls) -> Optional[GrypeDBMetadata]:
-        """
-        Return the GrypeDBMetadata for the currently active GrypeDB IF a sync is necessary. Return None otherwise.
-        :return: GrypeDBMetadata if sync is necessary or None if sync is not necessary
-        :rtype: Optional[GrypeDBMetadata]
-        """
-        active_grypedb = cls._get_active_grypedb()
-        if active_grypedb:
-            if cls._check_sync_necessary(active_grypedb.checksum):
-                return active_grypedb
-        return None
-
-    @classmethod
-    def _check_sync_necessary(cls, active_grypedb_checksum: str) -> bool:
-        """
-        Check if a sync is necessary
-
-        :param active_grypedb_checksum: Checksum of currently active Grype DB
-        :type active_grypedb_checksum: str
-        :return: true if sync is necessary, false if not
-        :rtype: bool
-        """
-        local_grypedb_checksum = cls._get_local_grypedb_checksum()
-        sync_needed = local_grypedb_checksum != active_grypedb_checksum
-        if not sync_needed:
-            logger.info("No Grype DB sync needed at this time")
-        else:
-            logger.info("Grype DB sync is required.")
-
-        return sync_needed
 
     @classmethod
     def _update_grypedb(
@@ -173,6 +151,22 @@ class GrypeDBSyncManager:
             logger.exception("GrypeDBSyncTask failed to sync")
             raise GrypeDBSyncError(str(e)) from e
 
+    @staticmethod
+    def _is_sync_necessary(
+        active_grypedb: GrypeDBMetadata, local_grypedb_checksum: str
+    ) -> bool:
+        """
+        Returns bool based upon comparisons between the active grype db and the local checksum passed to the function
+        """
+        if (
+            not active_grypedb.checksum
+            or local_grypedb_checksum == active_grypedb.checksum
+        ):
+            logger.info("No Grype DB sync needed at this time")
+            return False
+
+        return True
+
     @classmethod
     def run_grypedb_sync(cls, grypedb_file_path: Optional[str] = None):
         """
@@ -185,11 +179,29 @@ class GrypeDBSyncManager:
         """
         # Do an initial check outside of lock to determine if sync is necessary
         # Helps ensure that synchronous processes are not slowed by lock
-        if not cls._get_active_grypedb_if_sync_necessary():
+        active_grypedb = cls._get_active_grypedb()
+        local_grypedb_checksum = cls._get_local_grypedb_checksum()
+        is_sync_necessary = cls._is_sync_necessary(
+            active_grypedb, local_grypedb_checksum
+        )
+        if not is_sync_necessary:
             return False
+
         with GrypeDBSyncLock(LOCK_AQUISITION_TIMEOUT):
-            active_grypedb = cls._get_active_grypedb_if_sync_necessary()
-            if active_grypedb:
+            # Need to requery and recheck the active an local checksums because data may have changed since waiting
+            # on lock
+            active_grypedb = cls._get_active_grypedb()
+            local_grypedb_checksum = cls._get_local_grypedb_checksum()
+            is_sync_necessary = cls._is_sync_necessary(
+                active_grypedb, local_grypedb_checksum
+            )
+
+            if is_sync_necessary:
+                logger.info(
+                    "Grypedb sync is needed to replace local db with checksum %s with current active db with checksum %s",
+                    active_grypedb.checksum,
+                    local_grypedb_checksum,
+                )
                 cls._update_grypedb(
                     active_grypedb=active_grypedb,
                     grypedb_file_path=grypedb_file_path,

--- a/tests/unit/anchore_engine/services/policy_engine/engine/feeds/test_grypedb_sync.py
+++ b/tests/unit/anchore_engine/services/policy_engine/engine/feeds/test_grypedb_sync.py
@@ -148,6 +148,9 @@ class TestGrypeDBSyncTask:
 
         assert sync_ran is True
 
+    def test_uninitialized_grype_wrapper(self):
+        assert GrypeDBSyncManager._get_local_grypedb_checksum() is None
+
     def test_class_lock_called(self, mock_calls_for_sync, monkeypatch):
         """
         Verfies that the lock enter and exit methods are called to ensure that the lock is being used correctly


### PR DESCRIPTION
This PR does two things:
1. Following feedback from @nightfurys I have removed some of the functions in grypedb sync manager to enhance clarity
2. Grype wrapper now raises a value error when attempting to get the checksum if it has not been initialized. The sync manager now catches this and returns None for the checksum.