### PR TITLE
Fix grype sbom string analysis

### DIFF
--- a/anchore_engine/clients/grype_wrapper.py
+++ b/anchore_engine/clients/grype_wrapper.py
@@ -568,7 +568,9 @@ class GrypeWrapperSingleton(object):
             stdout = None
             err = None
             try:
-                _, stdout, _ = run_piped_command_list(full_cmd, env=proc_env)
+                _, stdout, _ = run_piped_command_list(
+                    full_cmd, env=proc_env, sanitize_input=False
+                )
             except CommandException as exc:
                 logger.error(
                     "Exception running command: %s | %s, stderr: %s",

--- a/anchore_engine/utils.py
+++ b/anchore_engine/utils.py
@@ -232,6 +232,10 @@ def run_piped_command_list(
     For example, the command: 'echo {}' | grype
     cmd_lists should be passed as: [['echo', '{}'], ['grype']]
     Do not include the actual pipe symbol, it is inferred from the data structure.
+
+    If sanitize_input is passed as true, the command input to this function will not be filtered on the characters
+    disallowed by run_sanitize(). This parameter should not be used in the general case, but is needed for things
+    like grype sbom analysis, where part of the command is a functionally-arbitrary string, already wrapped in quotes.
     """
     if not cmd_lists:
         raise ValueError(PIPED_CMD_VALUE_ERROR_MESSAGE)

--- a/anchore_engine/utils.py
+++ b/anchore_engine/utils.py
@@ -221,7 +221,11 @@ def run_sanitize(cmd_list):
 
 
 def run_piped_command_list(
-    cmd_lists, stdout=subprocess.PIPE, stderr=subprocess.PIPE, **kwargs
+    cmd_lists,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    sanitize_input=True,
+    **kwargs
 ):
     """
     Executes a series of subcommands from cmd_lists, the stdout result of each being piped stdin for the next.
@@ -234,7 +238,8 @@ def run_piped_command_list(
     else:
         output = None
         for cmd_list in cmd_lists:
-            run_sanitize(cmd_list)
+            if sanitize_input:
+                run_sanitize(cmd_list)
             if output is None:
                 output = subprocess.Popen(
                     cmd_list, stdout=stdout, stderr=stderr, **kwargs

--- a/tests/unit/anchore_engine/clients/test_grype_wrapper.py
+++ b/tests/unit/anchore_engine/clients/test_grype_wrapper.py
@@ -580,7 +580,10 @@ def test_get_proc_env_missing_dir():
 # pass if you have grype installed.
 # @pytest.mark.parametrize(
 #     "sbom_file_name, expected_output",
-#     [("sbom-ubuntu-20.04--pruned.json", "ubuntu")],
+#     [
+#         ("sbom-ubuntu-20.04--pruned.json", "ubuntu"),
+#         ("sbom-alpine-3.2.0.json", "alpine"),
+#     ],
 # )
 # def test_get_vulnerabilities_for_sbom(grype_db_dir, sbom_file_name, expected_output):
 #     # Create grype_wrapper_singleton instance
@@ -588,7 +591,7 @@ def test_get_proc_env_missing_dir():
 #
 #     # Setup test inputs
 #     grype_wrapper_singleton._grype_db_dir = grype_db_dir
-#     test_sbom = get_test_sbom(sbom_file_name).replace("<", "").replace(">", "")
+#     test_sbom = get_test_sbom(sbom_file_name)
 #
 #     # Function under test
 #     result = grype_wrapper_singleton.get_vulnerabilities_for_sbom(test_sbom)
@@ -603,7 +606,10 @@ def test_get_proc_env_missing_dir():
 # pass if you have grype installed.
 # @pytest.mark.parametrize(
 #     "sbom_file_name, expected_output",
-#     [("sbom-ubuntu-20.04--pruned.json", "ubuntu")],
+#     [
+#         ("sbom-ubuntu-20.04--pruned.json", "ubuntu"),
+#         ("sbom-alpine-3.2.0.json", "alpine"),
+#     ],
 # )
 # def test_get_vulnerabilities_for_sbom_file(
 #     grype_db_dir, sbom_file_name, expected_output

--- a/tests/unit/anchore_engine/test_utils.py
+++ b/tests/unit/anchore_engine/test_utils.py
@@ -126,14 +126,20 @@ def test_run_sanitize_bad_input(input):
 
 
 @pytest.mark.parametrize(
-    "cmds_list, expected_return_code, expected_stdout, expected_stderr",
-    [([["pwd"], ["wc", "-l"]], 0, "1", b"")],
+    "cmds_list, sanitize_input, expected_return_code, expected_stdout, expected_stderr",
+    [
+        ([["pwd"], ["wc", "-l"]], True, 0, "1", b""),
+        ([["pwd"], ["wc", "-l"]], False, 0, "1", b""),
+        ([["echo", ";&<>"]], False, 0, ";&<>", b""),
+    ],
 )
 def test_run_piped_command(
-    cmds_list, expected_return_code, expected_stdout, expected_stderr
+    cmds_list, sanitize_input, expected_return_code, expected_stdout, expected_stderr
 ):
     # Function under test
-    return_code, stdout, stderr = run_piped_command_list(cmds_list)
+    return_code, stdout, stderr = run_piped_command_list(
+        cmds_list, sanitize_input=sanitize_input
+    )
 
     # Binary string returned in different environments can be padded with different amounts of whitespace
     # So convert it to utf-8 and trim it so we get a clean, reliable comparison

--- a/tests/unit/data/grype_db/sbom-alpine-3.2.0.json
+++ b/tests/unit/data/grype_db/sbom-alpine-3.2.0.json
@@ -1,0 +1,2372 @@
+{
+ "artifacts": [
+  {
+   "id": "4d404212-7b1f-413f-8e2e-f42262a48948",
+   "name": "alpine-baselayout",
+   "version": "3.2.0-r8",
+   "type": "apk",
+   "foundBy": "apkdb-cataloger",
+   "locations": [
+    {
+     "path": "/lib/apk/db/installed",
+     "layerID": "sha256:b2d5eeeaba3a22b9b8aa97261957974a6bd65274ebd43e1d81d0a7b8b752b116"
+    }
+   ],
+   "licenses": [
+    "GPL-2.0-only"
+   ],
+   "language": "",
+   "cpes": [
+    "cpe:2.3:a:alpine-baselayout:alpine-baselayout:3.2.0-r8:*:*:*:*:*:*:*",
+    "cpe:2.3:a:alpine_baselayout:alpine-baselayout:3.2.0-r8:*:*:*:*:*:*:*",
+    "cpe:2.3:a:alpine-baselayout:alpine_baselayout:3.2.0-r8:*:*:*:*:*:*:*",
+    "cpe:2.3:a:alpine_baselayout:alpine_baselayout:3.2.0-r8:*:*:*:*:*:*:*",
+    "cpe:2.3:a:*:alpine-baselayout:3.2.0-r8:*:*:*:*:*:*:*",
+    "cpe:2.3:a:*:alpine_baselayout:3.2.0-r8:*:*:*:*:*:*:*"
+   ],
+   "purl": "pkg:alpine/alpine-baselayout@3.2.0-r8?arch=x86_64",
+   "metadataType": "ApkMetadata",
+   "metadata": {
+    "package": "alpine-baselayout",
+    "originPackage": "alpine-baselayout",
+    "maintainer": "Natanael Copa <ncopa@alpinelinux.org>",
+    "version": "3.2.0-r8",
+    "license": "GPL-2.0-only",
+    "architecture": "x86_64",
+    "url": "https://git.alpinelinux.org/cgit/aports/tree/main/alpine-baselayout",
+    "description": "Alpine base dir structure and init scripts",
+    "size": 20014,
+    "installedSize": 409600,
+    "pullDependencies": "/bin/sh so:libc.musl-x86_64.so.1",
+    "pullChecksum": "Q1FdK1eP1+iEG29MyAE0ylBMICMxc=",
+    "gitCommitOfApkPort": "c0b37ac12e5f2616d00726c9cdf41a2e59aa6b38",
+    "files": [
+     {
+      "path": "/dev",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/dev/pts",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/dev/shm",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/fstab",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q11Q7hNe8QpDS531guqCdrXBzoA/o="
+      }
+     },
+     {
+      "path": "/etc/group",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1oJ16xWudgKOrXIEquEDzlF2Lsm4="
+      }
+     },
+     {
+      "path": "/etc/hostname",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q16nVwYVXP/tChvUPdukVD2ifXOmc="
+      }
+     },
+     {
+      "path": "/etc/hosts",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1BD6zJKZTRWyqGnPi4tSfd3krsMU="
+      }
+     },
+     {
+      "path": "/etc/inittab",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1TsthbhW7QzWRe1E/NKwTOuD4pHc="
+      }
+     },
+     {
+      "path": "/etc/modules",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1toogjUipHGcMgECgPJX64SwUT1M="
+      }
+     },
+     {
+      "path": "/etc/motd",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1XmduVVNURHQ27TvYp1Lr5TMtFcA="
+      }
+     },
+     {
+      "path": "/etc/mtab",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "777",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1kiljhXXH1LlQroHsEJIkPZg2eiw="
+      }
+     },
+     {
+      "path": "/etc/passwd",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1TchuuLUfur0izvfZQZxgN/LJhB8="
+      }
+     },
+     {
+      "path": "/etc/profile",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1KpFb8kl5LvwXWlY3e58FNsjrI34="
+      }
+     },
+     {
+      "path": "/etc/protocols",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q13FqXUnvuOpMDrH/6rehxuYAEE34="
+      }
+     },
+     {
+      "path": "/etc/services",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1C6HJNgQvLWqt5VY+n7MZJ1rsDuY="
+      }
+     },
+     {
+      "path": "/etc/shadow",
+      "ownerUid": "0",
+      "ownerGid": "42",
+      "permissions": "640",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1ltrPIAW2zHeDiajsex2Bdmq3uqA="
+      }
+     },
+     {
+      "path": "/etc/shells",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1ojm2YdpCJ6B/apGDaZ/Sdb2xJkA="
+      }
+     },
+     {
+      "path": "/etc/sysctl.conf",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q14upz3tfnNxZkIEsUhWn7Xoiw96g="
+      }
+     },
+     {
+      "path": "/etc/apk",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/conf.d",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/crontabs",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/crontabs/root",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "600",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1vfk1apUWI4yLJGhhNRd0kJixfvY="
+      }
+     },
+     {
+      "path": "/etc/init.d",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/modprobe.d",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/modprobe.d/aliases.conf",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1WUbh6TBYNVK7e4Y+uUvLs/7viqk="
+      }
+     },
+     {
+      "path": "/etc/modprobe.d/blacklist.conf",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1xxYGU6S6TLQvb7ervPrWWwAWqMg="
+      }
+     },
+     {
+      "path": "/etc/modprobe.d/i386.conf",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1pnay/njn6ol9cCssL7KiZZ8etlc="
+      }
+     },
+     {
+      "path": "/etc/modprobe.d/kms.conf",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1ynbLn3GYDpvajba/ldp1niayeog="
+      }
+     },
+     {
+      "path": "/etc/modules-load.d",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/network",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/network/if-down.d",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/network/if-post-down.d",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/network/if-pre-up.d",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/network/if-up.d",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/opt",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/periodic",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/periodic/15min",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/periodic/daily",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/periodic/hourly",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/periodic/monthly",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/periodic/weekly",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/profile.d",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/profile.d/color_prompt",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q10wL23GuSCVfumMRgakabUI6EsSk="
+      }
+     },
+     {
+      "path": "/etc/profile.d/locale.sh",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1S8j+WW71mWxfVy8ythqU7HUVoBw="
+      }
+     },
+     {
+      "path": "/etc/sysctl.d",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/home",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/lib",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/lib/firmware",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/lib/mdev",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/lib/modules-load.d",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/lib/sysctl.d",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/lib/sysctl.d/00-alpine.conf",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1HpElzW1xEgmKfERtTy7oommnq6c="
+      }
+     },
+     {
+      "path": "/media",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/media/cdrom",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/media/floppy",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/media/usb",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/mnt",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/opt",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/proc",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/root",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "700",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/run",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/sbin",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/sbin/mkmntdirs",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "755",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1j2ogVvvSvkqatNmLneXGl0cf85Q="
+      }
+     },
+     {
+      "path": "/srv",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/sys",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/tmp",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "1777",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/lib",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/lib/modules-load.d",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/local",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/local/bin",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/local/lib",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/local/share",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/sbin",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/share",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/share/man",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/share/misc",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/var",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/var/run",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "777",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q11/SNZz/8cK2dSKK+cJpVrZIuF4Q="
+      }
+     },
+     {
+      "path": "/var/cache",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/var/cache/misc",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/var/empty",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "555",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/var/lib",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/var/lib/misc",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/var/local",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/var/lock",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/var/lock/subsys",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/var/log",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/var/mail",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/var/opt",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/var/spool",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/var/spool/mail",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "777",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1dzbdazYZA2nTzSIG3YyNw7d4Juc="
+      }
+     },
+     {
+      "path": "/var/spool/cron",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/var/spool/cron/crontabs",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "777",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1OFZt+ZMp7j0Gny0rqSKuWJyqYmA="
+      }
+     },
+     {
+      "path": "/var/tmp",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "1777",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     }
+    ]
+   }
+  },
+  {
+   "id": "e789da9b-0218-4806-9074-41f4060d995f",
+   "name": "alpine-keys",
+   "version": "2.2-r0",
+   "type": "apk",
+   "foundBy": "apkdb-cataloger",
+   "locations": [
+    {
+     "path": "/lib/apk/db/installed",
+     "layerID": "sha256:b2d5eeeaba3a22b9b8aa97261957974a6bd65274ebd43e1d81d0a7b8b752b116"
+    }
+   ],
+   "licenses": [
+    "MIT"
+   ],
+   "language": "",
+   "cpes": [
+    "cpe:2.3:a:alpine-keys:alpine-keys:2.2-r0:*:*:*:*:*:*:*",
+    "cpe:2.3:a:alpine_keys:alpine-keys:2.2-r0:*:*:*:*:*:*:*",
+    "cpe:2.3:a:alpine-keys:alpine_keys:2.2-r0:*:*:*:*:*:*:*",
+    "cpe:2.3:a:alpine_keys:alpine_keys:2.2-r0:*:*:*:*:*:*:*",
+    "cpe:2.3:a:*:alpine-keys:2.2-r0:*:*:*:*:*:*:*",
+    "cpe:2.3:a:*:alpine_keys:2.2-r0:*:*:*:*:*:*:*"
+   ],
+   "purl": "pkg:alpine/alpine-keys@2.2-r0?arch=x86_64",
+   "metadataType": "ApkMetadata",
+   "metadata": {
+    "package": "alpine-keys",
+    "originPackage": "alpine-keys",
+    "maintainer": "Natanael Copa <ncopa@alpinelinux.org>",
+    "version": "2.2-r0",
+    "license": "MIT",
+    "architecture": "x86_64",
+    "url": "https://alpinelinux.org",
+    "description": "Public keys for Alpine Linux packages",
+    "size": 5460,
+    "installedSize": 106496,
+    "pullDependencies": "",
+    "pullChecksum": "Q1Lh23fkhkaffiXz6sR+4nQvUfkVM=",
+    "gitCommitOfApkPort": "a8372f3ce6e7a3f4cf28524aa729b334eb9d2fd6",
+    "files": [
+     {
+      "path": "/etc",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/apk",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/apk/keys",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/apk/keys/alpine-devel@lists.alpinelinux.org-4a6a0840.rsa.pub",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1OvCFSO94z97c80mIDCxqGkh2Og4="
+      }
+     },
+     {
+      "path": "/etc/apk/keys/alpine-devel@lists.alpinelinux.org-5243ef4b.rsa.pub",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1v7YWZYzAWoclaLDI45jEguI7YN0="
+      }
+     },
+     {
+      "path": "/etc/apk/keys/alpine-devel@lists.alpinelinux.org-5261cecb.rsa.pub",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1NnGuDsdQOx4ZNYfB3N97eLyGPkI="
+      }
+     },
+     {
+      "path": "/usr",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/share",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/share/apk",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/share/apk/keys",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-4a6a0840.rsa.pub",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1OvCFSO94z97c80mIDCxqGkh2Og4="
+      }
+     },
+     {
+      "path": "/usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-5243ef4b.rsa.pub",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1v7YWZYzAWoclaLDI45jEguI7YN0="
+      }
+     },
+     {
+      "path": "/usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-524d27bb.rsa.pub",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1BTqS+H/UUyhQuzHwiBl47+BTKuU="
+      }
+     },
+     {
+      "path": "/usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-5261cecb.rsa.pub",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1NnGuDsdQOx4ZNYfB3N97eLyGPkI="
+      }
+     },
+     {
+      "path": "/usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-58199dcc.rsa.pub",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1Oaxdcsa6AYoPdLi0U4lO3J2we18="
+      }
+     },
+     {
+      "path": "/usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-58cbb476.rsa.pub",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1yPq+su65ksNox3uXB+DR7P18+QU="
+      }
+     },
+     {
+      "path": "/usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-58e4f17d.rsa.pub",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1MpZDNX0LeLHvSOwVUyXiXx11NN0="
+      }
+     },
+     {
+      "path": "/usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-5e69ca50.rsa.pub",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1glCQ/eJbvA5xqcswdjFrWv5Fnk0="
+      }
+     },
+     {
+      "path": "/usr/share/apk/keys/aarch64",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/share/apk/keys/aarch64/alpine-devel@lists.alpinelinux.org-58199dcc.rsa.pub",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "777",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q17j9nWJkQ+wfIuVQzIFrmFZ7fSOc="
+      }
+     },
+     {
+      "path": "/usr/share/apk/keys/armhf",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/share/apk/keys/armhf/alpine-devel@lists.alpinelinux.org-524d27bb.rsa.pub",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "777",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1U9QtsdN+rYZ9Zh76EfXy00JZHMg="
+      }
+     },
+     {
+      "path": "/usr/share/apk/keys/mips64",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/share/apk/keys/mips64/alpine-devel@lists.alpinelinux.org-5e69ca50.rsa.pub",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "777",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1hCZdFx+LvzbLtPs753je78gEEBQ="
+      }
+     },
+     {
+      "path": "/usr/share/apk/keys/ppc64le",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/share/apk/keys/ppc64le/alpine-devel@lists.alpinelinux.org-58cbb476.rsa.pub",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "777",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1t21dhCLbTJmAHXSCeOMq/2vfSgo="
+      }
+     },
+     {
+      "path": "/usr/share/apk/keys/s390x",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/share/apk/keys/s390x/alpine-devel@lists.alpinelinux.org-58e4f17d.rsa.pub",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "777",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1sjbV2r2w0Ih2vwdzC4Jq6UI7cMQ="
+      }
+     },
+     {
+      "path": "/usr/share/apk/keys/x86",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/share/apk/keys/x86/alpine-devel@lists.alpinelinux.org-4a6a0840.rsa.pub",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "777",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1Ii51i7Nrc4uft14HhqugaUqdH64="
+      }
+     },
+     {
+      "path": "/usr/share/apk/keys/x86/alpine-devel@lists.alpinelinux.org-5243ef4b.rsa.pub",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "777",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1Y49eVxhpvftbQ3yAdvlLfcrPLTU="
+      }
+     },
+     {
+      "path": "/usr/share/apk/keys/x86_64",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/share/apk/keys/x86_64/alpine-devel@lists.alpinelinux.org-4a6a0840.rsa.pub",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "777",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1Ii51i7Nrc4uft14HhqugaUqdH64="
+      }
+     },
+     {
+      "path": "/usr/share/apk/keys/x86_64/alpine-devel@lists.alpinelinux.org-5261cecb.rsa.pub",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "777",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1AUFY+fwSBTcrYetjT7NHvafrSQc="
+      }
+     }
+    ]
+   }
+  },
+  {
+   "id": "66940e38-a20f-41d2-ada1-5855844361c4",
+   "name": "apk-tools",
+   "version": "2.12.5-r0",
+   "type": "apk",
+   "foundBy": "apkdb-cataloger",
+   "locations": [
+    {
+     "path": "/lib/apk/db/installed",
+     "layerID": "sha256:b2d5eeeaba3a22b9b8aa97261957974a6bd65274ebd43e1d81d0a7b8b752b116"
+    }
+   ],
+   "licenses": [
+    "GPL-2.0-only"
+   ],
+   "language": "",
+   "cpes": [
+    "cpe:2.3:a:apk-tools:apk-tools:2.12.5-r0:*:*:*:*:*:*:*",
+    "cpe:2.3:a:apk_tools:apk-tools:2.12.5-r0:*:*:*:*:*:*:*",
+    "cpe:2.3:a:apk-tools:apk_tools:2.12.5-r0:*:*:*:*:*:*:*",
+    "cpe:2.3:a:apk_tools:apk_tools:2.12.5-r0:*:*:*:*:*:*:*",
+    "cpe:2.3:a:*:apk-tools:2.12.5-r0:*:*:*:*:*:*:*",
+    "cpe:2.3:a:*:apk_tools:2.12.5-r0:*:*:*:*:*:*:*"
+   ],
+   "purl": "pkg:alpine/apk-tools@2.12.5-r0?arch=x86_64",
+   "metadataType": "ApkMetadata",
+   "metadata": {
+    "package": "apk-tools",
+    "originPackage": "apk-tools",
+    "maintainer": "Natanael Copa <ncopa@alpinelinux.org>",
+    "version": "2.12.5-r0",
+    "license": "GPL-2.0-only",
+    "architecture": "x86_64",
+    "url": "https://gitlab.alpinelinux.org/alpine/apk-tools",
+    "description": "Alpine Package Keeper - package manager for alpine",
+    "size": 119276,
+    "installedSize": 311296,
+    "pullDependencies": "musl>=1.2 so:libc.musl-x86_64.so.1 so:libcrypto.so.1.1 so:libssl.so.1.1 so:libz.so.1",
+    "pullChecksum": "Q1htyHuI0zNxVIV6aLaXNyDwgZFCg=",
+    "gitCommitOfApkPort": "ac1b1085ae4954a01110b0a9b4d6796ba5a6d630",
+    "files": [
+     {
+      "path": "/etc",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/apk",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/apk/keys",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/apk/protected_paths.d",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/lib",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/lib/libapk.so.3.12.0",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "755",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q12minLQ0Rm/+l3rtT7KdJ3qlrTh8="
+      }
+     },
+     {
+      "path": "/sbin",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/sbin/apk",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "755",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1cnbswyencSZuQdKnN50MUwdb7uY="
+      }
+     },
+     {
+      "path": "/var",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/var/cache",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/var/cache/misc",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/var/lib",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/var/lib/apk",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     }
+    ]
+   }
+  },
+  {
+   "id": "c4505f11-75bf-4c32-abd2-8701b7adc3d9",
+   "name": "busybox",
+   "version": "1.32.1-r6",
+   "type": "apk",
+   "foundBy": "apkdb-cataloger",
+   "locations": [
+    {
+     "path": "/lib/apk/db/installed",
+     "layerID": "sha256:b2d5eeeaba3a22b9b8aa97261957974a6bd65274ebd43e1d81d0a7b8b752b116"
+    }
+   ],
+   "licenses": [
+    "GPL-2.0-only"
+   ],
+   "language": "",
+   "cpes": [
+    "cpe:2.3:a:busybox:busybox:1.32.1-r6:*:*:*:*:*:*:*",
+    "cpe:2.3:a:*:busybox:1.32.1-r6:*:*:*:*:*:*:*"
+   ],
+   "purl": "pkg:alpine/busybox@1.32.1-r6?arch=x86_64",
+   "metadataType": "ApkMetadata",
+   "metadata": {
+    "package": "busybox",
+    "originPackage": "busybox",
+    "maintainer": "Natanael Copa <ncopa@alpinelinux.org>",
+    "version": "1.32.1-r6",
+    "license": "GPL-2.0-only",
+    "architecture": "x86_64",
+    "url": "https://busybox.net/",
+    "description": "Size optimized toolbox of many common UNIX utilities",
+    "size": 497774,
+    "installedSize": 946176,
+    "pullDependencies": "so:libc.musl-x86_64.so.1",
+    "pullChecksum": "Q1qwlR6vNeSFcNQWzpcifus9YorNk=",
+    "gitCommitOfApkPort": "8f37ff27685a4e44ede31c6738661032f6656668",
+    "files": [
+     {
+      "path": "/bin",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/bin/busybox",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "755",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1ccKCuw60J+4z1H9b9mYgXQ+GonI="
+      }
+     },
+     {
+      "path": "/bin/sh",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "777",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1pcfTfDNEbNKQc2s1tia7da05M8Q="
+      }
+     },
+     {
+      "path": "/etc",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/securetty",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1mB95Hq2NUTZ599RDiSsj9w5FrOU="
+      }
+     },
+     {
+      "path": "/etc/udhcpd.conf",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1UAiPZcDIW1ClRzobfggcCQ77V28="
+      }
+     },
+     {
+      "path": "/etc/logrotate.d",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/logrotate.d/acpid",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1TylyCINVmnS+A/Tead4vZhE7Bks="
+      }
+     },
+     {
+      "path": "/etc/network",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/network/if-down.d",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/network/if-post-down.d",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/network/if-post-up.d",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/network/if-pre-down.d",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/network/if-pre-up.d",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/network/if-up.d",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/network/if-up.d/dad",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "775",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1hlxd3qExrihH8bYxDQ3i7TsM/44="
+      }
+     },
+     {
+      "path": "/sbin",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/tmp",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "1777",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/sbin",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/share",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/share/udhcpc",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/share/udhcpc/default.script",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "755",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1t9vir/ZrX3nbSIYT9BDLWZenkVQ="
+      }
+     },
+     {
+      "path": "/var",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/var/cache",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/var/cache/misc",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/var/lib",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/var/lib/udhcpd",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     }
+    ]
+   }
+  },
+  {
+   "id": "2a10794d-8cfb-4f2f-90f3-48b5700376e1",
+   "name": "ca-certificates-bundle",
+   "version": "20191127-r5",
+   "type": "apk",
+   "foundBy": "apkdb-cataloger",
+   "locations": [
+    {
+     "path": "/lib/apk/db/installed",
+     "layerID": "sha256:b2d5eeeaba3a22b9b8aa97261957974a6bd65274ebd43e1d81d0a7b8b752b116"
+    }
+   ],
+   "licenses": [
+    "MPL-2.0",
+    "AND",
+    "MIT"
+   ],
+   "language": "",
+   "cpes": [
+    "cpe:2.3:a:ca-certificates-bundle:ca-certificates-bundle:20191127-r5:*:*:*:*:*:*:*",
+    "cpe:2.3:a:ca_certificates_bundle:ca-certificates-bundle:20191127-r5:*:*:*:*:*:*:*",
+    "cpe:2.3:a:ca-certificates-bundle:ca_certificates_bundle:20191127-r5:*:*:*:*:*:*:*",
+    "cpe:2.3:a:ca_certificates_bundle:ca_certificates_bundle:20191127-r5:*:*:*:*:*:*:*",
+    "cpe:2.3:a:*:ca-certificates-bundle:20191127-r5:*:*:*:*:*:*:*",
+    "cpe:2.3:a:*:ca_certificates_bundle:20191127-r5:*:*:*:*:*:*:*"
+   ],
+   "purl": "pkg:alpine/ca-certificates-bundle@20191127-r5?arch=x86_64",
+   "metadataType": "ApkMetadata",
+   "metadata": {
+    "package": "ca-certificates-bundle",
+    "originPackage": "ca-certificates",
+    "maintainer": "Natanael Copa <ncopa@alpinelinux.org>",
+    "version": "20191127-r5",
+    "license": "MPL-2.0 AND MIT",
+    "architecture": "x86_64",
+    "url": "https://www.mozilla.org/en-US/about/governance/policies/security-group/certs/",
+    "description": "Pre generated bundle of Mozilla certificates",
+    "size": 124471,
+    "installedSize": 233472,
+    "pullDependencies": "",
+    "pullChecksum": "Q1nZWVjYzawa8UHUFAJJBcfOhhRY0=",
+    "gitCommitOfApkPort": "51999ab9304ec11c68c4ea9e99350ac7570e7f21",
+    "files": [
+     {
+      "path": "/etc",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/ssl",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/ssl/cert.pem",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "777",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1Nj6gTBdkZpTFW/obJGdpfvK0StA="
+      }
+     },
+     {
+      "path": "/etc/ssl/certs",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/ssl/certs/ca-certificates.crt",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1yxhc/Gjt/YEWliIZBXQz/RBrszU="
+      }
+     }
+    ]
+   }
+  },
+  {
+   "id": "24c24ed4-2ab0-4ed3-b367-c6bb7fa2aeac",
+   "name": "libc-utils",
+   "version": "0.7.2-r3",
+   "type": "apk",
+   "foundBy": "apkdb-cataloger",
+   "locations": [
+    {
+     "path": "/lib/apk/db/installed",
+     "layerID": "sha256:b2d5eeeaba3a22b9b8aa97261957974a6bd65274ebd43e1d81d0a7b8b752b116"
+    }
+   ],
+   "licenses": [
+    "BSD-2-Clause",
+    "AND",
+    "BSD-3-Clause"
+   ],
+   "language": "",
+   "cpes": [
+    "cpe:2.3:a:libc-utils:libc-utils:0.7.2-r3:*:*:*:*:*:*:*",
+    "cpe:2.3:a:libc_utils:libc-utils:0.7.2-r3:*:*:*:*:*:*:*",
+    "cpe:2.3:a:libc-utils:libc_utils:0.7.2-r3:*:*:*:*:*:*:*",
+    "cpe:2.3:a:libc_utils:libc_utils:0.7.2-r3:*:*:*:*:*:*:*",
+    "cpe:2.3:a:*:libc-utils:0.7.2-r3:*:*:*:*:*:*:*",
+    "cpe:2.3:a:*:libc_utils:0.7.2-r3:*:*:*:*:*:*:*"
+   ],
+   "purl": "pkg:alpine/libc-utils@0.7.2-r3?arch=x86_64",
+   "metadataType": "ApkMetadata",
+   "metadata": {
+    "package": "libc-utils",
+    "originPackage": "libc-dev",
+    "maintainer": "Natanael Copa <ncopa@alpinelinux.org>",
+    "version": "0.7.2-r3",
+    "license": "BSD-2-Clause AND BSD-3-Clause",
+    "architecture": "x86_64",
+    "url": "https://alpinelinux.org",
+    "description": "Meta package to pull in correct libc",
+    "size": 1228,
+    "installedSize": 4096,
+    "pullDependencies": "musl-utils",
+    "pullChecksum": "Q1JhyrSSh6Nws4iebsM6/VHCxwPfQ=",
+    "gitCommitOfApkPort": "60424133be2e79bbfeff3d58147a22886f817ce2",
+    "files": []
+   }
+  },
+  {
+   "id": "548c3523-5a5f-4ba8-8516-fd7ba89dee8e",
+   "name": "libcrypto1.1",
+   "version": "1.1.1k-r0",
+   "type": "apk",
+   "foundBy": "apkdb-cataloger",
+   "locations": [
+    {
+     "path": "/lib/apk/db/installed",
+     "layerID": "sha256:b2d5eeeaba3a22b9b8aa97261957974a6bd65274ebd43e1d81d0a7b8b752b116"
+    }
+   ],
+   "licenses": [
+    "OpenSSL"
+   ],
+   "language": "",
+   "cpes": [
+    "cpe:2.3:a:libcrypto1.1:libcrypto1.1:1.1.1k-r0:*:*:*:*:*:*:*",
+    "cpe:2.3:a:*:libcrypto1.1:1.1.1k-r0:*:*:*:*:*:*:*"
+   ],
+   "purl": "pkg:alpine/libcrypto1.1@1.1.1k-r0?arch=x86_64",
+   "metadataType": "ApkMetadata",
+   "metadata": {
+    "package": "libcrypto1.1",
+    "originPackage": "openssl",
+    "maintainer": "Timo Teras <timo.teras@iki.fi>",
+    "version": "1.1.1k-r0",
+    "license": "OpenSSL",
+    "architecture": "x86_64",
+    "url": "https://www.openssl.org/",
+    "description": "Crypto library from openssl",
+    "size": 1211309,
+    "installedSize": 2768896,
+    "pullDependencies": "so:libc.musl-x86_64.so.1",
+    "pullChecksum": "Q18XDPXW8a0Q3eH/qyp7goUZ8Bfc8=",
+    "gitCommitOfApkPort": "36515dd3bda2fc9f66fb4c16e0f97689be0a192f",
+    "files": [
+     {
+      "path": "/etc",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/ssl",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/ssl/ct_log_list.cnf",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1olh8TpdAi2QnTl4FK3TjdUiSwTo="
+      }
+     },
+     {
+      "path": "/etc/ssl/ct_log_list.cnf.dist",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1olh8TpdAi2QnTl4FK3TjdUiSwTo="
+      }
+     },
+     {
+      "path": "/etc/ssl/openssl.cnf",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1wGuxVEOK9iGLj1i8D3BSBnT7MJA="
+      }
+     },
+     {
+      "path": "/etc/ssl/openssl.cnf.dist",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1wGuxVEOK9iGLj1i8D3BSBnT7MJA="
+      }
+     },
+     {
+      "path": "/etc/ssl/certs",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/ssl/misc",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/etc/ssl/misc/CA.pl",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "755",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1IACevKhK93GYBHp96Ie26jgZ17s="
+      }
+     },
+     {
+      "path": "/etc/ssl/misc/tsget",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "777",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q13NVgfr7dQUuGYxur0tNalH6EIjU="
+      }
+     },
+     {
+      "path": "/etc/ssl/misc/tsget.pl",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "755",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1lLC21tVsYX/50HBS+UhaARiFhng="
+      }
+     },
+     {
+      "path": "/etc/ssl/private",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/lib",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/lib/libcrypto.so.1.1",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "755",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q17vYq9uqO2DnFwhuuQ+gT6dW2Rcs="
+      }
+     },
+     {
+      "path": "/usr",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/lib",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/lib/libcrypto.so.1.1",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "777",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1T2si+c7ts7sgDxQYve4B3i1Dgo0="
+      }
+     },
+     {
+      "path": "/usr/lib/engines-1.1",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/lib/engines-1.1/afalg.so",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "755",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1aHfC1a+9YaqpQWGGxu5T6N5az1U="
+      }
+     },
+     {
+      "path": "/usr/lib/engines-1.1/capi.so",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "755",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1+sLp231Nz9jaDVcvpkSafrp9798="
+      }
+     },
+     {
+      "path": "/usr/lib/engines-1.1/padlock.so",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "755",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q112HsqidDkA/gnephBqZQPylG94Q="
+      }
+     }
+    ]
+   }
+  },
+  {
+   "id": "44c38cb1-eb7c-4d10-a851-2f636ad891f7",
+   "name": "libssl1.1",
+   "version": "1.1.1k-r0",
+   "type": "apk",
+   "foundBy": "apkdb-cataloger",
+   "locations": [
+    {
+     "path": "/lib/apk/db/installed",
+     "layerID": "sha256:b2d5eeeaba3a22b9b8aa97261957974a6bd65274ebd43e1d81d0a7b8b752b116"
+    }
+   ],
+   "licenses": [
+    "OpenSSL"
+   ],
+   "language": "",
+   "cpes": [
+    "cpe:2.3:a:libssl1.1:libssl1.1:1.1.1k-r0:*:*:*:*:*:*:*",
+    "cpe:2.3:a:*:libssl1.1:1.1.1k-r0:*:*:*:*:*:*:*"
+   ],
+   "purl": "pkg:alpine/libssl1.1@1.1.1k-r0?arch=x86_64",
+   "metadataType": "ApkMetadata",
+   "metadata": {
+    "package": "libssl1.1",
+    "originPackage": "openssl",
+    "maintainer": "Timo Teras <timo.teras@iki.fi>",
+    "version": "1.1.1k-r0",
+    "license": "OpenSSL",
+    "architecture": "x86_64",
+    "url": "https://www.openssl.org/",
+    "description": "SSL shared libraries",
+    "size": 212475,
+    "installedSize": 540672,
+    "pullDependencies": "so:libc.musl-x86_64.so.1 so:libcrypto.so.1.1",
+    "pullChecksum": "Q12fEJvCHSrvN0Ciao0Wyv9HOfVgw=",
+    "gitCommitOfApkPort": "36515dd3bda2fc9f66fb4c16e0f97689be0a192f",
+    "files": [
+     {
+      "path": "/lib",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/lib/libssl.so.1.1",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "755",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1+NRZ1uaviuw0ZyDySeryhL75Di0="
+      }
+     },
+     {
+      "path": "/usr",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/lib",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/lib/libssl.so.1.1",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "777",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q18j35pe3yp6HOgMih1wlGP1/mm2c="
+      }
+     }
+    ]
+   }
+  },
+  {
+   "id": "e85dc394-e8b2-4c3b-a3b9-db271008a7ce",
+   "name": "libtls-standalone",
+   "version": "2.9.1-r1",
+   "type": "apk",
+   "foundBy": "apkdb-cataloger",
+   "locations": [
+    {
+     "path": "/lib/apk/db/installed",
+     "layerID": "sha256:b2d5eeeaba3a22b9b8aa97261957974a6bd65274ebd43e1d81d0a7b8b752b116"
+    }
+   ],
+   "licenses": [
+    "ISC"
+   ],
+   "language": "",
+   "cpes": [
+    "cpe:2.3:a:libtls-standalone:libtls-standalone:2.9.1-r1:*:*:*:*:*:*:*",
+    "cpe:2.3:a:libtls_standalone:libtls-standalone:2.9.1-r1:*:*:*:*:*:*:*",
+    "cpe:2.3:a:libtls-standalone:libtls_standalone:2.9.1-r1:*:*:*:*:*:*:*",
+    "cpe:2.3:a:libtls_standalone:libtls_standalone:2.9.1-r1:*:*:*:*:*:*:*",
+    "cpe:2.3:a:*:libtls-standalone:2.9.1-r1:*:*:*:*:*:*:*",
+    "cpe:2.3:a:*:libtls_standalone:2.9.1-r1:*:*:*:*:*:*:*"
+   ],
+   "purl": "pkg:alpine/libtls-standalone@2.9.1-r1?arch=x86_64",
+   "metadataType": "ApkMetadata",
+   "metadata": {
+    "package": "libtls-standalone",
+    "originPackage": "libtls-standalone",
+    "maintainer": "",
+    "version": "2.9.1-r1",
+    "license": "ISC",
+    "architecture": "x86_64",
+    "url": "https://www.libressl.org/",
+    "description": "libtls extricated from libressl sources",
+    "size": 33160,
+    "installedSize": 110592,
+    "pullDependencies": "ca-certificates-bundle so:libc.musl-x86_64.so.1 so:libcrypto.so.1.1 so:libssl.so.1.1",
+    "pullChecksum": "Q1gtM9DxinD9sbjJMnriOhltW7sNQ=",
+    "gitCommitOfApkPort": "7ebfa23b6119a24ca9b9375bdc55373259192da1",
+    "files": [
+     {
+      "path": "/usr",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/lib",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/lib/libtls-standalone.so.1",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "777",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1MePJJ8Ajcuvc5x+6vlF3ygJoZYw="
+      }
+     },
+     {
+      "path": "/usr/lib/libtls-standalone.so.1.0.0",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "755",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q18u08wcDBVmwXMchjwU42HGj9Gfs="
+      }
+     }
+    ]
+   }
+  },
+  {
+   "id": "99bc31e2-8ed4-433c-bc89-07d5ba42f560",
+   "name": "musl",
+   "version": "1.2.2-r0",
+   "type": "apk",
+   "foundBy": "apkdb-cataloger",
+   "locations": [
+    {
+     "path": "/lib/apk/db/installed",
+     "layerID": "sha256:b2d5eeeaba3a22b9b8aa97261957974a6bd65274ebd43e1d81d0a7b8b752b116"
+    }
+   ],
+   "licenses": [
+    "MIT"
+   ],
+   "language": "",
+   "cpes": [
+    "cpe:2.3:a:musl:musl:1.2.2-r0:*:*:*:*:*:*:*",
+    "cpe:2.3:a:*:musl:1.2.2-r0:*:*:*:*:*:*:*"
+   ],
+   "purl": "pkg:alpine/musl@1.2.2-r0?arch=x86_64",
+   "metadataType": "ApkMetadata",
+   "metadata": {
+    "package": "musl",
+    "originPackage": "musl",
+    "maintainer": "Timo Teräs <timo.teras@iki.fi>",
+    "version": "1.2.2-r0",
+    "license": "MIT",
+    "architecture": "x86_64",
+    "url": "https://musl.libc.org/",
+    "description": "the musl c library (libc) implementation",
+    "size": 382732,
+    "installedSize": 622592,
+    "pullDependencies": "",
+    "pullChecksum": "Q10Nu5eN4wrh8WXuJA2JaSwqOlJyE=",
+    "gitCommitOfApkPort": "c6c2cd54a0db8503a7e0238f388e1daff35d5d4d",
+    "files": [
+     {
+      "path": "/lib",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/lib/ld-musl-x86_64.so.1",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "755",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1+iSDev5zZq96D14Qgc18qcKJ+Qk="
+      }
+     },
+     {
+      "path": "/lib/libc.musl-x86_64.so.1",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "777",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q17yJ3JFNypA4mxhJJr0ou6CzsJVI="
+      }
+     }
+    ]
+   }
+  },
+  {
+   "id": "3d8323e2-dd21-4f5d-adcd-fa8e9f8ee77e",
+   "name": "musl-utils",
+   "version": "1.2.2-r0",
+   "type": "apk",
+   "foundBy": "apkdb-cataloger",
+   "locations": [
+    {
+     "path": "/lib/apk/db/installed",
+     "layerID": "sha256:b2d5eeeaba3a22b9b8aa97261957974a6bd65274ebd43e1d81d0a7b8b752b116"
+    }
+   ],
+   "licenses": [
+    "MIT",
+    "BSD",
+    "GPL2+"
+   ],
+   "language": "",
+   "cpes": [
+    "cpe:2.3:a:musl-utils:musl-utils:1.2.2-r0:*:*:*:*:*:*:*",
+    "cpe:2.3:a:musl_utils:musl-utils:1.2.2-r0:*:*:*:*:*:*:*",
+    "cpe:2.3:a:musl-utils:musl_utils:1.2.2-r0:*:*:*:*:*:*:*",
+    "cpe:2.3:a:musl_utils:musl_utils:1.2.2-r0:*:*:*:*:*:*:*",
+    "cpe:2.3:a:*:musl-utils:1.2.2-r0:*:*:*:*:*:*:*",
+    "cpe:2.3:a:*:musl_utils:1.2.2-r0:*:*:*:*:*:*:*"
+   ],
+   "purl": "pkg:alpine/musl-utils@1.2.2-r0?arch=x86_64",
+   "metadataType": "ApkMetadata",
+   "metadata": {
+    "package": "musl-utils",
+    "originPackage": "musl",
+    "maintainer": "Timo Teräs <timo.teras@iki.fi>",
+    "version": "1.2.2-r0",
+    "license": "MIT BSD GPL2+",
+    "architecture": "x86_64",
+    "url": "https://musl.libc.org/",
+    "description": "the musl c library (libc) implementation",
+    "size": 36088,
+    "installedSize": 143360,
+    "pullDependencies": "scanelf so:libc.musl-x86_64.so.1",
+    "pullChecksum": "Q1D3JYIm61JtNwGxQ0PUsPCuyuE7w=",
+    "gitCommitOfApkPort": "c6c2cd54a0db8503a7e0238f388e1daff35d5d4d",
+    "files": [
+     {
+      "path": "/sbin",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/sbin/ldconfig",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "755",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1Kja2+POZKxEkUOZqwSjC6kmaED4="
+      }
+     },
+     {
+      "path": "/usr",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/bin",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/bin/getconf",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "755",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1G5/8MlwJWgoSRHNJrmP2RHt+lxE="
+      }
+     },
+     {
+      "path": "/usr/bin/getent",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "755",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1lLfcBvvIa6lyRdpKPoDHPoVRTw4="
+      }
+     },
+     {
+      "path": "/usr/bin/iconv",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "755",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1F6hdb6eg/3RIU0YGKtZoY/RhSiA="
+      }
+     },
+     {
+      "path": "/usr/bin/ldd",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "755",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1yFAhGggmL7ERgbIA7KQxyTzf3ks="
+      }
+     }
+    ]
+   }
+  },
+  {
+   "id": "5ed59c6b-8af9-4b74-a542-72b2f06a8f73",
+   "name": "scanelf",
+   "version": "1.2.8-r0",
+   "type": "apk",
+   "foundBy": "apkdb-cataloger",
+   "locations": [
+    {
+     "path": "/lib/apk/db/installed",
+     "layerID": "sha256:b2d5eeeaba3a22b9b8aa97261957974a6bd65274ebd43e1d81d0a7b8b752b116"
+    }
+   ],
+   "licenses": [
+    "GPL-2.0-only"
+   ],
+   "language": "",
+   "cpes": [
+    "cpe:2.3:a:scanelf:scanelf:1.2.8-r0:*:*:*:*:*:*:*",
+    "cpe:2.3:a:*:scanelf:1.2.8-r0:*:*:*:*:*:*:*"
+   ],
+   "purl": "pkg:alpine/scanelf@1.2.8-r0?arch=x86_64",
+   "metadataType": "ApkMetadata",
+   "metadata": {
+    "package": "scanelf",
+    "originPackage": "pax-utils",
+    "maintainer": "Natanael Copa <ncopa@alpinelinux.org>",
+    "version": "1.2.8-r0",
+    "license": "GPL-2.0-only",
+    "architecture": "x86_64",
+    "url": "https://wiki.gentoo.org/wiki/Hardened/PaX_Utilities",
+    "description": "Scan ELF binaries for stuff",
+    "size": 36506,
+    "installedSize": 94208,
+    "pullDependencies": "so:libc.musl-x86_64.so.1",
+    "pullChecksum": "Q1OYJOhU51ILwDQRwNiYgqtq986/o=",
+    "gitCommitOfApkPort": "375980196b4c31373fcffaf3aba1bd6b65744dc4",
+    "files": [
+     {
+      "path": "/usr",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/bin",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/bin/scanelf",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "755",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q12n+1EW8lrQAvNQsRIOBhmja3IFc="
+      }
+     }
+    ]
+   }
+  },
+  {
+   "id": "0c82e342-d931-46c2-8811-6967dccd58e5",
+   "name": "ssl_client",
+   "version": "1.32.1-r6",
+   "type": "apk",
+   "foundBy": "apkdb-cataloger",
+   "locations": [
+    {
+     "path": "/lib/apk/db/installed",
+     "layerID": "sha256:b2d5eeeaba3a22b9b8aa97261957974a6bd65274ebd43e1d81d0a7b8b752b116"
+    }
+   ],
+   "licenses": [
+    "GPL-2.0-only"
+   ],
+   "language": "",
+   "cpes": [
+    "cpe:2.3:a:ssl_client:ssl_client:1.32.1-r6:*:*:*:*:*:*:*",
+    "cpe:2.3:a:*:ssl_client:1.32.1-r6:*:*:*:*:*:*:*"
+   ],
+   "purl": "pkg:alpine/ssl_client@1.32.1-r6?arch=x86_64",
+   "metadataType": "ApkMetadata",
+   "metadata": {
+    "package": "ssl_client",
+    "originPackage": "busybox",
+    "maintainer": "Natanael Copa <ncopa@alpinelinux.org>",
+    "version": "1.32.1-r6",
+    "license": "GPL-2.0-only",
+    "architecture": "x86_64",
+    "url": "https://busybox.net/",
+    "description": "EXternal ssl_client for busybox wget",
+    "size": 4392,
+    "installedSize": 28672,
+    "pullDependencies": "so:libc.musl-x86_64.so.1 so:libtls-standalone.so.1",
+    "pullChecksum": "Q1mN+6Lxj1yf4Aedv8hqK6deLW69s=",
+    "gitCommitOfApkPort": "8f37ff27685a4e44ede31c6738661032f6656668",
+    "files": [
+     {
+      "path": "/usr",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/bin",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/usr/bin/ssl_client",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "755",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1sd86AUTI2Ca16xVi39q+WDnKC8Y="
+      }
+     }
+    ]
+   }
+  },
+  {
+   "id": "801a3f42-1322-414a-81ba-4e3c202f208d",
+   "name": "zlib",
+   "version": "1.2.11-r3",
+   "type": "apk",
+   "foundBy": "apkdb-cataloger",
+   "locations": [
+    {
+     "path": "/lib/apk/db/installed",
+     "layerID": "sha256:b2d5eeeaba3a22b9b8aa97261957974a6bd65274ebd43e1d81d0a7b8b752b116"
+    }
+   ],
+   "licenses": [
+    "Zlib"
+   ],
+   "language": "",
+   "cpes": [
+    "cpe:2.3:a:zlib:zlib:1.2.11-r3:*:*:*:*:*:*:*",
+    "cpe:2.3:a:*:zlib:1.2.11-r3:*:*:*:*:*:*:*"
+   ],
+   "purl": "pkg:alpine/zlib@1.2.11-r3?arch=x86_64",
+   "metadataType": "ApkMetadata",
+   "metadata": {
+    "package": "zlib",
+    "originPackage": "zlib",
+    "maintainer": "Natanael Copa <ncopa@alpinelinux.org>",
+    "version": "1.2.11-r3",
+    "license": "Zlib",
+    "architecture": "x86_64",
+    "url": "https://zlib.net/",
+    "description": "A compression/decompression Library",
+    "size": 51440,
+    "installedSize": 110592,
+    "pullDependencies": "so:libc.musl-x86_64.so.1",
+    "pullChecksum": "Q1Nr9Y2nTUjgARywC34n9NEUt3LO4=",
+    "gitCommitOfApkPort": "388a4fb3640f8ccbd18e105df3ad741dca4247e1",
+    "files": [
+     {
+      "path": "/lib",
+      "digest": {
+       "algorithm": "",
+       "value": ""
+      }
+     },
+     {
+      "path": "/lib/libz.so.1",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "777",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1a2H8hP24ryCAGf8fnc1Nha9IIHc="
+      }
+     },
+     {
+      "path": "/lib/libz.so.1.2.11",
+      "ownerUid": "0",
+      "ownerGid": "0",
+      "permissions": "755",
+      "digest": {
+       "algorithm": "sha1",
+       "value": "Q1bLzKAuJLsPS23RBo+pMAHc+KOn4="
+      }
+     }
+    ]
+   }
+  }
+ ],
+ "artifactRelationships": [],
+ "source": {
+  "type": "image",
+  "target": {
+   "userInput": "alpine:latest",
+   "imageID": "sha256:6dbb9cc54074106d46d4ccb330f2a40a682d49dda5f4844962b7dce9fe44aaec",
+   "manifestDigest": "sha256:da67fd4f37edac865097deafd160999543243f09e055c508d369ce3ff72e6a87",
+   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+   "tags": [
+    "alpine:latest"
+   ],
+   "imageSize": 5608905,
+   "layers": [
+    {
+     "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+     "digest": "sha256:b2d5eeeaba3a22b9b8aa97261957974a6bd65274ebd43e1d81d0a7b8b752b116",
+     "size": 5608905
+    }
+   ],
+   "manifest": "eyJzY2hlbWFWZXJzaW9uIjoyLCJtZWRpYVR5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwiY29uZmlnIjp7Im1lZGlhVHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuY29udGFpbmVyLmltYWdlLnYxK2pzb24iLCJzaXplIjoxNDcyLCJkaWdlc3QiOiJzaGEyNTY6NmRiYjljYzU0MDc0MTA2ZDQ2ZDRjY2IzMzBmMmE0MGE2ODJkNDlkZGE1ZjQ4NDQ5NjJiN2RjZTlmZTQ0YWFlYyJ9LCJsYXllcnMiOlt7Im1lZGlhVHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuaW1hZ2Uucm9vdGZzLmRpZmYudGFyLmd6aXAiLCJzaXplIjo1ODc5ODA4LCJkaWdlc3QiOiJzaGEyNTY6YjJkNWVlZWFiYTNhMjJiOWI4YWE5NzI2MTk1Nzk3NGE2YmQ2NTI3NGViZDQzZTFkODFkMGE3YjhiNzUyYjExNiJ9XX0=",
+   "config": "eyJhcmNoaXRlY3R1cmUiOiJhbWQ2NCIsImNvbmZpZyI6eyJIb3N0bmFtZSI6IiIsIkRvbWFpbm5hbWUiOiIiLCJVc2VyIjoiIiwiQXR0YWNoU3RkaW4iOmZhbHNlLCJBdHRhY2hTdGRvdXQiOmZhbHNlLCJBdHRhY2hTdGRlcnIiOmZhbHNlLCJUdHkiOmZhbHNlLCJPcGVuU3RkaW4iOmZhbHNlLCJTdGRpbk9uY2UiOmZhbHNlLCJFbnYiOlsiUEFUSD0vdXNyL2xvY2FsL3NiaW46L3Vzci9sb2NhbC9iaW46L3Vzci9zYmluOi91c3IvYmluOi9zYmluOi9iaW4iXSwiQ21kIjpbIi9iaW4vc2giXSwiSW1hZ2UiOiJzaGEyNTY6ZDNkNDU1NGY4YjA3Y2Y1OTg5NGJmYjM1NTFlMTBmODlhNTU5YjI0ZWUwOTkyYzQ5MDBjNTQxNzU1OTZiMTM4OSIsIlZvbHVtZXMiOm51bGwsIldvcmtpbmdEaXIiOiIiLCJFbnRyeXBvaW50IjpudWxsLCJPbkJ1aWxkIjpudWxsLCJMYWJlbHMiOm51bGx9LCJjb250YWluZXIiOiI2MGEzY2RkMTI4YThiMzczYjMxM2VkM2UxMDgzZmY0NWU2YmFkYWFkNWRjYTUxODcyODJiMDA1YzM4ZDA0NzEyIiwiY29udGFpbmVyX2NvbmZpZyI6eyJIb3N0bmFtZSI6IjYwYTNjZGQxMjhhOCIsIkRvbWFpbm5hbWUiOiIiLCJVc2VyIjoiIiwiQXR0YWNoU3RkaW4iOmZhbHNlLCJBdHRhY2hTdGRvdXQiOmZhbHNlLCJBdHRhY2hTdGRlcnIiOmZhbHNlLCJUdHkiOmZhbHNlLCJPcGVuU3RkaW4iOmZhbHNlLCJTdGRpbk9uY2UiOmZhbHNlLCJFbnYiOlsiUEFUSD0vdXNyL2xvY2FsL3NiaW46L3Vzci9sb2NhbC9iaW46L3Vzci9zYmluOi91c3IvYmluOi9zYmluOi9iaW4iXSwiQ21kIjpbIi9iaW4vc2giLCItYyIsIiMobm9wKSAiLCJDTUQgW1wiL2Jpbi9zaFwiXSJdLCJJbWFnZSI6InNoYTI1NjpkM2Q0NTU0ZjhiMDdjZjU5ODk0YmZiMzU1MWUxMGY4OWE1NTliMjRlZTA5OTJjNDkwMGM1NDE3NTU5NmIxMzg5IiwiVm9sdW1lcyI6bnVsbCwiV29ya2luZ0RpciI6IiIsIkVudHJ5cG9pbnQiOm51bGwsIk9uQnVpbGQiOm51bGwsIkxhYmVscyI6e319LCJjcmVhdGVkIjoiMjAyMS0wNC0xNFQxOToxOTozOS42NDMyMzYxMzVaIiwiZG9ja2VyX3ZlcnNpb24iOiIxOS4wMy4xMiIsImhpc3RvcnkiOlt7ImNyZWF0ZWQiOiIyMDIxLTA0LTE0VDE5OjE5OjM5LjI2Nzg4NTQ5MVoiLCJjcmVhdGVkX2J5IjoiL2Jpbi9zaCAtYyAjKG5vcCkgQUREIGZpbGU6OGVjNjlkODgyZTdmMjlmMDY1MmQ1Mzc1NTcxNjBlNjM4MTY4NTUwZjczOGQwZDQ5ZjkwYTdlZjk2YmYzMTc4NyBpbiAvICJ9LHsiY3JlYXRlZCI6IjIwMjEtMDQtMTRUMTk6MTk6MzkuNjQzMjM2MTM1WiIsImNyZWF0ZWRfYnkiOiIvYmluL3NoIC1jICMobm9wKSAgQ01EIFtcIi9iaW4vc2hcIl0iLCJlbXB0eV9sYXllciI6dHJ1ZX1dLCJvcyI6ImxpbnV4Iiwicm9vdGZzIjp7InR5cGUiOiJsYXllcnMiLCJkaWZmX2lkcyI6WyJzaGEyNTY6YjJkNWVlZWFiYTNhMjJiOWI4YWE5NzI2MTk1Nzk3NGE2YmQ2NTI3NGViZDQzZTFkODFkMGE3YjhiNzUyYjExNiJdfX0=",
+   "repoDigests": [
+    "alpine@sha256:69e70a79f2d41ab5d637de98c1e0b055206ba40a8145e7bddb55ccc04e13cf8f"
+   ],
+   "scope": "Squashed"
+  }
+ },
+ "distro": {
+  "name": "alpine",
+  "version": "3.13.5",
+  "idLike": ""
+ },
+ "descriptor": {
+  "name": "syft",
+  "version": "0.15.2"
+ },
+ "schema": {
+  "version": "1.1.0",
+  "url": "https://raw.githubusercontent.com/anchore/syft/main/schema/json/schema-1.1.0.json"
+ }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**: Fixes a bug in grype wrapper where special characters in sboms that we normally filter on for subcommand execution ("[;&<>]" were causing those sboms to not be analyzable. utils.run_piped_command_list() can now be optionally parameterized to skip that filtering, which the grype-wrapper now uses. The default for the function elsewhere is still to do the filtering.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #:1056

**Special notes**:


