### PR TITLE
Handle too many active dbs

### DIFF
--- a/anchore_engine/db/db_grype_db_feed_metadata.py
+++ b/anchore_engine/db/db_grype_db_feed_metadata.py
@@ -1,0 +1,27 @@
+from anchore_engine.db import GrypeDBFeedMetadata
+from anchore_engine.subsys import logger
+
+
+class NoActiveGrypeDB(Exception):
+    def __init__(self):
+        super().__init__("No active grypedb available")
+
+
+def get_most_recent_active_grypedb(session) -> GrypeDBFeedMetadata:
+    """
+    Queries active GrypeDBFeedMetadata order by created at desc
+    If no active grypedb, raises NoActiveGrypeDB
+    """
+    active_db = (
+        session.query(GrypeDBFeedMetadata)
+        .filter(GrypeDBFeedMetadata.active.is_(True))
+        .order_by(GrypeDBFeedMetadata.created_at.desc())
+        .limit(1)
+        .all()
+    )
+
+    if not active_db:
+        logger.error("No active grypedb found")
+        raise NoActiveGrypeDB
+    else:
+        return active_db[0]

--- a/anchore_engine/services/policy_engine/__init__.py
+++ b/anchore_engine/services/policy_engine/__init__.py
@@ -333,11 +333,8 @@ def handle_grypedb_sync(*args, **kwargs):
         provider = get_provider_name(get_section_for_vulnerabilities())
         if provider == "grype":  # TODO fix this
             try:
-                result = GrypeDBSyncTask().execute()
-
-                if result:
-                    logger.info("Grype DB synced to local instance via handler")
-            #         TODO narrow scope of exceptions in handlers. see https://github.com/anchore/anchore-engine/issues/1005
+                GrypeDBSyncTask().execute()
+            # TODO narrow scope of exceptions in handlers. see https://github.com/anchore/anchore-engine/issues/1005
             except Exception:
                 logger.exception(
                     "Error encountered when running GrypeDBSyncTask from async monitor"

--- a/anchore_engine/services/policy_engine/engine/vulns/scanners.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/scanners.py
@@ -18,7 +18,7 @@ from anchore_engine.common.models.policy_engine import (
 from anchore_engine.services.policy_engine.engine import vulnerabilities
 from anchore_engine.services.policy_engine.engine.feeds.grypedb_sync import (
     GrypeDBSyncManager,
-    NoActiveGrypeDB,
+    NoActiveDBSyncError,
 )
 from anchore_engine.subsys import logger
 from anchore_engine.utils import timer
@@ -202,8 +202,8 @@ class GrypeScanner:
 
         # check and run grype sync if necessary
         try:
-            GrypeDBSyncManager.run_grypedb_sync()
-        except NoActiveGrypeDB:
+            GrypeDBSyncManager.run_grypedb_sync(db_session)
+        except NoActiveDBSyncError:
             logger.exception("Failed to initialize local vulnerability database")
             report.problems.append(
                 VulnerabilityScanProblem(

--- a/tests/integration/db/test_grype_db_feed_metadata.py
+++ b/tests/integration/db/test_grype_db_feed_metadata.py
@@ -1,0 +1,54 @@
+from datetime import datetime
+
+import pytest
+
+from anchore_engine.db import GrypeDBFeedMetadata, session_scope
+from anchore_engine.db.db_grype_db_feed_metadata import (
+    NoActiveGrypeDB,
+    get_most_recent_active_grypedb,
+)
+from tests.fixtures import anchore_db
+
+meta_objs = [
+    GrypeDBFeedMetadata(
+        archive_checksum="first_meta",
+        schema_version="2",
+        object_url="1234",
+        active=True,
+        built_at=datetime.utcnow(),
+    ),
+    GrypeDBFeedMetadata(
+        archive_checksum="second_meta",
+        schema_version="2",
+        object_url="1234",
+        active=True,
+        built_at=datetime.utcnow(),
+    ),
+]
+
+
+def test_get_most_recent_active_grypedb(anchore_db):
+    with session_scope() as session:
+        session.add(meta_objs[0])
+        session.commit()
+
+        grype_db = get_most_recent_active_grypedb(session)
+        assert isinstance(grype_db, GrypeDBFeedMetadata) is True
+        assert grype_db.archive_checksum == "first_meta"
+
+
+def test_get_most_recent_active_grypedb_no_active_Db(anchore_db):
+    with session_scope() as session:
+        with pytest.raises(NoActiveGrypeDB):
+            get_most_recent_active_grypedb(session)
+
+
+def test_get_most_recent_active_grypedb_multiple_active(anchore_db):
+    with session_scope() as session:
+        for meta in meta_objs:
+            session.add(meta)
+        session.commit()
+
+        grype_db = get_most_recent_active_grypedb(session)
+        assert isinstance(grype_db, GrypeDBFeedMetadata) is True
+        assert grype_db.archive_checksum == "second_meta"

--- a/tests/unit/anchore_engine/services/policy_engine/engine/feeds/test_grypedb_sync.py
+++ b/tests/unit/anchore_engine/services/policy_engine/engine/feeds/test_grypedb_sync.py
@@ -3,15 +3,17 @@ from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-import sqlalchemy
 
 from anchore_engine.db import GrypeDBFeedMetadata
+from anchore_engine.db.db_grype_db_feed_metadata import (
+    NoActiveGrypeDB,
+    get_most_recent_active_grypedb,
+)
 from anchore_engine.services.policy_engine.engine.feeds.grypedb_sync import (
     GrypeDBSyncLock,
     GrypeDBSyncLockAquisitionTimeout,
     GrypeDBSyncManager,
-    NoActiveGrypeDB,
-    TooManyActiveGrypeDBs,
+    NoActiveDBSyncError,
 )
 
 
@@ -23,10 +25,12 @@ class TestGrypeDBSyncTask:
         """
 
         def _mock_query(mocked_output):
+            def _mocked_call(session):
+                return mocked_output
+
             monkeypatch.setattr(
-                GrypeDBSyncManager,
-                "_query_active_dbs",
-                Mock(return_value=mocked_output),
+                "anchore_engine.services.policy_engine.engine.feeds.grypedb_sync.get_most_recent_active_grypedb",
+                _mocked_call,
             )
 
         return _mock_query
@@ -54,8 +58,8 @@ class TestGrypeDBSyncTask:
         Provides ability to mock all class methods necessary to run a sync as a unit test
         """
 
-        def _mock(mock_active_dbs=[], mock_local_checksum=""):
-            mock_query_active_dbs_with_data(mock_active_dbs)
+        def _mock(mock_active_db=[], mock_local_checksum=""):
+            mock_query_active_dbs_with_data(mock_active_db)
             mock_get_local_grypedb_checksum(mock_local_checksum)
 
         return _mock
@@ -92,36 +96,26 @@ class TestGrypeDBSyncTask:
             GrypeDBSyncManager, "_update_grypedb", _mock_update_grypedb_for_thread1
         )
 
-    def test_no_active_grypedb(self, mock_calls_for_sync):
-        mock_calls_for_sync(
-            mock_active_dbs=None,
-            mock_local_checksum="eef3b1bcd5728346cb1b30eae09647348bacfbde3ba225d70cb0374da249277c",
-        )
-
-        with pytest.raises(NoActiveGrypeDB):
-            GrypeDBSyncManager.run_grypedb_sync()
-
-    def test_too_many_active_grypedbs(self, monkeypatch):
-        def _raise_multiple_results_found():
-            raise sqlalchemy.orm.exc.MultipleResultsFound
+    def test_no_active_grypedb(self, monkeypatch):
+        def _mocked_call(session):
+            raise NoActiveGrypeDB
 
         monkeypatch.setattr(
-            GrypeDBSyncManager,
-            "_query_active_dbs",
-            _raise_multiple_results_found,
+            "anchore_engine.services.policy_engine.engine.feeds.grypedb_sync.get_most_recent_active_grypedb",
+            _mocked_call,
         )
 
-        with pytest.raises(TooManyActiveGrypeDBs):
-            GrypeDBSyncManager.run_grypedb_sync()
+        with pytest.raises(NoActiveDBSyncError):
+            GrypeDBSyncManager.run_grypedb_sync(Mock())
 
     def test_matching_checksums(self, mock_calls_for_sync):
         checksum = "eef3b1bcd5728346cb1b30eae09647348bacfbde3ba225d70cb0374da249277c"
         mock_calls_for_sync(
-            mock_active_dbs=GrypeDBFeedMetadata(archive_checksum=checksum),
+            mock_active_db=GrypeDBFeedMetadata(archive_checksum=checksum),
             mock_local_checksum=checksum,
         )
 
-        sync_ran = GrypeDBSyncManager.run_grypedb_sync()
+        sync_ran = GrypeDBSyncManager.run_grypedb_sync(Mock())
 
         assert sync_ran is False
 
@@ -134,7 +128,7 @@ class TestGrypeDBSyncTask:
         )
 
         mock_calls_for_sync(
-            mock_active_dbs=GrypeDBFeedMetadata(archive_checksum=global_checksum),
+            mock_active_db=GrypeDBFeedMetadata(archive_checksum=global_checksum),
             mock_local_checksum=local_checksum,
         )
 
@@ -145,7 +139,7 @@ class TestGrypeDBSyncTask:
 
         # pass a file path to bypass connection to catalog to retrieve tar from object storage
         sync_ran = GrypeDBSyncManager.run_grypedb_sync(
-            grypedb_file_path="test/bypass/catalog.txt"
+            Mock(), grypedb_file_path="test/bypass/catalog.txt"
         )
 
         assert sync_ran is True
@@ -162,7 +156,7 @@ class TestGrypeDBSyncTask:
         mock_lock = MagicMock()
         monkeypatch.setattr(GrypeDBSyncLock, "_lock", mock_lock)
         mock_calls_for_sync(
-            mock_active_dbs=GrypeDBFeedMetadata(archive_checksum=checksum),
+            mock_active_db=GrypeDBFeedMetadata(archive_checksum=checksum),
             mock_local_checksum="",
         )
 
@@ -171,7 +165,7 @@ class TestGrypeDBSyncTask:
         )
 
         sync_ran = GrypeDBSyncManager.run_grypedb_sync(
-            grypedb_file_path="test/bypass/catalog.txt"
+            Mock(), grypedb_file_path="test/bypass/catalog.txt"
         )
 
         assert sync_ran is True
@@ -202,7 +196,7 @@ class TestGrypeDBSyncTask:
                 if GrypeDBSyncLock._lock.locked():
                     lock_acquired = True
                     synchronous_task = GrypeDBSyncManager.run_grypedb_sync(
-                        grypedb_file_path="test/bypass/catalog.txt"
+                        Mock(), grypedb_file_path="test/bypass/catalog.txt"
                     )
                     break
                 else:
@@ -226,7 +220,7 @@ class TestGrypeDBSyncTask:
         with ThreadPoolExecutor() as executor:
             # run thread1
             thread1 = executor.submit(
-                GrypeDBSyncManager.run_grypedb_sync, "test/bypass/catalog.txt"
+                GrypeDBSyncManager.run_grypedb_sync, Mock(), "test/bypass/catalog.txt"
             )
 
             # Wait until thread1 has taken the lock and then run thread2 with timeout of ~5 seconds
@@ -236,7 +230,7 @@ class TestGrypeDBSyncTask:
                     lock_acquired = True
                     with pytest.raises(GrypeDBSyncLockAquisitionTimeout):
                         GrypeDBSyncManager.run_grypedb_sync(
-                            grypedb_file_path="test/bypass/catalog.txt"
+                            Mock(), grypedb_file_path="test/bypass/catalog.txt"
                         )
                     break
                 else:


### PR DESCRIPTION
This PR does two separate things:

1. Changes GrypeDBSyncManager to gracefully handle situations in which there are TooManyActiveDBs. It does this by querying all the active dbs and determines the true active to be the most rececntly created. It then set all the other active dbs to active=False. By doing this, when the next sync runs, the sync task will cleanup all inactive dbs. This new public getter is called `resolve_and_get_active_grypedb`
2. Changes how sessions are managed in the class by having db sessions get passed by the caller
