### PR TITLE
Fix auth issue with requests to toolbox service

### DIFF
--- a/anchore_engine/services/policy_engine/engine/feeds/client.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/client.py
@@ -173,12 +173,15 @@ class HTTPBasicAuthClient(IAuthenticatedHTTPClientBase):
             count += 1
             logger.debug("get attempt " + str(count) + " of " + str(retries))
             try:
-                auth = (self.user, self.password)
                 logger.debug(
                     "making authenticated request (user={}, conn_timeout={}, read_timeout={}, verify={}) to url {}".format(
                         str(self.user), conn_timeout, read_timeout, verify, str(url)
                     )
                 )
+                # TODO: move un-authed requests to new class or rename this class
+                auth = None
+                if self.user or self.password:
+                    auth = (self.user, self.password)
                 r = method(
                     url, auth=auth, timeout=(conn_timeout, read_timeout), verify=verify
                 )


### PR DESCRIPTION
Apparently requests passes the auth header even if you give it a tuple of (None, None) for basic auth. The toolbox service seems to be inconsistent in rejecting the header. It's also possible that there is something that is suppressing the exception. But regardless, the exception has surfaced again. Here's a quick fix.

Problem symptom:

```
anchore_engine.services.policy_engine.engine.feeds.client.HTTPStatusException: (HTTPStatusException(...), 'Non-200 HTTP Status. The HTTP request generated a status of 400 <?xml version="1.0" encoding="UTF-8"?>\n<Error><Code>InvalidArgument</Code><Message>Unsupported Authorization Type</Message><ArgumentName>Authorization</ArgumentName><ArgumentValue>Basic Tm9uZTpOb25l</ArgumentValue><RequestId>PGQCGQNZ06TEG8QP</RequestId><HostId>YxJ9mzYaCQQBzj1BRvLBjL2ytNlsShohbcSeoQlPWzJnKVPz1g/XnDW5lKCv2betjcgQf8O4+9g=</HostId></Error>.')
...

echo Tm9uZTpOb25l | base64 -d
None:None
```

