### PR TITLE
Updates to grype integration mappers

### DIFF
--- a/anchore_engine/db/entities/policy_engine.py
+++ b/anchore_engine/db/entities/policy_engine.py
@@ -2201,16 +2201,57 @@ class ImageCpe(Base):
             final_cpe[4] = self.name
             final_cpe[5] = self.version
             final_cpe[6] = self.update
-            # final_cpe[7] = self.edition
+            final_cpe[7] = self.meta
             # final_cpe[8] = self.language
             # final_cpe[9] = self.sw_edition
             # final_cpe[10] = self.target_sw
             # final_cpe[11] = self.target_hw
-            final_cpe[12] = self.meta
+            # final_cpe[12] = self.other
             ret = ":".join(final_cpe)
         except:
             ret = None
         return ret
+
+    def get_cpe23_fs_for_sbom(self):
+        """
+        Returns the formatted string representation of 2.3 CPE for use in sbom constructed for Grype
+
+        A 2.3 CPE is in the format
+        cpe:2.3:part:vendor:product:version:update:edition:language:sw_edition:target_sw:target_hw:other
+
+        The value '-' for a CPE component means the field is not applicable. Component comparison results in not-equal
+        if one CPE has the component set (to value other than * or -) and another CPE indicates the same component is not applicable (-)
+        Grype uses all the CPE components for finding a match against the CPEs provided by the vulnerability data.
+        Anchore engine does not currently record the last 5 components and thereby defaults them to '-'.
+        But that runs the risk of missed matches because of Grype's matching logic as explained above.
+        This function is at the other end of the spectrum where it defaults all missing components to the wild character.
+        While more matches are found this way, this approach runs the risk of finding false positives.
+        Considering the components in play here, there may be a very small chance of such false positives since not many CPEs make use of them
+        """
+        cpe_components = [
+            "cpe",
+            "2.3",
+            "-",  # part
+            "-",  # vendor
+            "-",  # product
+            "-",  # version
+            "-",  # update
+            "-",  # edition
+            # '*' for all components currently unknown to engine to enable matching in grype.
+            "*",  # language
+            "*",  # sw_edition
+            "*",  # target_sw
+            "*",  # target_hw
+            "*",  # other
+        ]
+        cpe_components[2] = self.cpetype
+        cpe_components[3] = self.vendor
+        cpe_components[4] = self.name
+        cpe_components[5] = self.version
+        cpe_components[6] = self.update
+        cpe_components[7] = self.meta
+
+        return ":".join(cpe_components)
 
 
 class FilesystemAnalysis(Base):

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:406413437f26223183d133ccc7186f24c827729e1b21adc7330dd43fcdc030b3.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:406413437f26223183d133ccc7186f24c827729e1b21adc7330dd43fcdc030b3.json
@@ -4237,7 +4237,7 @@
       "pkg_type": "gem",
       "pkg_path": "/var/lib/gems/2.5.0/specifications/ftpd-0.2.1.gemspec",
       "version": "0.2.1",
-      "cpe23": "cpe:2.3:a:ftpd:ftpd:0.2.1:*:-:-:-:-:-:*",
+      "cpe23": "cpe:2.3:a:ftpd:ftpd:0.2.1:*:*:-:-:-:-:-",
       "cpe": "cpe:a:ftpd:ftpd:0.2.1:*:*"
     },
     "vulnerability": {

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:80a31c3ce2e99c3691c27ac3b1753163214494e9b2ca07bfdccf29a5cca2bfbe.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:80a31c3ce2e99c3691c27ac3b1753163214494e9b2ca07bfdccf29a5cca2bfbe.json
@@ -282,7 +282,7 @@
     "fixes": [],
     "artifact": {
       "cpe": "cpe:a:ftpd:ftpd:0.2.1:*:*",
-      "cpe23": "cpe:2.3:a:ftpd:ftpd:0.2.1:*:-:-:-:-:-:*",
+      "cpe23": "cpe:2.3:a:ftpd:ftpd:0.2.1:*:*:-:-:-:-:-",
       "name": "ftpd",
       "pkg_path": "/usr/lib/ruby/gems/2.7.0/specifications/ftpd-0.2.1.gemspec",
       "pkg_type": "gem",

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:fe3ca35038008b0eac0fa4e686bd072c9430000ab7d7853001bde5f5b8ccf60c.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:fe3ca35038008b0eac0fa4e686bd072c9430000ab7d7853001bde5f5b8ccf60c.json
@@ -1384,7 +1384,7 @@
       "name": "ftpd",
       "pkg_path": "/usr/local/share/gems/specifications/ftpd-0.2.1.gemspec",
       "version": "0.2.1",
-      "cpe23": "cpe:2.3:a:ftpd:ftpd:0.2.1:*:-:-:-:-:-:*",
+      "cpe23": "cpe:2.3:a:ftpd:ftpd:0.2.1:*:*:-:-:-:-:-",
       "pkg_type": "gem",
       "cpe": "cpe:a:ftpd:ftpd:0.2.1:*:*"
     },

--- a/tests/unit/anchore_engine/services/policy_engine/engine/vulnerabilities/test_mappers.py
+++ b/tests/unit/anchore_engine/services/policy_engine/engine/vulnerabilities/test_mappers.py
@@ -1,0 +1,76 @@
+import pytest
+
+
+from anchore_engine.services.policy_engine.engine.vulns.mappers import (
+    GRYPE_PACKAGE_MAPPERS,
+    GRYPE_DISTRO_MAPPERS,
+    ENGINE_PACKAGE_MAPPERS,
+    ENGINE_DISTRO_MAPPERS,
+)
+
+
+@pytest.mark.parametrize(
+    "test_distro, expected_os, expected_like_os",
+    [
+        pytest.param("rhel", "redhat", "fedora", id="rhel"),
+        pytest.param("amzn", "amazonlinux", "fedora", id="amazonlinux"),
+        pytest.param("ol", "oraclelinux", "fedora", id="oraclelinux"),
+        pytest.param("centos", "centos", "fedora", id="centos"),
+        pytest.param("debian", "debian", "debian", id="debian"),
+        pytest.param("ubuntu", "ubuntu", "debian", id="ubuntu"),
+        pytest.param("alpine", "alpine", "alpine", id="ubuntu"),
+    ],
+)
+def test_engine_distro_mappers(test_distro, expected_os, expected_like_os):
+    mapper = ENGINE_DISTRO_MAPPERS.get(test_distro)
+    assert mapper.grype_os == expected_os
+    assert mapper.grype_like_os == expected_like_os
+    assert mapper.to_grype_distro("0") == {
+        "name": expected_os,
+        "version": "0",
+        "idLike": expected_like_os,
+    }
+
+
+@pytest.mark.parametrize(
+    "test_os, expected_distro",
+    [
+        pytest.param("redhat", "rhel", id="rhel"),
+        pytest.param("amazonlinux", "amzn", id="amazonlinux"),
+        pytest.param("oraclelinux", "ol", id="oraclelinux"),
+        pytest.param("centos", "centos", id="centos"),
+        pytest.param("debian", "debian", id="debian"),
+        pytest.param("ubuntu", "ubuntu", id="ubuntu"),
+        pytest.param("alpine", "alpine", id="ubuntu"),
+    ],
+)
+def test_grype_distro_mappers(test_os, expected_distro):
+    mapper = GRYPE_DISTRO_MAPPERS.get(test_os)
+    assert mapper.engine_distro == expected_distro
+
+
+@pytest.mark.parametrize(
+    "test_type, expected_type",
+    [
+        pytest.param("java", "java-archive", id="java"),
+        pytest.param("APKG", "apk", id="apkg"),
+        pytest.param("dpkg", "deb", id="dpkg"),
+    ],
+)
+def test_engine_package_mappers(test_type, expected_type):
+    mapper = ENGINE_PACKAGE_MAPPERS.get(test_type)
+    assert mapper.grype_type == expected_type
+
+
+@pytest.mark.parametrize(
+    "test_type, expected_type",
+    [
+        pytest.param("jenkins-plugin", "java", id="jenkins"),
+        pytest.param("java-archive", "java", id="java"),
+        pytest.param("deb", "dpkg", id="dpkg"),
+        pytest.param("apk", "APKG", id="apkg"),
+    ],
+)
+def test_grype_package_mappers(test_type, expected_type):
+    mapper = GRYPE_PACKAGE_MAPPERS.get(test_type)
+    assert mapper.engine_type == expected_type


### PR DESCRIPTION
- add source package information to sbom generated by the grype integration
- replace CPE components not maintained by engine currently with  `*` instead of `-` for better matching using grype