### PR TITLE
GrypeDBMetadata Persistence Model Changes

### DIFF
--- a/anchore_engine/db/entities/policy_engine.py
+++ b/anchore_engine/db/entities/policy_engine.py
@@ -146,8 +146,8 @@ class GrypeDBMetadata(Base):
 
     __tablename__ = "grype_db_metadata"
 
-    checksum = Column(String, primary_key=True)
-    feed_name = Column(String, ForeignKey(FeedMetadata.name), nullable=False)
+    archive_checksum = Column(String, primary_key=True)
+    feed_name = Column(String, nullable=False)
     group_name = Column(String, nullable=False)
     date_generated = Column(DateTime, nullable=False)
     object_url = Column(String, nullable=False)
@@ -155,13 +155,6 @@ class GrypeDBMetadata(Base):
     created_at = Column(DateTime, default=datetime.datetime.utcnow)
     last_update = Column(
         DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow
-    )
-
-    __table_args__ = (
-        ForeignKeyConstraint(
-            columns=(feed_name, group_name),
-            refcolumns=(FeedGroupMetadata.feed_name, FeedGroupMetadata.name),
-        ),
     )
 
 

--- a/anchore_engine/services/policy_engine/engine/feeds/feeds.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/feeds.py
@@ -728,7 +728,7 @@ class GrypeDBFeed(AnchoreServiceFeed):
         """
         results = db.query(GrypeDBMetadata)
         if checksum:
-            results = results.filter(GrypeDBMetadata.checksum == checksum)
+            results = results.filter(GrypeDBMetadata.archive_checksum == checksum)
         if not isinstance(active, type(None)):
             results = results.filter(GrypeDBMetadata.active == active)
         return results
@@ -764,7 +764,7 @@ class GrypeDBFeed(AnchoreServiceFeed):
 
         records = self._find_match(db)
         for record in records.all():
-            catalog_client.delete_document(record.group_name, record.checksum)
+            catalog_client.delete_document(record.group_name, record.archive_checksum)
         records.delete(synchronize_session="evaluate")
         group_obj.last_sync = None  # Null the update timestamp to reflect the flush
         group_obj.count = 0
@@ -820,7 +820,7 @@ class GrypeDBFeed(AnchoreServiceFeed):
         inactive_records = self._find_match(db, active=False)
         for inactive_record in inactive_records.all():
             catalog_client.delete_document(
-                inactive_record.group_name, inactive_record.checksum
+                inactive_record.group_name, inactive_record.archive_checksum
             )
         inactive_records.delete(synchronize_session="evaluate")
         # search for active and mark inactive
@@ -833,7 +833,7 @@ class GrypeDBFeed(AnchoreServiceFeed):
         )
         date_generated = rfc3339str_to_datetime(record.metadata["Date-Created"])
         grypedb_meta = GrypeDBMetadata(
-            checksum=checksum,
+            archive_checksum=checksum,
             feed_name=GrypeDBFeed.__feed_name__,
             group_name=group_download_result.group,
             date_generated=date_generated,

--- a/anchore_engine/services/policy_engine/engine/feeds/grypedb_sync.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/grypedb_sync.py
@@ -136,7 +136,7 @@ class GrypeDBSyncManager:
         try:
             if grypedb_file_path:
                 GrypeWrapperSingleton.get_instance().init_grype_db_engine(
-                    grypedb_file_path, active_grypedb.checksum
+                    grypedb_file_path, active_grypedb.archive_checksum
                 )
             else:
                 catalog_client = internal_client_for(CatalogClient, userId=None)
@@ -144,12 +144,14 @@ class GrypeDBSyncManager:
                 grypedb_document = catalog_client.get_raw_object(bucket, archive_id)
 
                 # verify integrity of data, create tempfile, and pass path to facade
-                GrypeDBFile.verify_integrity(grypedb_document, active_grypedb.checksum)
+                GrypeDBFile.verify_integrity(
+                    grypedb_document, active_grypedb.archive_checksum
+                )
                 with GrypeDBStorage() as grypedb_file:
-                    with grypedb_file.create_file(active_grypedb.checksum) as f:
+                    with grypedb_file.create_file(active_grypedb.archive_checksum) as f:
                         f.write(grypedb_document)
                     GrypeWrapperSingleton.get_instance().init_grype_db_engine(
-                        grypedb_file.path, active_grypedb.checksum
+                        grypedb_file.path, active_grypedb.archive_checksum
                     )
         except Exception as e:
             logger.exception("GrypeDBSyncTask failed to sync")
@@ -163,8 +165,8 @@ class GrypeDBSyncManager:
         Returns bool based upon comparisons between the active grype db and the local checksum passed to the function
         """
         if (
-            not active_grypedb.checksum
-            or local_grypedb_checksum == active_grypedb.checksum
+            not active_grypedb.archive_checksum
+            or local_grypedb_checksum == active_grypedb.archive_checksum
         ):
             logger.info("No Grype DB sync needed at this time")
             return False
@@ -203,7 +205,7 @@ class GrypeDBSyncManager:
             if is_sync_necessary:
                 logger.info(
                     "Grypedb sync is needed to replace local db with checksum %s with current active db with checksum %s",
-                    active_grypedb.checksum,
+                    active_grypedb.archive_checksum,
                     local_grypedb_checksum,
                 )
                 cls._update_grypedb(

--- a/tests/unit/anchore_engine/services/policy_engine/engine/feeds/test_grypedb_sync.py
+++ b/tests/unit/anchore_engine/services/policy_engine/engine/feeds/test_grypedb_sync.py
@@ -73,7 +73,7 @@ class TestGrypeDBSyncTask:
         )
 
         # mock initial state so execution occurs
-        mock_calls_for_sync(GrypeDBMetadata(checksum=old_checksum), "")
+        mock_calls_for_sync(GrypeDBMetadata(archive_checksum=old_checksum), "")
 
         # Mock the update_grypedb method for task to sleep and update mocks for active and local grype dbs
         def _mock_update_grypedb_for_thread1(
@@ -84,7 +84,9 @@ class TestGrypeDBSyncTask:
 
             # mock the returns to mimic persistent change of active grypedb local and global
             # This in effect mocks the actual execution for the first thread
-            mock_calls_for_sync(GrypeDBMetadata(checksum=new_checksum), new_checksum)
+            mock_calls_for_sync(
+                GrypeDBMetadata(archive_checksum=new_checksum), new_checksum
+            )
 
         monkeypatch.setattr(
             GrypeDBSyncManager, "_update_grypedb", _mock_update_grypedb_for_thread1
@@ -115,7 +117,7 @@ class TestGrypeDBSyncTask:
     def test_matching_checksums(self, mock_calls_for_sync):
         checksum = "eef3b1bcd5728346cb1b30eae09647348bacfbde3ba225d70cb0374da249277c"
         mock_calls_for_sync(
-            mock_active_dbs=GrypeDBMetadata(checksum=checksum),
+            mock_active_dbs=GrypeDBMetadata(archive_checksum=checksum),
             mock_local_checksum=checksum,
         )
 
@@ -132,7 +134,7 @@ class TestGrypeDBSyncTask:
         )
 
         mock_calls_for_sync(
-            mock_active_dbs=GrypeDBMetadata(checksum=global_checksum),
+            mock_active_dbs=GrypeDBMetadata(archive_checksum=global_checksum),
             mock_local_checksum=local_checksum,
         )
 
@@ -160,7 +162,7 @@ class TestGrypeDBSyncTask:
         mock_lock = MagicMock()
         monkeypatch.setattr(GrypeDBSyncLock, "_lock", mock_lock)
         mock_calls_for_sync(
-            mock_active_dbs=GrypeDBMetadata(checksum=checksum),
+            mock_active_dbs=GrypeDBMetadata(archive_checksum=checksum),
             mock_local_checksum="",
         )
 


### PR DESCRIPTION
Removes foreign key constraints on GrypeDBMetadata and changes name of "checksum" column to "archive_checksum".
