### PR TITLE
Grype manage db versions

### DIFF
--- a/anchore_engine/clients/grype_wrapper.py
+++ b/anchore_engine/clients/grype_wrapper.py
@@ -443,30 +443,42 @@ class GrypeWrapperSingleton(object):
             if old_grype_db_dir and old_grype_db_dir != self._grype_db_dir:
                 self._remove_local_grype_db(old_grype_db_dir)
 
-    def get_current_grype_db_metadata(self) -> json:
+    def _get_metadata_file_contents(self, metadata_file_name) -> json:
         """
-        Return the json contents of the metadata file for the in-use version of grype db
+        Return the json contents of one of the metadata files for the in-use version of grype db
         """
-        # Get the path to the latest grype_db metadata file
-        latest_grype_db_metadata_file = os.path.join(
-            self._grype_db_dir, self.METADATA_FILE_NAME
-        )
+        # Get the path to the latest metadata file
+        latest_metadata_file = os.path.join(self._grype_db_dir, metadata_file_name)
 
         # Ensure the file exists
-        if not os.path.exists(latest_grype_db_metadata_file):
+        if not os.path.exists(latest_metadata_file):
             # If not, return None
             return None
         else:
             # Get the contents of the file
-            with open(latest_grype_db_metadata_file) as read_file:
+            with open(latest_metadata_file) as read_file:
                 try:
                     return json.load(read_file)
                 except JSONDecodeError:
                     logger.error(
-                        "Unable to decode grype_db metadata file into json: %s",
+                        "Unable to decode metadata file into json: %s",
                         read_file,
                     )
                     return None
+
+    def get_current_grype_db_metadata(self) -> json:
+        """
+        Return the json contents of the current grype_db metadata file.
+        This file contains metadata specific to grype about the current grype_db instance.
+        """
+        return self._get_metadata_file_contents(self.METADATA_FILE_NAME)
+
+    def get_current_grype_db_engine_metadata(self) -> json:
+        """
+        Return the json contents of the current grype_db engine metadata file.
+        This file contains metadata specific to engine about the current grype_db instance.
+        """
+        return self._get_metadata_file_contents(self.ENGINE_METADATA_FILE_NAME)
 
     def _get_proc_env(self, include_grype_db=True):
         # Set grype env variables, including the grype db location

--- a/anchore_engine/db/entities/policy_engine.py
+++ b/anchore_engine/db/entities/policy_engine.py
@@ -25,8 +25,8 @@ from sqlalchemy import (
     func,
     or_,
 )
-from sqlalchemy.orm import joinedload, relationship, synonym
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import joinedload, relationship, synonym
 
 from anchore_engine.util.apk import compare_versions as apkg_compare_versions
 from anchore_engine.util.deb import compare_versions as dpkg_compare_versions
@@ -147,6 +147,7 @@ class GrypeDBMetadata(Base):
     __tablename__ = "grype_db_metadata"
 
     checksum = Column(String, primary_key=True)
+    schema_version = Column(String, nullable=False)
     feed_name = Column(String, ForeignKey(FeedMetadata.name), nullable=False)
     group_name = Column(String, nullable=False)
     date_generated = Column(DateTime, nullable=False)

--- a/anchore_engine/services/policy_engine/engine/feeds/feeds.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/feeds.py
@@ -831,9 +831,10 @@ class GrypeDBFeed(AnchoreServiceFeed):
         object_url = catalog_client.create_raw_object(
             group_download_result.group, checksum, record.data
         )
-        date_generated = rfc3339str_to_datetime(record.metadata["Date-Created"])
+        date_generated = rfc3339str_to_datetime(record.metadata["built"])
         grypedb_meta = GrypeDBMetadata(
             checksum=checksum,
+            schema_version=record.metadata["version"],
             feed_name=GrypeDBFeed.__feed_name__,
             group_name=group_download_result.group,
             date_generated=date_generated,
@@ -890,7 +891,7 @@ class GrypeDBFeed(AnchoreServiceFeed):
             if total_records_updated >= 1:
                 raise UnexpectedRawGrypeDBFile()
             # Check that the data that we downloaded matches the checksum provided
-            checksum = record.metadata["Checksum"]
+            checksum = record.metadata["checksum"]
             GrypeDBFile.verify_integrity(record.data, checksum)
             # If there aren't any other database files with the same checksum, then this is a new database file.
             if self._find_match(db, checksum).count() == 0:

--- a/anchore_engine/services/policy_engine/engine/feeds/grypedb_sync.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/grypedb_sync.py
@@ -136,7 +136,9 @@ class GrypeDBSyncManager:
         try:
             if grypedb_file_path:
                 GrypeWrapperSingleton.get_instance().init_grype_db_engine(
-                    grypedb_file_path, active_grypedb.checksum
+                    grypedb_file_path,
+                    active_grypedb.checksum,
+                    active_grypedb.schema_version,
                 )
             else:
                 catalog_client = internal_client_for(CatalogClient, userId=None)
@@ -149,7 +151,9 @@ class GrypeDBSyncManager:
                     with grypedb_file.create_file(active_grypedb.checksum) as f:
                         f.write(grypedb_document)
                     GrypeWrapperSingleton.get_instance().init_grype_db_engine(
-                        grypedb_file.path, active_grypedb.checksum
+                        grypedb_file.path,
+                        active_grypedb.checksum,
+                        active_grypedb.schema_version,
                     )
         except Exception as e:
             logger.exception("GrypeDBSyncTask failed to sync")

--- a/tests/unit/anchore_engine/clients/test_grype_wrapper.py
+++ b/tests/unit/anchore_engine/clients/test_grype_wrapper.py
@@ -416,36 +416,59 @@ def test_init_grype_db_engine(grype_db_parent_dir, old_grype_db_dir, grype_db_ar
     assert not os.path.exists(old_grype_db_dir)
 
 
-def test_get_current_grype_db_metadata(grype_db_dir):
+@pytest.mark.parametrize(
+    "metadata_file_name",
+    [
+        GrypeWrapperSingleton.METADATA_FILE_NAME,
+        GrypeWrapperSingleton.ENGINE_METADATA_FILE_NAME,
+    ],
+)
+def test_get_current_grype_db_metadata(grype_db_dir, metadata_file_name):
     # Create grype_wrapper_singleton instance
     grype_wrapper_singleton = TestGrypeWrapperSingleton.get_instance()
 
     # Setup test input
     grype_wrapper_singleton._grype_db_dir = grype_db_dir
 
+    # Setup expected output
+    metadata_file_path = os.path.join(grype_db_dir, metadata_file_name)
+    with open(metadata_file_path, "r") as read_file:
+        expected_metadata = json.load(read_file)
+
     # Function under test
-    result = grype_wrapper_singleton.get_current_grype_db_metadata()
+    result = grype_wrapper_singleton._get_metadata_file_contents(metadata_file_name)
 
     # Validate result
-    assert (
-        result["checksum"]
-        == "sha256:1db8bd20af545fadc5fb2b25260601d49339349cf04e32650531324ded8a45d0"
-    )
+    assert result == expected_metadata
 
 
-def test_get_current_grype_db_metadata_missing_dir():
+@pytest.mark.parametrize(
+    "metadata_file_name",
+    [
+        GrypeWrapperSingleton.METADATA_FILE_NAME,
+        GrypeWrapperSingleton.ENGINE_METADATA_FILE_NAME,
+    ],
+)
+def test_get_current_grype_db_metadata_missing_dir(metadata_file_name):
     # Create grype_wrapper_singleton instance, with no grype_db_dir set
     grype_wrapper_singleton = TestGrypeWrapperSingleton.get_instance()
 
     # Function under test
     with pytest.raises(ValueError) as error:
-        grype_wrapper_singleton.get_current_grype_db_metadata()
+        grype_wrapper_singleton._get_metadata_file_contents(metadata_file_name)
 
     # Validate error message
     assert str(error.value) == GrypeWrapperSingleton.MISSING_GRYPE_DB_DIR_ERROR_MESSAGE
 
 
-def test_get_current_grype_db_metadata_missing_file(tmp_path):
+@pytest.mark.parametrize(
+    "metadata_file_name",
+    [
+        GrypeWrapperSingleton.METADATA_FILE_NAME,
+        GrypeWrapperSingleton.ENGINE_METADATA_FILE_NAME,
+    ],
+)
+def test_get_current_grype_db_metadata_missing_file(tmp_path, metadata_file_name):
     # Create grype_wrapper_singleton instance
     grype_wrapper_singleton = TestGrypeWrapperSingleton.get_instance()
 
@@ -453,13 +476,20 @@ def test_get_current_grype_db_metadata_missing_file(tmp_path):
     grype_wrapper_singleton._grype_db_dir = os.path.join(tmp_path)
 
     # Function under test
-    result = grype_wrapper_singleton.get_current_grype_db_metadata()
+    result = grype_wrapper_singleton._get_metadata_file_contents(metadata_file_name)
 
     # Validate result
     assert result is None
 
 
-def test_get_current_grype_db_metadata_bad_file(tmp_path):
+@pytest.mark.parametrize(
+    "metadata_file_name",
+    [
+        GrypeWrapperSingleton.METADATA_FILE_NAME,
+        GrypeWrapperSingleton.ENGINE_METADATA_FILE_NAME,
+    ],
+)
+def test_get_current_grype_db_metadata_bad_file(tmp_path, metadata_file_name):
     # Create grype_wrapper_singleton instance
     grype_wrapper_singleton = TestGrypeWrapperSingleton.get_instance()
 
@@ -468,7 +498,7 @@ def test_get_current_grype_db_metadata_bad_file(tmp_path):
     grype_wrapper_singleton._grype_db_dir = os.path.join(tmp_path)
 
     # Function under test
-    result = grype_wrapper_singleton.get_current_grype_db_metadata()
+    result = grype_wrapper_singleton._get_metadata_file_contents(metadata_file_name)
 
     # Validate result
     assert result is None

--- a/tests/unit/anchore_engine/clients/test_grype_wrapper.py
+++ b/tests/unit/anchore_engine/clients/test_grype_wrapper.py
@@ -438,6 +438,21 @@ def test_get_proc_env_missing_dir():
     assert str(error.value) == GrypeWrapperSingleton.MISSING_GRYPE_DB_DIR_ERROR_MESSAGE
 
 
+# This test will not pass on the CI because that machine does not have grype installed.
+# I am leaving it for now, but commented out. It is useful for local dev and will
+# pass if you have grype installed.
+# def test_get_grype_version():
+#     # Create grype_wrapper_singleton instance
+#     grype_wrapper_singleton = TestGrypeWrapperSingleton.get_instance()
+#
+#     # Function under test
+#     result = grype_wrapper_singleton.get_grype_version()
+#
+#     # Validate results
+#     assert result["application"] == "grype"
+#     assert result["version"] is not None
+
+
 # TODO Replace this with a functional test against the API that calls the function under test.
 # This test will not pass on the CI because that machine does not have grype installed.
 # I am leaving it for now, but commented out. It is useful for local dev and will

--- a/tests/unit/data/grype_db/new_version/engine_metadata.json
+++ b/tests/unit/data/grype_db/new_version/engine_metadata.json
@@ -1,0 +1,4 @@
+{
+  "archive_checksum": "new_version",
+  "grype_db_version": "2"
+}

--- a/tests/unit/data/grype_db/old_version/engine_metadata.json
+++ b/tests/unit/data/grype_db/old_version/engine_metadata.json
@@ -1,0 +1,4 @@
+{
+  "archive_checksum": "old_version",
+  "grype_db_version": "2"
+}


### PR DESCRIPTION
<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**:
Adds the following to the grype wrapper
- Adds a method to wrap a call to `grype version` and return the results
- Expects both archive checksum and grype db version as params when syncing grype db
- Stores archive checksum and grype db version as engine-specific metadata during the sync, alongside the db
- Adds a method to return the aforementioned new metadata
- New and updated tests for all of the above

**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #:1036

**Special notes**:


