### PR TITLE
Enable GrypeDB to sync without creating FeedGroupMetadata

### DIFF
--- a/anchore_engine/apis/exceptions.py
+++ b/anchore_engine/apis/exceptions.py
@@ -64,6 +64,10 @@ class BadGatewayError(AnchoreApiError):
     __response_code__ = 502
 
 
+class UnprocessableEntityError(AnchoreApiError):
+    __response_code__ = 422
+
+
 class MissingRequiredField(BadRequest):
     def __init__(self, required_property, because_of_properties=None):
         if because_of_properties:

--- a/anchore_engine/apis/exceptions.py
+++ b/anchore_engine/apis/exceptions.py
@@ -64,8 +64,8 @@ class BadGatewayError(AnchoreApiError):
     __response_code__ = 502
 
 
-class UnprocessableEntityError(AnchoreApiError):
-    __response_code__ = 422
+class HTTPNotImplementedError(AnchoreApiError):
+    __response_code__ = 501
 
 
 class MissingRequiredField(BadRequest):

--- a/anchore_engine/common/models/schemas.py
+++ b/anchore_engine/common/models/schemas.py
@@ -3,7 +3,7 @@ Shared global location for all JSON serialization schemas. They should only refe
 can import cleanly into any service or module.
 """
 import datetime
-from typing import Dict
+from typing import Dict, Optional
 
 import marshmallow
 from marshmallow import Schema, fields, post_load
@@ -415,11 +415,34 @@ class ImportQueueMessage(JsonSerializable):
         self.type = type
 
 
+class GrypeDBListing(JsonSerializable):
+    class GrypeDBListingV1Schema(Schema):
+        built = fields.DateTime()
+        version = fields.Int()
+        url = fields.Str()
+        checksum = fields.Str()
+
+        @post_load
+        def make(self, data, **kwargs):
+            return GrypeDBListing(**data)
+
+    __schema__ = GrypeDBListingV1Schema()
+
+    def __init__(self, built, version, url, checksum):
+        self.built = built
+        self.version = version
+        self.url = url
+        self.checksum = checksum
+
+
 class FeedAPIGroupRecord(JsonSerializable):
     class FeedAPIGroupV1Schema(Schema):
         name = fields.Str()
         access_tier = fields.Int()
         description = fields.Str()
+        grype_listing = fields.Nested(
+            GrypeDBListing.GrypeDBListingV1Schema, allow_none=True
+        )
 
         @post_load
         def make(self, data, **kwargs):
@@ -427,10 +450,17 @@ class FeedAPIGroupRecord(JsonSerializable):
 
     __schema__ = FeedAPIGroupV1Schema()
 
-    def __init__(self, name="", access_tier=0, description=""):
+    def __init__(
+        self,
+        name="",
+        access_tier=0,
+        description="",
+        grype_listing: Optional[GrypeDBListing] = None,
+    ):
         self.name = name
         self.access_tier = access_tier
         self.description = description
+        self.grype_listing = grype_listing
 
 
 class FeedAPIRecord(JsonSerializable):

--- a/anchore_engine/services/policy_engine/api/controllers/feeds.py
+++ b/anchore_engine/services/policy_engine/api/controllers/feeds.py
@@ -24,6 +24,9 @@ from anchore_engine.common.models.policy_engine import (
     FeedMetadata,
 )
 from anchore_engine.services.policy_engine.engine.feeds import db, sync
+from anchore_engine.services.policy_engine.engine.feeds.sync_utils import (
+    GRYPE_DB_FEED_NAME,
+)
 from anchore_engine.services.policy_engine.engine.tasks import FeedsUpdateTask
 from anchore_engine.subsys import logger as log
 
@@ -214,7 +217,7 @@ def delete_feed(feed):
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
 def delete_group(feed, group):
     session = db.get_session()
-    if feed == "grypedb":
+    if feed == GRYPE_DB_FEED_NAME:
         raise UnprocessableEntityError(
             message="Cannot delete individual groups for grypedb feed. Must delete entire feed.",
             detail={},

--- a/anchore_engine/services/policy_engine/api/controllers/feeds.py
+++ b/anchore_engine/services/policy_engine/api/controllers/feeds.py
@@ -131,11 +131,6 @@ def sync_feeds(sync=True, force_flush=False):
 def toggle_feed_enabled(feed, enabled):
     if type(enabled) != bool:
         raise BadRequest(message="state must be a boolean", detail={"value": enabled})
-    if feed == GRYPE_DB_FEED_NAME:
-        raise HTTPNotImplementedError(
-            message="Cannot disable/enable grypedb feed.",
-            detail={},
-        )
     session = db.get_session()
     try:
         f = db.set_feed_enabled(session, feed, enabled)
@@ -162,7 +157,7 @@ def toggle_group_enabled(feed, group, enabled):
         raise BadRequest(message="state must be a boolean", detail={"value": enabled})
     if feed == GRYPE_DB_FEED_NAME:
         raise HTTPNotImplementedError(
-            message="Cannot disable/enable groups for grypedb feed.",
+            message="Enabling and disabling groups for grypedb feed is not currently supported.",
             detail={},
         )
     session = db.get_session()
@@ -190,7 +185,7 @@ def toggle_group_enabled(feed, group, enabled):
 def delete_feed(feed):
     if feed == GRYPE_DB_FEED_NAME:
         raise HTTPNotImplementedError(
-            message="Cannot delete grypedb feed.",
+            message="Deleting the grypedb feed is not yet supported.",
             detail={},
         )
     session = db.get_session()
@@ -226,12 +221,12 @@ def delete_feed(feed):
 
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
 def delete_group(feed, group):
-    session = db.get_session()
     if feed == GRYPE_DB_FEED_NAME:
         raise HTTPNotImplementedError(
-            message="Cannot delete individual groups for grypedb feed.",
+            message="Deleting individual groups for the grypedb feed is not yet supported.",
             detail={},
         )
+    session = db.get_session()
     try:
         f = db.lookup_feed_group(db_session=session, feed_name=feed, group_name=group)
         if not f:

--- a/anchore_engine/services/policy_engine/api/controllers/feeds.py
+++ b/anchore_engine/services/policy_engine/api/controllers/feeds.py
@@ -9,6 +9,7 @@ from anchore_engine.apis.exceptions import (
     BadRequest,
     ConflictingRequest,
     ResourceNotFound,
+    UnprocessableEntityError,
 )
 from anchore_engine.clients.services.simplequeue import (
     LeaseAcquisitionFailedError,
@@ -34,7 +35,6 @@ def list_feeds(refresh_counts=False):
     """
     GET /feeds
 
-    :param include_counts (ignored since counts are handled in the record now)
     :param refresh_counts: forcibly update the group counts (not normally necessary)
     :return:
     """
@@ -214,6 +214,11 @@ def delete_feed(feed):
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
 def delete_group(feed, group):
     session = db.get_session()
+    if feed == "grypedb":
+        raise UnprocessableEntityError(
+            message="Cannot delete individual groups for grypedb feed. Must delete entire feed.",
+            detail={},
+        )
     try:
         f = db.lookup_feed_group(db_session=session, feed_name=feed, group_name=group)
         if not f:

--- a/anchore_engine/services/policy_engine/api/controllers/feeds.py
+++ b/anchore_engine/services/policy_engine/api/controllers/feeds.py
@@ -8,8 +8,8 @@ from anchore_engine.apis.exceptions import (
     AnchoreApiError,
     BadRequest,
     ConflictingRequest,
+    HTTPNotImplementedError,
     ResourceNotFound,
-    UnprocessableEntityError,
 )
 from anchore_engine.clients.services.simplequeue import (
     LeaseAcquisitionFailedError,
@@ -17,12 +17,9 @@ from anchore_engine.clients.services.simplequeue import (
 )
 from anchore_engine.common.errors import AnchoreError
 from anchore_engine.common.helpers import make_response_error
+from anchore_engine.common.models.policy_engine import FeedGroupMetadata, FeedMetadata
 from anchore_engine.db import FeedGroupMetadata as DbFeedGroupMetadata
 from anchore_engine.db import FeedMetadata as DbFeedMetadata
-from anchore_engine.common.models.policy_engine import (
-    FeedGroupMetadata,
-    FeedMetadata,
-)
 from anchore_engine.services.policy_engine.engine.feeds import db, sync
 from anchore_engine.services.policy_engine.engine.feeds.sync_utils import (
     GRYPE_DB_FEED_NAME,
@@ -218,7 +215,7 @@ def delete_feed(feed):
 def delete_group(feed, group):
     session = db.get_session()
     if feed == GRYPE_DB_FEED_NAME:
-        raise UnprocessableEntityError(
+        raise HTTPNotImplementedError(
             message="Cannot delete individual groups for grypedb feed. Must delete entire feed.",
             detail={},
         )

--- a/anchore_engine/services/policy_engine/api/controllers/feeds.py
+++ b/anchore_engine/services/policy_engine/api/controllers/feeds.py
@@ -131,7 +131,11 @@ def sync_feeds(sync=True, force_flush=False):
 def toggle_feed_enabled(feed, enabled):
     if type(enabled) != bool:
         raise BadRequest(message="state must be a boolean", detail={"value": enabled})
-
+    if feed == GRYPE_DB_FEED_NAME:
+        raise HTTPNotImplementedError(
+            message="Cannot disable/enable grypedb feed.",
+            detail={},
+        )
     session = db.get_session()
     try:
         f = db.set_feed_enabled(session, feed, enabled)
@@ -156,7 +160,11 @@ def toggle_feed_enabled(feed, enabled):
 def toggle_group_enabled(feed, group, enabled):
     if type(enabled) != bool:
         raise BadRequest(message="state must be a boolean", detail={"value": enabled})
-
+    if feed == GRYPE_DB_FEED_NAME:
+        raise HTTPNotImplementedError(
+            message="Cannot disable/enable groups for grypedb feed.",
+            detail={},
+        )
     session = db.get_session()
     try:
         g = db.set_feed_group_enabled(session, feed, group, enabled)
@@ -180,6 +188,11 @@ def toggle_group_enabled(feed, group, enabled):
 
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
 def delete_feed(feed):
+    if feed == GRYPE_DB_FEED_NAME:
+        raise HTTPNotImplementedError(
+            message="Cannot delete grypedb feed.",
+            detail={},
+        )
     session = db.get_session()
     try:
         f = db.lookup_feed(db_session=session, feed_name=feed)
@@ -216,7 +229,7 @@ def delete_group(feed, group):
     session = db.get_session()
     if feed == GRYPE_DB_FEED_NAME:
         raise HTTPNotImplementedError(
-            message="Cannot delete individual groups for grypedb feed. Must delete entire feed.",
+            message="Cannot delete individual groups for grypedb feed.",
             detail={},
         )
     try:

--- a/anchore_engine/services/policy_engine/engine/feeds/client.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/client.py
@@ -14,7 +14,7 @@ from anchore_engine.clients.grype_wrapper import GrypeWrapperSingleton
 from anchore_engine.common.models.schemas import (
     FeedAPIGroupRecord,
     FeedAPIRecord,
-    GrypeDBListing
+    GrypeDBListing,
 )
 from anchore_engine.services.policy_engine.engine.feeds import (
     FeedGroupList,

--- a/anchore_engine/services/policy_engine/engine/feeds/client.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/client.py
@@ -11,7 +11,11 @@ import requests
 import requests.exceptions
 
 from anchore_engine.clients.grype_wrapper import GrypeWrapperSingleton
-from anchore_engine.common.models.schemas import FeedAPIGroupRecord, FeedAPIRecord
+from anchore_engine.common.models.schemas import (
+    FeedAPIGroupRecord,
+    FeedAPIRecord,
+    GrypeDBListing
+)
 from anchore_engine.services.policy_engine.engine.feeds import (
     FeedGroupList,
     FeedList,
@@ -25,6 +29,7 @@ from anchore_engine.utils import (
     CommandException,
     ensure_bytes,
     ensure_str,
+    rfc3339str_to_datetime,
 )
 
 FEED_DATA_ITEMS_PATH = "data.item"
@@ -472,13 +477,33 @@ class GrypeDBServiceClient(IFeedSource):
             ]
         )
 
+    def _list_feed_groups(self):
+        logger.info("Downloading grypedb listing.json from {}".format(self.feed_url))
+        listing_response = self.http_client.execute_request(
+            requests.get, self.feed_url, retries=self.RETRY_COUNT
+        )
+        if not listing_response.success:
+            raise HTTPStatusException(listing_response)
+        listings_json = json.loads(listing_response.content.decode("utf-8"))
+        required_grype_db_version = self._get_supported_grype_db_version()
+        available_dbs = listings_json.get("available").get(required_grype_db_version)
+        if not available_dbs:
+            raise GrypeDBUnavailable(required_grype_db_version)
+        raw_db_listing = available_dbs[0]
+        logger.info("Found relevant grypedb listing: {}".format(raw_db_listing))
+        return raw_db_listing
+
     def list_feed_groups(self, feed: str) -> FeedGroupList:
+        raw_db_listing = self._list_feed_groups()
+        grype_db_listing = dict(raw_db_listing)
+        grype_db_listing["built"] = rfc3339str_to_datetime(raw_db_listing["built"])
         return FeedGroupList(
             groups=[
                 FeedAPIGroupRecord(
                     name="grypedb:vulnerabilities",
                     description="grypedb:vulnerabilities group",
                     access_tier="0",
+                    grype_listing=GrypeDBListing(**grype_db_listing),
                 )
             ]
         )
@@ -495,30 +520,16 @@ class GrypeDBServiceClient(IFeedSource):
         except KeyError as exc:
             raise InvalidGrypeVersionResponse(json.dumps(version_response)) from exc
 
-    def _get_raw_feed_group_data(
-        self,
-    ) -> Tuple[Dict, HTTPClientResponse]:
-        logger.info("Downloading grypedb listing.json from {}".format(self.feed_url))
-        listing_response = self.http_client.execute_request(
-            requests.get, self.feed_url, retries=self.RETRY_COUNT
-        )
-        if not listing_response.success:
-            raise HTTPStatusException(listing_response)
-        listings_json = json.loads(listing_response.content.decode("utf-8"))
-        required_grype_db_version = self._get_supported_grype_db_version()
-        available_dbs = listings_json.get("available").get(required_grype_db_version)
-        if not available_dbs:
-            raise GrypeDBUnavailable(required_grype_db_version)
-        db_listing = available_dbs[0]
-        logger.info("Found relevant grypedb listing: {}".format(db_listing))
-        grype_db_url = db_listing.get("url")
+    def _get_feed_group_data(self) -> Tuple[Dict, HTTPClientResponse]:
+        grype_db_listing = self._list_feed_groups()
+        grype_db_url = grype_db_listing["url"]
         logger.info("Downloading grypedb {}".format(grype_db_url))
         grype_db_download_response = self.http_client.execute_request(
             requests.get, grype_db_url, retries=self.RETRY_COUNT
         )
         if not grype_db_download_response.success:
             raise HTTPStatusException(grype_db_download_response)
-        return db_listing, grype_db_download_response
+        return grype_db_listing, grype_db_download_response
 
     def get_feed_group_data(
         self,
@@ -528,7 +539,7 @@ class GrypeDBServiceClient(IFeedSource):
         next_token: str = None,
     ):
         try:
-            listing_json, record = self._get_raw_feed_group_data()
+            listing_json, record = self._get_feed_group_data()
             if record.content_type != "application/x-tar":
                 raise UnexpectedMIMEType(record.content_type)
             return GroupData(

--- a/anchore_engine/services/policy_engine/engine/feeds/client.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/client.py
@@ -505,7 +505,7 @@ class GrypeDBServiceClient(IFeedSource):
         :return: Grype DB listing.json
         :rtype: Dict[str, Union[int, str]
         """
-        logger.info("Downloading grypedb listing.json from {}".format(self.feed_url))
+        logger.info("Downloading grypedb listing.json from %s", self.feed_url)
         listing_response = self.http_client.execute_request(
             requests.get, self.feed_url, retries=self.RETRY_COUNT
         )
@@ -517,7 +517,7 @@ class GrypeDBServiceClient(IFeedSource):
         if not available_dbs:
             raise GrypeDBUnavailable(required_grype_db_version)
         raw_db_listing = available_dbs[0]
-        logger.info("Found relevant grypedb listing: {}".format(raw_db_listing))
+        logger.info("Found relevant grypedb listing: %s", raw_db_listing)
         return raw_db_listing
 
     def list_feed_groups(self, feed: str) -> FeedGroupList:
@@ -574,7 +574,7 @@ class GrypeDBServiceClient(IFeedSource):
         """
         grype_db_listing = self._list_feed_groups()
         grype_db_url = grype_db_listing["url"]
-        logger.info("Downloading grypedb {}".format(grype_db_url))
+        logger.info("Downloading grypedb %s", grype_db_url)
         grype_db_download_response = self.http_client.execute_request(
             requests.get, grype_db_url, retries=self.RETRY_COUNT
         )
@@ -619,7 +619,7 @@ class GrypeDBServiceClient(IFeedSource):
                 },
             )
         except (HTTPStatusException, json.JSONDecodeError, UnicodeDecodeError) as e:
-            logger.debug("Error executing grype DB data download: {}".format(e))
+            logger.debug("Error executing grype DB data download: %s", e)
             raise e
 
 
@@ -664,11 +664,10 @@ def get_grype_db_client(sync_config: SyncConfig) -> GrypeDBServiceClient:
     """
 
     logger.debug(
-        "Initializing a grype db client: url={}, conn_timeout={}, read_timeout={}".format(
-            sync_config.url,
-            sync_config.connection_timeout_seconds,
-            sync_config.read_timeout_seconds,
-        )
+        "Initializing a grype db client: url=%s, conn_timeout=%d, read_timeout=%d",
+        sync_config.url,
+        sync_config.connection_timeout_seconds,
+        sync_config.read_timeout_seconds,
     )
 
     return GrypeDBServiceClient(

--- a/anchore_engine/services/policy_engine/engine/feeds/feeds.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/feeds.py
@@ -215,6 +215,18 @@ class DataFeed(ABC):
         ...
 
     @abstractmethod
+    def group_by_name(self, group_name: str) -> Optional[FeedGroupMetadata]:
+        """
+        Gets the metadata record for the group with the given name.
+
+        :param group_name: the name of the group for which to retreive the metadata record
+        :type group_name: str
+        :return: the metadata record if it exists
+        :rtype: Optional[FeedGroupMetadata]
+        """
+        ...
+
+    @abstractmethod
     def flush_group(self, group_name: str) -> FeedGroupMetadata:
         """
         Flush a specific data group. Do a db flush, but not a commit at the end to keep the transaction open.
@@ -752,6 +764,17 @@ class GrypeDBFeed(DataFeed):
         :rtype: FeedGroupMetadata
         """
         raise NotImplementedError
+
+    def group_by_name(self, group_name: str) -> Optional[FeedGroupMetadata]:
+        """
+        Gets the metadata record for the group with the given name.
+
+        :param group_name: the name of the group for which to retreive the metadata record
+        :type group_name: str
+        :return: the metadata record if it exists
+        :rtype: Optional[FeedGroupMetadata]
+        """
+        return None
 
     def update_counts(self) -> None:
         """

--- a/anchore_engine/services/policy_engine/engine/feeds/feeds.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/feeds.py
@@ -830,7 +830,8 @@ class GrypeDBFeed(DataFeed):
                 errors.append((result.id, err))
         if len(errors) > 0:
             logger.error(
-                f"Failed to create/enqueue {len(errors)}/{len(image_ids)} refresh tasks."
+                f"Failed to create/enqueue %d/%d refresh tasks.",
+                (len(errors), len(image_ids)),
             )
             raise RefreshTaskCreationError(errors)
 
@@ -955,11 +956,9 @@ class GrypeDBFeed(DataFeed):
                 total_records_updated += 1
                 logger.info(
                     self._log_context.format_msg(
-                        "DB Update Progress: {}/{}".format(
-                            total_records_updated,
-                            group_download_result.total_records,
-                        ),
-                    )
+                        "DB Update Progress: %d/%d"
+                        % (total_records_updated, group_download_result.total_records)
+                    ),
                 )
             else:
                 # If checksum already exists and  updating, assign to instance variable so timestamps can be updated
@@ -968,7 +967,8 @@ class GrypeDBFeed(DataFeed):
             db.commit()
             logger.info(
                 self._log_context.format_msg(
-                    "DB Update Complete, Progress: {}/{}".format(
+                    "DB Update Complete, Progress: %d/%d"
+                    % (
                         total_records_updated,
                         group_download_result.total_records,
                     ),
@@ -1022,9 +1022,8 @@ class GrypeDBFeed(DataFeed):
 
             logger.info(
                 self._log_context.format_msg(
-                    "Syncing {} total update records into db".format(
-                        group_download_result.total_records
-                    ),
+                    "Syncing %d total update records into db"
+                    % group_download_result.total_records,
                 )
             )
             result.updated_record_count = self._process_group_file_records(
@@ -1034,7 +1033,7 @@ class GrypeDBFeed(DataFeed):
 
             logger.debug(
                 self._log_context.format_msg(
-                    "Updating last sync timestamp to {}".format(download_started),
+                    "Updating last sync timestamp to %s" % download_started,
                 )
             )
             # There is potential failures that could happen when downloading,
@@ -1058,14 +1057,13 @@ class GrypeDBFeed(DataFeed):
             result.total_time_seconds = time.time() - download_started.timestamp()
             logger.info(
                 self._log_context.format_msg(
-                    "Sync to db duration: {} sec".format(sync_time),
+                    "Sync to db duration: %d sec" % sync_time,
                 )
             )
             logger.info(
                 self._log_context.format_msg(
-                    "Total sync, including download, duration: {} sec".format(
-                        result.total_time_seconds
-                    ),
+                    "Total sync, including download, duration: %d sec"
+                    % result.total_time_seconds,
                 )
             )
 

--- a/anchore_engine/services/policy_engine/engine/feeds/grypedb_sync.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/grypedb_sync.py
@@ -79,7 +79,7 @@ class GrypeDBSyncManager:
             raise NoActiveDBSyncError
 
     @classmethod
-    def _get_local_grypedb_checksum(cls) -> str:
+    def _get_local_grypedb_checksum(cls) -> Optional[str]:
         """
         Returns checksum of grypedb on local instance
 
@@ -136,7 +136,7 @@ class GrypeDBSyncManager:
         archive_checksum = engine_metadata.archive_checksum
 
         # Verify that the checksum matches what was expected
-        if archive_checksum == active_grypedb.checksum:
+        if archive_checksum == active_grypedb.archive_checksum:
             # If so, Promote
             GrypeWrapperSingleton.get_instance().update_grype_db(archive_checksum)
         else:
@@ -144,7 +144,7 @@ class GrypeDBSyncManager:
             GrypeWrapperSingleton.get_instance().unstage_grype_db()
             raise GrypeDBSyncError(
                 "Unable to promote grype_db with archive checksum %s. It has been unstaged.",
-                active_grypedb.checksum,
+                active_grypedb.archive_checksum,
             )
 
     @staticmethod

--- a/anchore_engine/services/policy_engine/engine/feeds/sync.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/sync.py
@@ -11,22 +11,20 @@ import os
 import time
 import uuid
 from dataclasses import asdict
-from typing import List, Optional
+from typing import Dict, List, Union
 
 from anchore_engine.clients.services.catalog import CatalogClient
 from anchore_engine.common.models.schemas import (
     DownloadOperationConfiguration,
+    FeedAPIGroupRecord,
+    FeedAPIRecord,
     GroupDownloadOperationConfiguration,
     GroupDownloadOperationParams,
 )
 from anchore_engine.configuration import localconfig
-from anchore_engine.db import FeedGroupMetadata, FeedMetadata
-from anchore_engine.db import get_thread_scoped_session as get_session
+from anchore_engine.db import FeedGroupMetadata
 from anchore_engine.services.policy_engine.engine.feeds import IFeedSource
-from anchore_engine.services.policy_engine.engine.feeds.db import (
-    get_all_feeds,
-    get_all_feeds_detached,
-)
+from anchore_engine.services.policy_engine.engine.feeds.db import get_all_feeds_detached
 from anchore_engine.services.policy_engine.engine.feeds.download import (
     FeedDownloader,
     LocalFeedDataRepo,
@@ -34,7 +32,6 @@ from anchore_engine.services.policy_engine.engine.feeds.download import (
 from anchore_engine.services.policy_engine.engine.feeds.feeds import (
     FeedSyncResult,
     GroupSyncResult,
-    GrypeDBFeed,
     NvdV2Feed,
     PackagesFeed,
     VulnDBFeed,
@@ -108,162 +105,27 @@ class DataFeeds(object):
                 )
 
     @staticmethod
-    def _pivot_and_filter_feeds_by_config(
-        to_sync: list, source_found: list, db_found: list
-    ):
-        """
-
-        :param to_sync: list of feed names requested to be synced
-        :param source_found: list of feed names available as returned by the upstream source
-        :param db_found: list of db records that were updated as result of upstream metadata sync (this is to handle db update failures)
-        :return:
-        """
-        available = set(to_sync).intersection(set(source_found))
-        return {x.name: x for x in db_found if x.name in available}
-
-    @staticmethod
-    def sync_metadata(
+    def get_feed_group_information(
         feed_client: IFeedSource,
         to_sync: list = None,
-        operation_id: Optional[str] = None,
-    ) -> tuple:
-        """
-        Get metadata from source and sync db metadata records to that (e.g. add any new groups or feeds)
-        Executes as a unit-of-work for db, so will commit result and returns the records found on upstream source.
-
-        If a record exists in db but was not found upstream, it is not returned
-
-        :param feed_client:
-        :param to_sync: list of string feed names to sync metadata on
-        :return: tuple, first element: dict of names mapped to db records post-sync only including records successfully updated by upstream, second element is a list of tuples where each tuple is (failed_feed_name, error_obj)
-        """
-
+    ) -> Dict[str, Dict[str, Union[FeedAPIRecord, List[FeedAPIGroupRecord]]]]:
         if not to_sync:
-            return {}, []
+            return {}
 
-        db = get_session()
-        try:
-            logger.info(
-                "Syncing feed and group metadata from upstream source (operation_id={})".format(
-                    operation_id
-                )
-            )
-
-            source_resp = feed_client.list_feeds()
-            if to_sync:
-                feeds = filter(lambda x: x.name in to_sync, source_resp.feeds)
-            else:
-                feeds = []
-
-            failed = []
-            source_feeds = {
-                x.name: {
-                    "meta": x,
-                    "groups": feed_client.list_feed_groups(x.name).groups,
-                }
-                for x in feeds
+        source_resp = feed_client.list_feeds()
+        if to_sync:
+            feeds = filter(lambda x: x.name in to_sync, source_resp.feeds)
+        else:
+            feeds = []
+        source_feeds = {
+            x.name: {
+                "meta": x,
+                "groups": feed_client.list_feed_groups(x.name).groups,
             }
-            logger.debug("Upstream feeds available: %s", source_feeds)
-            db_feeds = DataFeeds._pivot_and_filter_feeds_by_config(
-                to_sync, list(source_feeds.keys()), get_all_feeds(db)
-            )
-
-            for feed_name, feed_api_record in source_feeds.items():
-                try:
-                    logger.info(
-                        "Syncing metadata for feed: {} (operation_id={})".format(
-                            feed_name, operation_id
-                        )
-                    )
-
-                    api_feed = feed_api_record["meta"]
-                    db_feed = db_feeds.get(api_feed.name)
-
-                    # Do this instead of a db.merge() to ensure no timestamps are reset or overwritten
-                    if not db_feed:
-                        logger.debug(
-                            "Adding new feed metadata record to db: {} (operation_id={})".format(
-                                api_feed.name, operation_id
-                            )
-                        )
-                        db_feed = FeedMetadata(
-                            name=api_feed.name,
-                            description=api_feed.description,
-                            access_tier=api_feed.access_tier,
-                            enabled=True,
-                        )
-                        db.add(db_feed)
-                        db.flush()
-                    else:
-                        logger.debug(
-                            "Feed metadata already in db: {} (operation_id={})".format(
-                                api_feed.name, operation_id
-                            )
-                        )
-
-                    # Check for any update
-                    db_feed.description = api_feed.description
-                    db_feed.access_tier = api_feed.access_tier
-
-                    db_groups = {x.name: x for x in db_feed.groups}
-                    for api_group in feed_api_record.get("groups", []):
-                        db_group = db_groups.get(api_group.name)
-                        # Do this instead of a db.merge() to ensure no timestamps are reset or overwritten
-                        if not db_group:
-                            logger.debug(
-                                "Adding new feed metadata record to db: {} (operation_id={})".format(
-                                    api_group.name, operation_id
-                                )
-                            )
-                            db_group = FeedGroupMetadata(
-                                name=api_group.name,
-                                description=api_group.description,
-                                access_tier=api_group.access_tier,
-                                feed=db_feed,
-                                enabled=True,
-                            )
-                            db_group.last_sync = None
-                            db.add(db_group)
-                        else:
-                            logger.debug(
-                                "Feed group metadata already in db: {} (operation_id={})".format(
-                                    api_group.name, operation_id
-                                )
-                            )
-
-                        db_group.access_tier = api_group.access_tier
-                        db_group.description = api_group.description
-                except Exception as e:
-                    logger.exception("Error syncing feed {}".format(feed_name))
-                    logger.warn(
-                        "Could not sync metadata for feed: {} (operation_id={})".format(
-                            feed_name, operation_id
-                        )
-                    )
-                    failed.append((feed_name, e))
-                finally:
-                    db.flush()
-
-            # Reload
-            db_feeds = DataFeeds._pivot_and_filter_feeds_by_config(
-                to_sync, list(source_feeds.keys()), get_all_feeds(db)
-            )
-
-            db.commit()
-            logger.info(
-                "Metadata sync from feeds upstream source complete (operation_id={})".format(
-                    operation_id
-                )
-            )
-            return db_feeds, failed
-        except Exception as e:
-            logger.error(
-                "Rolling back feed metadata update due to error: {} (operation_id={})".format(
-                    e, operation_id
-                )
-            )
-            db.rollback()
-            raise
+            for x in feeds
+        }
+        logger.debug("Upstream feeds available: %s", source_feeds)
+        return source_feeds
 
     @staticmethod
     def sync_from_fetched(
@@ -278,6 +140,7 @@ class DataFeeds(object):
         :param operation_id:
         :param catalog_client:
         :param fetched_repo:
+        :param full_flush:
         :return:
         """
         # Load the feed objects
@@ -367,8 +230,7 @@ class DataFeeds(object):
 
     @staticmethod
     def sync(
-        feed_client,
-        to_sync=None,
+        sync_util_provider,
         full_flush=False,
         catalog_client=None,
         operation_id=None,
@@ -377,18 +239,19 @@ class DataFeeds(object):
         Sync all feeds.
         :return:
         """
-
         result = []
+        to_sync = sync_util_provider.to_sync
+        if not to_sync:
+            return result
+        feed_client = sync_util_provider.get_client()
 
         logger.info(
             "Performing sync of feeds: {} (operation_id={})".format(
                 "all" if to_sync is None else to_sync, operation_id
             )
         )
-
-        updated, failed = DataFeeds.sync_metadata(
-            feed_client=feed_client, to_sync=to_sync, operation_id=operation_id
-        )
+        source_feeds = DataFeeds.get_feed_group_information(feed_client, to_sync)
+        updated, failed = sync_util_provider.sync_metadata(source_feeds, operation_id)
         updated_names = set(updated.keys())
 
         # Feeds configured to sync but that were not on the upstream source at all
@@ -432,37 +295,9 @@ class DataFeeds(object):
         # Sort the feed instances for the syncing process to ensure highest priority feeds sync first (e.g. vulnerabilities before package metadatas)
         feeds_to_sync = _ordered_feeds(feeds_to_sync)
 
-        # Do the fetches
-        groups_to_download = []
-        for f in feeds_to_sync:
-            logger.info(
-                "Initialized feed to sync: {} (operation_id={})".format(
-                    f.__feed_name__, operation_id
-                )
-            )
-            if f.metadata:
-                if f.metadata.enabled:
-                    for g in f.metadata.groups:
-                        if g.enabled:
-                            groups_to_download.append(g)
-                        else:
-                            logger.info(
-                                "Will not sync/download group {} of feed {} because group is explicitly disabled".format(
-                                    g.name, g.feed_name
-                                )
-                            )
-                else:
-                    logger.info(
-                        "Skipping feed {} because it is explicitly not enabled".format(
-                            f.__feed_name__
-                        )
-                    )
-            else:
-                logger.warn(
-                    "No metadata found for feed {}. Unexpected but not an error (operation_id={})".format(
-                        f.__feed_name__, operation_id
-                    )
-                )
+        groups_to_download = sync_util_provider.get_groups_to_download(
+            source_feeds, updated, operation_id
+        )
 
         logger.debug("Groups to download {}".format(groups_to_download))
 
@@ -631,11 +466,10 @@ class DataFeeds(object):
         :param group_name:
         :return:
         """
-
+        # TODO throw exception if feed is grypedb
         f = feed_instance_by_name(feed_name)
         if not f:
             raise KeyError(feed_name)
-
         return f.flush_group(group_name)
 
     @staticmethod
@@ -677,8 +511,6 @@ def _sync_order(feed_name: str) -> int:
 
     # Later will want to generalize this and add sync order as property of the feed class
 
-    if feed_name == GrypeDBFeed.__feed_name__:
-        return 0
     if feed_name == VulnerabilityFeed.__feed_name__:
         return 1
     if feed_name == VulnDBFeed.__feed_name__:

--- a/anchore_engine/services/policy_engine/engine/feeds/sync.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/sync.py
@@ -11,7 +11,7 @@ import os
 import time
 import uuid
 from dataclasses import asdict
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 from anchore_engine.clients.services.catalog import CatalogClient
 from anchore_engine.common.models.schemas import (
@@ -22,9 +22,13 @@ from anchore_engine.common.models.schemas import (
     GroupDownloadOperationParams,
 )
 from anchore_engine.configuration import localconfig
-from anchore_engine.db import FeedGroupMetadata
+from anchore_engine.db import FeedGroupMetadata, FeedMetadata
+from anchore_engine.db import get_thread_scoped_session as get_session
 from anchore_engine.services.policy_engine.engine.feeds import IFeedSource
-from anchore_engine.services.policy_engine.engine.feeds.db import get_all_feeds_detached
+from anchore_engine.services.policy_engine.engine.feeds.db import (
+    get_all_feeds,
+    get_all_feeds_detached,
+)
 from anchore_engine.services.policy_engine.engine.feeds.download import (
     FeedDownloader,
     LocalFeedDataRepo,
@@ -103,6 +107,179 @@ class DataFeeds(object):
                     "Could not find feed instance for name %s. Cannot update counts",
                     feed.name,
                 )
+
+    # @staticmethod
+    # def get_grype_db_listing(
+    #         feed_group_information, grypedb_feed_name
+    # ) -> GrypeDBListing:
+    #     for feed_name, feed_api_record in feed_group_information.items():
+    #         if feed_name == grypedb_feed_name:
+    #             return next(group.grype_listing for group in feed_api_record["groups"])
+
+    @staticmethod
+    def _pivot_and_filter_feeds_by_config(
+        to_sync: list, source_found: list, db_found: list
+    ):
+        """
+
+        :param to_sync: list of feed names requested to be synced
+        :param source_found: list of feed names available as returned by the upstream source
+        :param db_found: list of db records that were updated as result of upstream metadata sync (this is to handle db update failures)
+        :return:
+        """
+        available = set(to_sync).intersection(set(source_found))
+        return {x.name: x for x in db_found if x.name in available}
+
+    @staticmethod
+    def _sync_feed_metadata(
+        db,
+        feed_api_record,
+        db_feeds,
+        operation_id: Optional[str] = None,
+    ) -> None:
+        api_feed = feed_api_record["meta"]
+        db_feed = db_feeds.get(api_feed.name)
+        # Do this instead of a db.merge() to ensure no timestamps are reset or overwritten
+        if not db_feed:
+            logger.debug(
+                "Adding new feed metadata record to db: {} (operation_id={})".format(
+                    api_feed.name, operation_id
+                )
+            )
+            db_feed = FeedMetadata(
+                name=api_feed.name,
+                description=api_feed.description,
+                access_tier=api_feed.access_tier,
+                enabled=True,
+            )
+            db.add(db_feed)
+            db.flush()
+        else:
+            logger.debug(
+                "Feed metadata already in db: {} (operation_id={})".format(
+                    api_feed.name, operation_id
+                )
+            )
+
+    @staticmethod
+    def _sync_feed_group_metadata(
+        db,
+        feed_api_record,
+        db_feeds,
+        operation_id: Optional[str] = None,
+    ):
+        api_feed = feed_api_record["meta"]
+        db_feed = db_feeds.get(api_feed.name)
+        # Check for any update
+        db_feed.description = api_feed.description
+        db_feed.access_tier = api_feed.access_tier
+
+        db_groups = {x.name: x for x in db_feed.groups}
+        for api_group in feed_api_record.get("groups", []):
+            db_group = db_groups.get(api_group.name)
+            # Do this instead of a db.merge() to ensure no timestamps are reset or overwritten
+            if not db_group:
+                logger.debug(
+                    "Adding new feed metadata record to db: {} (operation_id={})".format(
+                        api_group.name, operation_id
+                    )
+                )
+                db_group = FeedGroupMetadata(
+                    name=api_group.name,
+                    description=api_group.description,
+                    access_tier=api_group.access_tier,
+                    feed=db_feed,
+                    enabled=True,
+                )
+                db_group.last_sync = None
+                db.add(db_group)
+            else:
+                logger.debug(
+                    "Feed group metadata already in db: {} (operation_id={})".format(
+                        api_group.name, operation_id
+                    )
+                )
+
+            db_group.access_tier = api_group.access_tier
+            db_group.description = api_group.description
+
+    @staticmethod
+    def sync_metadata(
+        source_feeds,
+        to_sync: list = None,
+        operation_id: Optional[str] = None,
+        groups: bool = True,
+    ) -> tuple:
+        """
+        Get metadata from source and sync db metadata records to that (e.g. add any new groups or feeds)
+        Executes as a unit-of-work for db, so will commit result and returns the records found on upstream source.
+
+        If a record exists in db but was not found upstream, it is not returned
+
+        :param to_sync: list of string feed names to sync metadata on
+        :return: tuple, first element: dict of names mapped to db records post-sync only including records successfully updated by upstream, second element is a list of tuples where each tuple is (failed_feed_name, error_obj)
+        """
+
+        if not to_sync:
+            return {}, []
+
+        db = get_session()
+        try:
+            logger.info(
+                "Syncing feed and group metadata from upstream source (operation_id={})".format(
+                    operation_id
+                )
+            )
+            failed = []
+            db_feeds = DataFeeds._pivot_and_filter_feeds_by_config(
+                to_sync, list(source_feeds.keys()), get_all_feeds(db)
+            )
+
+            for feed_name, feed_api_record in source_feeds.items():
+                try:
+                    logger.info(
+                        "Syncing metadata for feed: {} (operation_id={})".format(
+                            feed_name, operation_id
+                        )
+                    )
+                    DataFeeds._sync_feed_metadata(
+                        db, feed_api_record, db_feeds, operation_id
+                    )
+                    if groups:
+                        DataFeeds._sync_feed_group_metadata(
+                            db, feed_api_record, db_feeds, operation_id
+                        )
+                except Exception as e:
+                    logger.exception("Error syncing feed {}".format(feed_name))
+                    logger.warn(
+                        "Could not sync metadata for feed: {} (operation_id={})".format(
+                            feed_name, operation_id
+                        )
+                    )
+                    failed.append((feed_name, e))
+                finally:
+                    db.flush()
+
+            # Reload
+            db_feeds = DataFeeds._pivot_and_filter_feeds_by_config(
+                to_sync, list(source_feeds.keys()), get_all_feeds(db)
+            )
+
+            db.commit()
+            logger.info(
+                "Metadata sync from feeds upstream source complete (operation_id={})".format(
+                    operation_id
+                )
+            )
+            return db_feeds, failed
+        except Exception as e:
+            logger.error(
+                "Rolling back feed metadata update due to error: {} (operation_id={})".format(
+                    e, operation_id
+                )
+            )
+            db.rollback()
+            raise
 
     @staticmethod
     def get_feed_group_information(

--- a/anchore_engine/services/policy_engine/engine/feeds/sync.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/sync.py
@@ -11,9 +11,7 @@ import os
 import time
 import uuid
 from dataclasses import asdict
-from typing import Dict, List, Optional, Tuple, Union
-
-from sqlalchemy.orm.session import Session
+from typing import Dict, List, Optional, Union
 
 from anchore_engine.clients.services.catalog import CatalogClient
 from anchore_engine.common.models.schemas import (
@@ -24,13 +22,9 @@ from anchore_engine.common.models.schemas import (
     GroupDownloadOperationParams,
 )
 from anchore_engine.configuration import localconfig
-from anchore_engine.db import FeedGroupMetadata, FeedMetadata
-from anchore_engine.db import get_thread_scoped_session as get_session
+from anchore_engine.db import FeedGroupMetadata
 from anchore_engine.services.policy_engine.engine.feeds import IFeedSource
-from anchore_engine.services.policy_engine.engine.feeds.db import (
-    get_all_feeds,
-    get_all_feeds_detached,
-)
+from anchore_engine.services.policy_engine.engine.feeds.db import get_all_feeds_detached
 from anchore_engine.services.policy_engine.engine.feeds.download import (
     FeedDownloader,
     LocalFeedDataRepo,
@@ -90,9 +84,6 @@ def download_operation_config_factory(
     return conf
 
 
-SourceFeeds = Dict[str, Dict[str, Union[FeedAPIRecord, List[FeedAPIGroupRecord]]]]
-
-
 class DataFeeds(object):
     _proxy = None
 
@@ -125,213 +116,10 @@ class DataFeeds(object):
     #             return next(group.grype_listing for group in feed_api_record["groups"])
 
     @staticmethod
-    def _pivot_and_filter_feeds_by_config(
-        to_sync: list, source_found: list, db_found: list
-    ) -> Dict[str, FeedMetadata]:
-        """
-        Filters FeedMetadata records to only include those that are configured
-
-        :param to_sync: list of feed names requested to be synced
-        :param source_found: list of feed names available as returned by the upstream source
-        :param db_found: list of db records that were updated as result of upstream metadata sync (this is to handle db update failures)
-        :return: dict of feed names to FeedMetadata records
-        :rtype: Dict[str, FeedMetadata]
-        """
-        available = set(to_sync).intersection(set(source_found))
-        return {x.name: x for x in db_found if x.name in available}
-
-    @staticmethod
-    def _sync_feed_metadata(
-        db: Session,
-        feed_api_record: Dict[str, Union[FeedAPIRecord, List[FeedAPIGroupRecord]]],
-        db_feeds: Dict[str, FeedMetadata],
-        operation_id: Optional[str] = None,
-    ) -> Dict[str, FeedMetadata]:
-        """
-        Add FeedMetadata records to DB if they don't already exist
-
-        :param db: database session
-        :type db: Session
-        :param feed_api_record: data from API client
-        :type feed_api_record: Dict[str, Union[FeedAPIRecord, List[FeedAPIGroupRecord]]]
-        :param db_feeds: map of feed names to FeedMetadata
-        :type db_feeds: Dict[str, FeedMetadata]
-        :param operation_id: UUID4 hexadecimal string
-        :type operation_id: Optional[str]
-        :return: map of feed names to FeedMetadata that has been updated or created in the DB
-        :rtype: Dict[str, FeedMetadata]
-        """
-        api_feed = feed_api_record["meta"]
-        db_feed = db_feeds.get(api_feed.name)
-        # Do this instead of a db.merge() to ensure no timestamps are reset or overwritten
-        if not db_feed:
-            logger.debug(
-                "Adding new feed metadata record to db: {} (operation_id={})".format(
-                    api_feed.name, operation_id
-                )
-            )
-            db_feed = FeedMetadata(
-                name=api_feed.name,
-                description=api_feed.description,
-                access_tier=api_feed.access_tier,
-                enabled=True,
-            )
-            db.add(db_feed)
-            db.flush()
-            return {api_feed.name: db_feed}
-        else:
-            logger.debug(
-                "Feed metadata already in db: {} (operation_id={})".format(
-                    api_feed.name, operation_id
-                )
-            )
-            return db_feeds
-
-    @staticmethod
-    def _sync_feed_group_metadata(
-        db: Session,
-        feed_api_record: Dict[str, Union[FeedAPIRecord, List[FeedAPIGroupRecord]]],
-        db_feeds: Dict[str, FeedMetadata],
-        operation_id: Optional[str] = None,
-    ) -> None:
-        """
-        Add FeedGroupMetadata records to DB if they don't already exist
-
-        :param db: database session
-        :type db: Session
-        :param feed_api_record: data from API client
-        :type feed_api_record: Dict[str, Union[FeedAPIRecord, List[FeedAPIGroupRecord]]]
-        :param db_feeds: map of feed names to FeedMetadata tied to DB session
-        :type db_feeds: Dict[str, FeedMetadata]
-        :param operation_id: UUID4 hexadecimal string
-        :type operation_id: Optional[str]
-        """
-        api_feed = feed_api_record["meta"]
-        db_feed = db_feeds.get(api_feed.name)
-        # Check for any update
-        db_feed.description = api_feed.description
-        db_feed.access_tier = api_feed.access_tier
-
-        db_groups = {x.name: x for x in db_feed.groups}
-        for api_group in feed_api_record.get("groups", []):
-            db_group = db_groups.get(api_group.name)
-            # Do this instead of a db.merge() to ensure no timestamps are reset or overwritten
-            if not db_group:
-                logger.debug(
-                    "Adding new feed metadata record to db: {} (operation_id={})".format(
-                        api_group.name, operation_id
-                    )
-                )
-                db_group = FeedGroupMetadata(
-                    name=api_group.name,
-                    description=api_group.description,
-                    access_tier=api_group.access_tier,
-                    feed=db_feed,
-                    enabled=True,
-                )
-                db_group.last_sync = None
-                db.add(db_group)
-            else:
-                logger.debug(
-                    "Feed group metadata already in db: {} (operation_id={})".format(
-                        api_group.name, operation_id
-                    )
-                )
-
-            db_group.access_tier = api_group.access_tier
-            db_group.description = api_group.description
-
-    @staticmethod
-    def sync_metadata(
-        source_feeds: SourceFeeds,
-        to_sync: List[str] = None,
-        operation_id: Optional[str] = None,
-        groups: bool = True,
-    ) -> Tuple[Dict[str, FeedMetadata], List[Tuple[str, Union[str, BaseException]]]]:
-        """
-        Get metadata from source and sync db metadata records to that (e.g. add any new groups or feeds)
-        Executes as a unit-of-work for db, so will commit result and returns the records found on upstream source.
-
-        If a record exists in db but was not found upstream, it is not returned
-
-        :param source_feeds: mapping containing FeedAPIRecord and FeedAPIGroupRecord
-        :type source_feeds: SourceFeeds
-        :param to_sync: list of string feed names to sync metadata on
-        :type to_sync: List[str]
-        :param operation_id: UUID4 hexadecimal string
-        :type operation_id: Optional[str]
-        :param groups: whether or not to sync group metadata (defaults to True, which will sync group metadata)
-        :type groups: bool
-        :return: tuple, first element: dict of names mapped to db records post-sync only including records successfully updated by upstream, second element is a list of tuples where each tuple is (failed_feed_name, error_obj)
-        :rtype: Tuple[Dict[str, FeedMetadata], List[Tuple[str, Union[str, BaseException]]]
-        """
-
-        if not to_sync:
-            return {}, []
-
-        db = get_session()
-        try:
-            logger.info(
-                "Syncing feed and group metadata from upstream source (operation_id={})".format(
-                    operation_id
-                )
-            )
-            failed = []
-            db_feeds = DataFeeds._pivot_and_filter_feeds_by_config(
-                to_sync, list(source_feeds.keys()), get_all_feeds(db)
-            )
-
-            for feed_name, feed_api_record in source_feeds.items():
-                try:
-                    logger.info(
-                        "Syncing metadata for feed: {} (operation_id={})".format(
-                            feed_name, operation_id
-                        )
-                    )
-                    feed_metadata_map = DataFeeds._sync_feed_metadata(
-                        db, feed_api_record, db_feeds, operation_id
-                    )
-                    if groups:
-                        DataFeeds._sync_feed_group_metadata(
-                            db, feed_api_record, feed_metadata_map, operation_id
-                        )
-                except Exception as e:
-                    logger.exception("Error syncing feed {}".format(feed_name))
-                    logger.warn(
-                        "Could not sync metadata for feed: {} (operation_id={})".format(
-                            feed_name, operation_id
-                        )
-                    )
-                    failed.append((feed_name, e))
-                finally:
-                    db.flush()
-
-            # Reload
-            db_feeds = DataFeeds._pivot_and_filter_feeds_by_config(
-                to_sync, list(source_feeds.keys()), get_all_feeds(db)
-            )
-
-            db.commit()
-            logger.info(
-                "Metadata sync from feeds upstream source complete (operation_id={})".format(
-                    operation_id
-                )
-            )
-            return db_feeds, failed
-        except Exception as e:
-            logger.error(
-                "Rolling back feed metadata update due to error: {} (operation_id={})".format(
-                    e, operation_id
-                )
-            )
-            db.rollback()
-            raise
-
-    @staticmethod
     def get_feed_group_information(
         feed_client: IFeedSource,
         to_sync: List[str] = None,
-    ) -> SourceFeeds:
+    ) -> Dict[str, Dict[str, Union[FeedAPIRecord, List[FeedAPIGroupRecord]]]]:
         """
         Uses API client to populate a mapping.
 
@@ -340,7 +128,7 @@ class DataFeeds(object):
         :param to_sync: list of feed names to download
         :type to_sync: List[str]
         :return: mapping containing API response
-        :rtype: SourceFeeds
+        :rtype: Dict[str, Dict[str, Union[FeedAPIRecord, List[FeedAPIGroupRecord]]]]
         """
         if not to_sync:
             return {}

--- a/anchore_engine/services/policy_engine/engine/feeds/sync.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/sync.py
@@ -478,7 +478,7 @@ class DataFeeds(object):
         feeds_to_sync = _ordered_feeds(feeds_to_sync)
 
         groups_to_download = sync_util_provider.get_groups_to_download(
-            source_feeds, updated, feeds_to_sync, operation_id
+            source_feeds, feeds_to_sync, operation_id
         )
 
         logger.debug("Groups to download {}".format(groups_to_download))

--- a/anchore_engine/services/policy_engine/engine/feeds/sync.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/sync.py
@@ -85,6 +85,9 @@ def download_operation_config_factory(
     return conf
 
 
+SourceFeeds = Dict[str, Dict[str, Union[FeedAPIRecord, List[FeedAPIGroupRecord]]]]
+
+
 class DataFeeds(object):
     _proxy = None
 
@@ -287,7 +290,7 @@ class DataFeeds(object):
     def get_feed_group_information(
         feed_client: IFeedSource,
         to_sync: list = None,
-    ) -> Dict[str, Dict[str, Union[FeedAPIRecord, List[FeedAPIGroupRecord]]]]:
+    ) -> SourceFeeds:
         if not to_sync:
             return {}
 

--- a/anchore_engine/services/policy_engine/engine/feeds/sync_utils.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/sync_utils.py
@@ -1,0 +1,297 @@
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from anchore_engine.common.schemas import GrypeDBListing
+from anchore_engine.db import FeedGroupMetadata, FeedMetadata
+from anchore_engine.db import get_thread_scoped_session as get_session
+from anchore_engine.services.policy_engine.engine.feeds.client import (
+    get_feeds_client,
+    get_grype_db_client,
+)
+from anchore_engine.services.policy_engine.engine.feeds.db import get_all_feeds
+from anchore_engine.subsys import logger
+
+GRYPE_DB_FEED_NAME = "grypedb"
+
+
+class MetadataSyncUtils:
+    @staticmethod
+    def get_grype_db_listing(
+        feed_group_information, grypedb_feed_name
+    ) -> GrypeDBListing:
+        for feed_name, feed_api_record in feed_group_information.items():
+            if feed_name == grypedb_feed_name:
+                return next(group.grype_listing for group in feed_api_record["groups"])
+
+    @staticmethod
+    def _pivot_and_filter_feeds_by_config(
+        to_sync: list, source_found: list, db_found: list
+    ):
+        """
+
+        :param to_sync: list of feed names requested to be synced
+        :param source_found: list of feed names available as returned by the upstream source
+        :param db_found: list of db records that were updated as result of upstream metadata sync (this is to handle db update failures)
+        :return:
+        """
+        available = set(to_sync).intersection(set(source_found))
+        return {x.name: x for x in db_found if x.name in available}
+
+    @staticmethod
+    def _sync_feed_metadata(
+        db,
+        feed_api_record,
+        db_feeds,
+        operation_id: Optional[str] = None,
+    ) -> None:
+        api_feed = feed_api_record["meta"]
+        db_feed = db_feeds.get(api_feed.name)
+        # Do this instead of a db.merge() to ensure no timestamps are reset or overwritten
+        if not db_feed:
+            logger.debug(
+                "Adding new feed metadata record to db: {} (operation_id={})".format(
+                    api_feed.name, operation_id
+                )
+            )
+            db_feed = FeedMetadata(
+                name=api_feed.name,
+                description=api_feed.description,
+                access_tier=api_feed.access_tier,
+                enabled=True,
+            )
+            db.add(db_feed)
+            db.flush()
+        else:
+            logger.debug(
+                "Feed metadata already in db: {} (operation_id={})".format(
+                    api_feed.name, operation_id
+                )
+            )
+
+    @staticmethod
+    def _sync_feed_group_metadata(
+        db,
+        feed_api_record,
+        db_feeds,
+        operation_id: Optional[str] = None,
+    ):
+        api_feed = feed_api_record["meta"]
+        db_feed = db_feeds.get(api_feed.name)
+        # Check for any update
+        db_feed.description = api_feed.description
+        db_feed.access_tier = api_feed.access_tier
+
+        db_groups = {x.name: x for x in db_feed.groups}
+        for api_group in feed_api_record.get("groups", []):
+            db_group = db_groups.get(api_group.name)
+            # Do this instead of a db.merge() to ensure no timestamps are reset or overwritten
+            if not db_group:
+                logger.debug(
+                    "Adding new feed metadata record to db: {} (operation_id={})".format(
+                        api_group.name, operation_id
+                    )
+                )
+                db_group = FeedGroupMetadata(
+                    name=api_group.name,
+                    description=api_group.description,
+                    access_tier=api_group.access_tier,
+                    feed=db_feed,
+                    enabled=True,
+                )
+                db_group.last_sync = None
+                db.add(db_group)
+            else:
+                logger.debug(
+                    "Feed group metadata already in db: {} (operation_id={})".format(
+                        api_group.name, operation_id
+                    )
+                )
+
+            db_group.access_tier = api_group.access_tier
+            db_group.description = api_group.description
+
+    @staticmethod
+    def sync_metadata(
+        source_feeds,
+        to_sync: list = None,
+        operation_id: Optional[str] = None,
+        groups: bool = True,
+    ) -> tuple:
+        """
+        Get metadata from source and sync db metadata records to that (e.g. add any new groups or feeds)
+        Executes as a unit-of-work for db, so will commit result and returns the records found on upstream source.
+
+        If a record exists in db but was not found upstream, it is not returned
+
+        :param to_sync: list of string feed names to sync metadata on
+        :return: tuple, first element: dict of names mapped to db records post-sync only including records successfully updated by upstream, second element is a list of tuples where each tuple is (failed_feed_name, error_obj)
+        """
+
+        if not to_sync:
+            return {}, []
+
+        db = get_session()
+        try:
+            logger.info(
+                "Syncing feed and group metadata from upstream source (operation_id={})".format(
+                    operation_id
+                )
+            )
+            failed = []
+            db_feeds = MetadataSyncUtils._pivot_and_filter_feeds_by_config(
+                to_sync, list(source_feeds.keys()), get_all_feeds(db)
+            )
+
+            for feed_name, feed_api_record in source_feeds.items():
+                try:
+                    logger.info(
+                        "Syncing metadata for feed: {} (operation_id={})".format(
+                            feed_name, operation_id
+                        )
+                    )
+                    MetadataSyncUtils._sync_feed_metadata(
+                        db, feed_api_record, db_feeds, operation_id
+                    )
+                    if groups:
+                        MetadataSyncUtils._sync_feed_group_metadata(
+                            db, feed_api_record, db_feeds, operation_id
+                        )
+                except Exception as e:
+                    logger.exception("Error syncing feed {}".format(feed_name))
+                    logger.warn(
+                        "Could not sync metadata for feed: {} (operation_id={})".format(
+                            feed_name, operation_id
+                        )
+                    )
+                    failed.append((feed_name, e))
+                finally:
+                    db.flush()
+
+            # Reload
+            db_feeds = MetadataSyncUtils._pivot_and_filter_feeds_by_config(
+                to_sync, list(source_feeds.keys()), get_all_feeds(db)
+            )
+
+            db.commit()
+            logger.info(
+                "Metadata sync from feeds upstream source complete (operation_id={})".format(
+                    operation_id
+                )
+            )
+            return db_feeds, failed
+        except Exception as e:
+            logger.error(
+                "Rolling back feed metadata update due to error: {} (operation_id={})".format(
+                    e, operation_id
+                )
+            )
+            db.rollback()
+            raise
+
+
+class SyncUtilProvider(ABC):
+    def __init__(self, sync_configs):
+        self._sync_configs = self._get_filtered_sync_configs(sync_configs)
+        self._to_sync = self._get_feeds_to_sync()
+
+    @property
+    def to_sync(self):
+        return self._to_sync
+
+    def _get_feeds_to_sync(self):
+        return list(self._sync_configs.keys())
+
+    @staticmethod
+    @abstractmethod
+    def _get_filtered_sync_configs(sync_configs):
+        ...
+
+    @abstractmethod
+    def get_client(self):
+        ...
+
+    @abstractmethod
+    def sync_metadata(self, source_feeds, operation_id):
+        ...
+
+    @staticmethod
+    def get_groups_to_download(source_feeds, updated, operation_id):
+        ...
+
+
+class LegacySyncUtilProvider(SyncUtilProvider):
+    @staticmethod
+    def _get_filtered_sync_configs(sync_configs):
+        return {
+            feed_name: sync_config
+            for feed_name, sync_config in sync_configs.items()
+            if feed_name != GRYPE_DB_FEED_NAME
+        }
+
+    def get_client(self):
+        sync_config = list(self._sync_configs.values())[0]
+        return get_feeds_client(sync_config)
+
+    def sync_metadata(self, source_feeds, operation_id):
+        return MetadataSyncUtils.sync_metadata(source_feeds, self.to_sync, operation_id)
+
+    def get_groups_to_download(self, source_feeds, feeds_to_sync, operation_id):
+        # Do the fetches
+        groups_to_download = []
+        for f in feeds_to_sync:
+            logger.info(
+                "Initialized feed to sync: {} (operation_id={})".format(
+                    f.__feed_name__, operation_id
+                )
+            )
+            if f.metadata:
+                if f.metadata.enabled:
+                    for g in f.metadata.groups:
+                        if g.enabled:
+                            groups_to_download.append(g)
+                        else:
+                            logger.info(
+                                "Will not sync/download group {} of feed {} because group is explicitly disabled".format(
+                                    g.name, g.feed_name
+                                )
+                            )
+                else:
+                    logger.info(
+                        "Skipping feed {} because it is explicitly not enabled".format(
+                            f.__feed_name__
+                        )
+                    )
+            else:
+                logger.warn(
+                    "No metadata found for feed {}. Unexpected but not an error (operation_id={})".format(
+                        f.__feed_name__, operation_id
+                    )
+                )
+            return groups_to_download
+
+
+class GrypeDBSyncUtilProvider(SyncUtilProvider):
+    @staticmethod
+    def _get_filtered_sync_configs(sync_configs):
+        return {GRYPE_DB_FEED_NAME: sync_configs.get(GRYPE_DB_FEED_NAME)}
+
+    def get_client(self):
+        grype_db_sync_config = self._sync_configs.get(GRYPE_DB_FEED_NAME)
+        return get_grype_db_client(grype_db_sync_config)
+
+    def sync_metadata(self, source_feeds, operation_id):
+        return MetadataSyncUtils.sync_metadata(
+            source_feeds, self.to_sync, operation_id, groups=False
+        )
+
+    def get_groups_to_download(self, source_feeds, updated, operation_id):
+        api_feed_group = source_feeds[GRYPE_DB_FEED_NAME]["groups"][0]
+        feed_metadata = updated[GRYPE_DB_FEED_NAME]
+        group_to_download = FeedGroupMetadata(
+            name=api_feed_group.name,
+            feed_name=feed_metadata.name,
+            description=api_feed_group.description,
+            access_tier=api_feed_group.access_tier,
+            enabled=True,
+        )
+        return [group_to_download]

--- a/anchore_engine/services/policy_engine/engine/feeds/sync_utils.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/sync_utils.py
@@ -5,10 +5,11 @@ from anchore_engine.services.policy_engine.engine.feeds.client import (
     get_feeds_client,
     get_grype_db_client,
 )
+from anchore_engine.services.policy_engine.engine.feeds.feeds import GrypeDBFeed
 from anchore_engine.services.policy_engine.engine.feeds.sync import DataFeeds
 from anchore_engine.subsys import logger
 
-GRYPE_DB_FEED_NAME = "grypedb"
+GRYPE_DB_FEED_NAME = GrypeDBFeed.__feed_name__
 
 
 class SyncUtilProvider(ABC):

--- a/anchore_engine/services/policy_engine/engine/feeds/sync_utils.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/sync_utils.py
@@ -1,66 +1,191 @@
 from abc import ABC, abstractmethod
+from typing import Dict, List, Optional, Tuple
 
-from anchore_engine.db import FeedGroupMetadata
+from anchore_engine.db import FeedGroupMetadata, FeedMetadata
+from anchore_engine.services.policy_engine.engine.feeds import IFeedSource
 from anchore_engine.services.policy_engine.engine.feeds.client import (
     get_feeds_client,
     get_grype_db_client,
 )
-from anchore_engine.services.policy_engine.engine.feeds.feeds import GrypeDBFeed
-from anchore_engine.services.policy_engine.engine.feeds.sync import DataFeeds
+from anchore_engine.services.policy_engine.engine.feeds.config import SyncConfig
+from anchore_engine.services.policy_engine.engine.feeds.feeds import (
+    DataFeed,
+    GrypeDBFeed,
+)
+from anchore_engine.services.policy_engine.engine.feeds.sync import (
+    DataFeeds,
+    SourceFeeds,
+)
 from anchore_engine.subsys import logger
 
 GRYPE_DB_FEED_NAME = GrypeDBFeed.__feed_name__
 
 
 class SyncUtilProvider(ABC):
-    def __init__(self, sync_configs):
-        self._sync_configs = self._get_filtered_sync_configs(sync_configs)
-        self._to_sync = self._get_feeds_to_sync()
+    """
+    Base class for SyncUtilProviders.
+    Encapsulates all feeds sync logic that functions differently for legacy feeds vs grypedb.
+
+    :param sync_configs: mapping of feed names to SyncConfigs
+    :type sync_configs: Dict[str, SyncConfig]
+    """
+
+    def __init__(self, sync_configs: Dict[str, SyncConfig]):
+        self._sync_configs: Dict[str, SyncConfig] = self._get_filtered_sync_configs(
+            sync_configs
+        )
+        self._to_sync: List[str] = self._get_feeds_to_sync()
 
     @property
-    def to_sync(self):
+    def to_sync(self) -> List[str]:
+        """
+        Getter for list of feeds to sync.
+
+        :return: list of feeds to sync
+        :rtype: List[str]
+        """
         return self._to_sync
 
     def _get_feeds_to_sync(self):
+        """
+        Convert dict of sync configs to list of feed names that are enabled for this provider.
+
+        :return: list of feeds to sync
+        :rtype: List[str]
+        """
         return list(self._sync_configs.keys())
 
     @staticmethod
     @abstractmethod
-    def _get_filtered_sync_configs(sync_configs):
+    def _get_filtered_sync_configs(sync_configs) -> Dict[str, SyncConfig]:
+        """
+        Filters sync configs to those applicable to this provider
+
+        :param sync_configs: unfiltered mapping of feed names to SyncConfigs
+        :type sync_configs: Dict[str, SyncConfig]
+        :return: filtered mapping of feed names to SyncConfigs
+        :rtype: Dict[str, SyncConfig]
+        """
         ...
 
     @abstractmethod
-    def get_client(self):
+    def get_client(self) -> IFeedSource:
+        """
+        Instantiate the appropriate feed client (implementation of IFeedSource) for this provider
+
+        :return: instance of GrypeDBServiceClient or FeedServiceClient
+        :rtype: IFeedSource
+        """
         ...
 
     @abstractmethod
-    def sync_metadata(self, source_feeds, operation_id):
+    def sync_metadata(
+        self, source_feeds: SourceFeeds, operation_id: Optional[str]
+    ) -> Tuple[Dict[str, FeedMetadata], List[Tuple[str, BaseException]]]:
+        """
+        Wraps DataFeeds.sync_metadata so that it may be called with arguments appropriate for the provider.
+
+        :param source_feeds: mapping containing FeedAPIRecord and FeedAPIGroupRecord
+        :type source_feeds: SourceFeeds
+        :param operation_id: UUID4 hexadecimal string
+        :type operation_id: Optional[str]
+        :return: response of DataFeeds.sync_metadata()
+        :rtype: Tuple[Dict[str, FeedMetadata], List[Tuple[str, BaseException]]]
+        """
         ...
 
     @staticmethod
-    def get_groups_to_download(source_feeds, updated, feeds_to_sync, operation_id):
+    def get_groups_to_download(
+        source_feeds: SourceFeeds,
+        updated: Dict[str, FeedMetadata],
+        feeds_to_sync: List[DataFeed],
+        operation_id: str,
+    ) -> List[FeedGroupMetadata]:
+        """
+        Returns a list of FeedGroupMetadata for each feed group to download.
+
+        :param source_feeds: mapping containing FeedAPIRecord and FeedAPIGroupRecord
+        :type source_feeds: SourceFeeds
+        :param updated: dict of names mapped to db records post-sync only including records successfully updated by upstream
+        :type updated: Dict[str, FeedMetadata]
+        :param feeds_to_sync: ordered list of DataFeed(s) to sync
+        :type feeds_to_sync: List[DataFeed]
+        :param operation_id: UUID4 hexadecimal string
+        :type operation_id: Optional[str]
+        :return:
+        """
         ...
 
 
 class LegacySyncUtilProvider(SyncUtilProvider):
+    """
+    Encapsulates all feeds sync logic that functions differently for legacy feeds.
+    """
+
     @staticmethod
-    def _get_filtered_sync_configs(sync_configs):
+    def _get_filtered_sync_configs(sync_configs) -> Dict[str, SyncConfig]:
+        """
+        Filters sync configs to those applicable to this provider.
+        Filters out SyncConfig for grypedb.
+
+        :param sync_configs: unfiltered mapping of feed names to SyncConfigs
+        :type sync_configs: Dict[str, SyncConfig]
+        :return: filtered mapping of feed names to SyncConfigs
+        :rtype: Dict[str, SyncConfig]
+        """
         return {
             feed_name: sync_config
             for feed_name, sync_config in sync_configs.items()
             if feed_name != GRYPE_DB_FEED_NAME
         }
 
-    def get_client(self):
+    def get_client(self) -> IFeedSource:
+        """
+        Instantiates the FeedServiceClient
+
+        :return: instance of FeedServiceClient
+        :rtype: IFeedSource
+        """
         sync_config = list(self._sync_configs.values())[0]
         return get_feeds_client(sync_config)
 
-    def sync_metadata(self, source_feeds, operation_id):
+    def sync_metadata(
+        self, source_feeds: SourceFeeds, operation_id: Optional[str]
+    ) -> Tuple[Dict[str, FeedMetadata], List[Tuple[str, BaseException]]]:
+        """
+        Wraps DataFeeds.sync_metadata so that it may be called with arguments appropriate for the provider.
+        In this case, we want to make sure that syncing FeedGroupMetadata is enabled for the legacy feeds.
+
+        :param source_feeds: mapping containing FeedAPIRecord and FeedAPIGroupRecord
+        :type source_feeds: SourceFeeds
+        :param operation_id: UUID4 hexadecimal string
+        :type operation_id: Optional[str]
+        :return: response of DataFeeds.sync_metadata()
+        :rtype: Tuple[Dict[str, FeedMetadata], List[Tuple[str, BaseException]]]
+        """
         return DataFeeds.sync_metadata(source_feeds, self.to_sync, operation_id)
 
+    @staticmethod
     def get_groups_to_download(
-        self, source_feeds, updated, feeds_to_sync, operation_id
-    ):
+        source_feeds: SourceFeeds,
+        updated: Dict[str, FeedMetadata],
+        feeds_to_sync: List[DataFeed],
+        operation_id: str,
+    ) -> List[FeedGroupMetadata]:
+        """
+        Iterates over feeds_to_sync, reads the FeedMetadata, and makes a list of FeedGroupMetadata objects where
+        enabled == True.
+
+        :param source_feeds: mapping containing FeedAPIRecord and FeedAPIGroupRecord
+        :type source_feeds: SourceFeeds
+        :param updated: dict of names mapped to db records post-sync only including records successfully updated by upstream
+        :type updated: Dict[str, FeedMetadata]
+        :param feeds_to_sync: ordered list of DataFeed(s) to sync
+        :type feeds_to_sync: List[DataFeed]
+        :param operation_id: UUID4 hexadecimal string
+        :type operation_id: Optional[str]
+        :return:
+        """
         # Do the fetches
         groups_to_download = []
         for f in feeds_to_sync:
@@ -96,25 +221,75 @@ class LegacySyncUtilProvider(SyncUtilProvider):
 
 
 class GrypeDBSyncUtilProvider(SyncUtilProvider):
+    """
+    Encapsulates all feeds sync logic that functions differently for grypedb feed.
+    """
+
     @staticmethod
-    def _get_filtered_sync_configs(sync_configs):
+    def _get_filtered_sync_configs(sync_configs) -> Dict[str, SyncConfig]:
+        """
+        Filters sync configs to those applicable to this provider.
+        Filters out SyncConfig that are NOT grypedb.
+
+        :param sync_configs: unfiltered mapping of feed names to SyncConfigs
+        :type sync_configs: Dict[str, SyncConfig]
+        :return: filtered mapping of feed names to SyncConfigs
+        :rtype: Dict[str, SyncConfig]
+        """
         grype_sync_config = sync_configs.get(GRYPE_DB_FEED_NAME)
         if grype_sync_config:
             return {GRYPE_DB_FEED_NAME: grype_sync_config}
         return {}
 
-    def get_client(self):
+    def get_client(self) -> IFeedSource:
+        """
+        Instantiates the GrypeDBServiceClient
+
+        :return: instance of GrypeDBServiceClient
+        :rtype: IFeedSource
+        """
         grype_db_sync_config = self._sync_configs.get(GRYPE_DB_FEED_NAME)
         return get_grype_db_client(grype_db_sync_config)
 
-    def sync_metadata(self, source_feeds, operation_id):
+    def sync_metadata(
+        self, source_feeds: SourceFeeds, operation_id: Optional[str]
+    ) -> Tuple[Dict[str, FeedMetadata], List[Tuple[str, BaseException]]]:
+        """
+        Wraps DataFeeds.sync_metadata so that it may be called with arguments appropriate for the provider.
+        In this case, we want to make sure that syncing FeedGroupMetadata is disabled for grypedb feed.
+
+        :param source_feeds: mapping containing FeedAPIRecord and FeedAPIGroupRecord
+        :type source_feeds: SourceFeeds
+        :param operation_id: UUID4 hexadecimal string
+        :type operation_id: Optional[str]
+        :return: response of DataFeeds.sync_metadata()
+        :rtype: Tuple[Dict[str, FeedMetadata], List[Tuple[str, BaseException]]]
+        """
         return DataFeeds.sync_metadata(
             source_feeds, self.to_sync, operation_id, groups=False
         )
 
+    @staticmethod
     def get_groups_to_download(
-        self, source_feeds, updated, feeds_to_sync, operation_id
-    ):
+        source_feeds: SourceFeeds,
+        updated: Dict[str, FeedMetadata],
+        feeds_to_sync: List[DataFeed],
+        operation_id: str,
+    ) -> List[FeedGroupMetadata]:
+        """
+        Creates a FeedGroupMetadata record that is never added to the database. We purposefully avoid adding the feed
+        attribute to the record so that this record does not get created implicitly by sqlalchemy back-population.
+
+        :param source_feeds: mapping containing FeedAPIRecord and FeedAPIGroupRecord
+        :type source_feeds: SourceFeeds
+        :param updated: dict of names mapped to db records post-sync only including records successfully updated by upstream
+        :type updated: Dict[str, FeedMetadata]
+        :param feeds_to_sync: ordered list of DataFeed(s) to sync
+        :type feeds_to_sync: List[DataFeed]
+        :param operation_id: UUID4 hexadecimal string
+        :type operation_id: Optional[str]
+        :return:
+        """
         api_feed_group = source_feeds[GRYPE_DB_FEED_NAME]["groups"][0]
         feed_metadata = updated[GRYPE_DB_FEED_NAME]
         group_to_download = FeedGroupMetadata(

--- a/anchore_engine/services/policy_engine/engine/feeds/sync_utils.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/sync_utils.py
@@ -97,7 +97,6 @@ class SyncUtilProvider(ABC):
     @staticmethod
     def get_groups_to_download(
         source_feeds: SourceFeeds,
-        updated: Dict[str, FeedMetadata],
         feeds_to_sync: List[DataFeed],
         operation_id: str,
     ) -> List[FeedGroupMetadata]:
@@ -106,8 +105,6 @@ class SyncUtilProvider(ABC):
 
         :param source_feeds: mapping containing FeedAPIRecord and FeedAPIGroupRecord
         :type source_feeds: SourceFeeds
-        :param updated: dict of names mapped to db records post-sync only including records successfully updated by upstream
-        :type updated: Dict[str, FeedMetadata]
         :param feeds_to_sync: ordered list of DataFeed(s) to sync
         :type feeds_to_sync: List[DataFeed]
         :param operation_id: UUID4 hexadecimal string
@@ -168,7 +165,6 @@ class LegacySyncUtilProvider(SyncUtilProvider):
     @staticmethod
     def get_groups_to_download(
         source_feeds: SourceFeeds,
-        updated: Dict[str, FeedMetadata],
         feeds_to_sync: List[DataFeed],
         operation_id: str,
     ) -> List[FeedGroupMetadata]:
@@ -178,8 +174,6 @@ class LegacySyncUtilProvider(SyncUtilProvider):
 
         :param source_feeds: mapping containing FeedAPIRecord and FeedAPIGroupRecord
         :type source_feeds: SourceFeeds
-        :param updated: dict of names mapped to db records post-sync only including records successfully updated by upstream
-        :type updated: Dict[str, FeedMetadata]
         :param feeds_to_sync: ordered list of DataFeed(s) to sync
         :type feeds_to_sync: List[DataFeed]
         :param operation_id: UUID4 hexadecimal string
@@ -272,26 +266,25 @@ class GrypeDBSyncUtilProvider(SyncUtilProvider):
     @staticmethod
     def get_groups_to_download(
         source_feeds: SourceFeeds,
-        updated: Dict[str, FeedMetadata],
         feeds_to_sync: List[DataFeed],
         operation_id: str,
     ) -> List[FeedGroupMetadata]:
         """
         Creates a FeedGroupMetadata record that is never added to the database. We purposefully avoid adding the feed
         attribute to the record so that this record does not get created implicitly by sqlalchemy back-population.
+        Uses FeedMetadata from feeds_to_sync. Expects only one record is present for grypedb.
 
         :param source_feeds: mapping containing FeedAPIRecord and FeedAPIGroupRecord
         :type source_feeds: SourceFeeds
-        :param updated: dict of names mapped to db records post-sync only including records successfully updated by upstream
-        :type updated: Dict[str, FeedMetadata]
         :param feeds_to_sync: ordered list of DataFeed(s) to sync
         :type feeds_to_sync: List[DataFeed]
         :param operation_id: UUID4 hexadecimal string
         :type operation_id: Optional[str]
         :return:
         """
+        # TODO consider throwing exceptions if length is not 1 for these
         api_feed_group = source_feeds[GRYPE_DB_FEED_NAME]["groups"][0]
-        feed_metadata = updated[GRYPE_DB_FEED_NAME]
+        feed_metadata = feeds_to_sync[0].metadata
         group_to_download = FeedGroupMetadata(
             name=api_feed_group.name,
             feed_name=feed_metadata.name,

--- a/anchore_engine/services/policy_engine/engine/feeds/sync_utils.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/sync_utils.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional, Tuple, Union
 
 from sqlalchemy.orm.session import Session
 
-from anchore_engine.common.schemas import FeedAPIGroupRecord, FeedAPIRecord
+from anchore_engine.common.models.schemas import FeedAPIGroupRecord, FeedAPIRecord
 from anchore_engine.db import FeedGroupMetadata, FeedMetadata
 from anchore_engine.db import get_thread_scoped_session as get_session
 from anchore_engine.services.policy_engine.engine.feeds import IFeedSource

--- a/anchore_engine/services/policy_engine/engine/feeds/sync_utils.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/sync_utils.py
@@ -89,7 +89,7 @@ class LegacySyncUtilProvider(SyncUtilProvider):
                         f.__feed_name__, operation_id
                     )
                 )
-            return groups_to_download
+        return groups_to_download
 
 
 class GrypeDBSyncUtilProvider(SyncUtilProvider):

--- a/anchore_engine/services/policy_engine/engine/feeds/sync_utils.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/sync_utils.py
@@ -57,7 +57,9 @@ class LegacySyncUtilProvider(SyncUtilProvider):
     def sync_metadata(self, source_feeds, operation_id):
         return DataFeeds.sync_metadata(source_feeds, self.to_sync, operation_id)
 
-    def get_groups_to_download(self, source_feeds, updated, feeds_to_sync, operation_id):
+    def get_groups_to_download(
+        self, source_feeds, updated, feeds_to_sync, operation_id
+    ):
         # Do the fetches
         groups_to_download = []
         for f in feeds_to_sync:
@@ -95,7 +97,10 @@ class LegacySyncUtilProvider(SyncUtilProvider):
 class GrypeDBSyncUtilProvider(SyncUtilProvider):
     @staticmethod
     def _get_filtered_sync_configs(sync_configs):
-        return {GRYPE_DB_FEED_NAME: sync_configs.get(GRYPE_DB_FEED_NAME)}
+        grype_sync_config = sync_configs.get(GRYPE_DB_FEED_NAME)
+        if grype_sync_config:
+            return {GRYPE_DB_FEED_NAME: grype_sync_config}
+        return {}
 
     def get_client(self):
         grype_db_sync_config = self._sync_configs.get(GRYPE_DB_FEED_NAME)
@@ -106,7 +111,9 @@ class GrypeDBSyncUtilProvider(SyncUtilProvider):
             source_feeds, self.to_sync, operation_id, groups=False
         )
 
-    def get_groups_to_download(self, source_feeds, updated, feeds_to_sync, operation_id):
+    def get_groups_to_download(
+        self, source_feeds, updated, feeds_to_sync, operation_id
+    ):
         api_feed_group = source_feeds[GRYPE_DB_FEED_NAME]["groups"][0]
         feed_metadata = updated[GRYPE_DB_FEED_NAME]
         group_to_download = FeedGroupMetadata(

--- a/anchore_engine/services/policy_engine/engine/feeds/sync_utils.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/sync_utils.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 
 from anchore_engine.db import FeedGroupMetadata, FeedMetadata
 from anchore_engine.services.policy_engine.engine.feeds import IFeedSource
@@ -83,7 +83,7 @@ class SyncUtilProvider(ABC):
     @abstractmethod
     def sync_metadata(
         self, source_feeds: SourceFeeds, operation_id: Optional[str]
-    ) -> Tuple[Dict[str, FeedMetadata], List[Tuple[str, BaseException]]]:
+    ) -> Tuple[Dict[str, FeedMetadata], List[Tuple[str, Union[str, BaseException]]]]:
         """
         Wraps DataFeeds.sync_metadata so that it may be called with arguments appropriate for the provider.
 
@@ -92,7 +92,7 @@ class SyncUtilProvider(ABC):
         :param operation_id: UUID4 hexadecimal string
         :type operation_id: Optional[str]
         :return: response of DataFeeds.sync_metadata()
-        :rtype: Tuple[Dict[str, FeedMetadata], List[Tuple[str, BaseException]]]
+        :rtype: Tuple[Dict[str, FeedMetadata], List[Tuple[str, Union[str, BaseException]]]]
         """
         ...
 
@@ -150,7 +150,7 @@ class LegacySyncUtilProvider(SyncUtilProvider):
 
     def sync_metadata(
         self, source_feeds: SourceFeeds, operation_id: Optional[str]
-    ) -> Tuple[Dict[str, FeedMetadata], List[Tuple[str, BaseException]]]:
+    ) -> Tuple[Dict[str, FeedMetadata], List[Tuple[str, Union[str, BaseException]]]]:
         """
         Wraps DataFeeds.sync_metadata so that it may be called with arguments appropriate for the provider.
         In this case, we want to make sure that syncing FeedGroupMetadata is enabled for the legacy feeds.
@@ -160,7 +160,7 @@ class LegacySyncUtilProvider(SyncUtilProvider):
         :param operation_id: UUID4 hexadecimal string
         :type operation_id: Optional[str]
         :return: response of DataFeeds.sync_metadata()
-        :rtype: Tuple[Dict[str, FeedMetadata], List[Tuple[str, BaseException]]]
+        :rtype: Tuple[Dict[str, FeedMetadata], List[Tuple[str, Union[str, BaseException]]]]
         """
         return DataFeeds.sync_metadata(source_feeds, self.to_sync, operation_id)
 
@@ -249,7 +249,7 @@ class GrypeDBSyncUtilProvider(SyncUtilProvider):
 
     def sync_metadata(
         self, source_feeds: SourceFeeds, operation_id: Optional[str]
-    ) -> Tuple[Dict[str, FeedMetadata], List[Tuple[str, BaseException]]]:
+    ) -> Tuple[Dict[str, FeedMetadata], List[Tuple[str, Union[str, BaseException]]]]:
         """
         Wraps DataFeeds.sync_metadata so that it may be called with arguments appropriate for the provider.
         In this case, we want to make sure that syncing FeedGroupMetadata is disabled for grypedb feed.
@@ -259,7 +259,7 @@ class GrypeDBSyncUtilProvider(SyncUtilProvider):
         :param operation_id: UUID4 hexadecimal string
         :type operation_id: Optional[str]
         :return: response of DataFeeds.sync_metadata()
-        :rtype: Tuple[Dict[str, FeedMetadata], List[Tuple[str, BaseException]]]
+        :rtype: Tuple[Dict[str, FeedMetadata], List[Tuple[str, Union[str, BaseException]]]]
         """
         return DataFeeds.sync_metadata(
             source_feeds, self.to_sync, operation_id, groups=False

--- a/anchore_engine/services/policy_engine/engine/feeds/sync_utils.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/sync_utils.py
@@ -37,7 +37,7 @@ class SyncUtilProvider(ABC):
         ...
 
     @staticmethod
-    def get_groups_to_download(source_feeds, updated, operation_id):
+    def get_groups_to_download(source_feeds, updated, feeds_to_sync, operation_id):
         ...
 
 
@@ -57,7 +57,7 @@ class LegacySyncUtilProvider(SyncUtilProvider):
     def sync_metadata(self, source_feeds, operation_id):
         return DataFeeds.sync_metadata(source_feeds, self.to_sync, operation_id)
 
-    def get_groups_to_download(self, source_feeds, feeds_to_sync, operation_id):
+    def get_groups_to_download(self, source_feeds, updated, feeds_to_sync, operation_id):
         # Do the fetches
         groups_to_download = []
         for f in feeds_to_sync:
@@ -106,7 +106,7 @@ class GrypeDBSyncUtilProvider(SyncUtilProvider):
             source_feeds, self.to_sync, operation_id, groups=False
         )
 
-    def get_groups_to_download(self, source_feeds, updated, operation_id):
+    def get_groups_to_download(self, source_feeds, updated, feeds_to_sync, operation_id):
         api_feed_group = source_feeds[GRYPE_DB_FEED_NAME]["groups"][0]
         feed_metadata = updated[GRYPE_DB_FEED_NAME]
         group_to_download = FeedGroupMetadata(

--- a/anchore_engine/services/policy_engine/engine/feeds/sync_utils.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/sync_utils.py
@@ -513,11 +513,20 @@ class GrypeDBSyncUtilProvider(SyncUtilProvider):
         # TODO consider throwing exceptions if length is not 1 for these
         api_feed_group = source_feeds[GRYPE_DB_FEED_NAME]["groups"][0]
         feed_metadata = feeds_to_sync[0].metadata
-        group_to_download = FeedGroupMetadata(
-            name=api_feed_group.name,
-            feed_name=feed_metadata.name,
-            description=api_feed_group.description,
-            access_tier=api_feed_group.access_tier,
-            enabled=True,
-        )
-        return [group_to_download]
+        groups_to_download = []
+        if feed_metadata.enabled:
+            groups_to_download.append(
+                FeedGroupMetadata(
+                    name=api_feed_group.name,
+                    feed_name=feed_metadata.name,
+                    description=api_feed_group.description,
+                    access_tier=api_feed_group.access_tier,
+                    enabled=True,
+                )
+            )
+        else:
+            logger.info(
+                "Will not sync/download feed %s because feed is explicitly disabled",
+                feed_metadata.name,
+            )
+        return groups_to_download

--- a/anchore_engine/services/policy_engine/engine/feeds/sync_utils.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/sync_utils.py
@@ -1,7 +1,11 @@
 from abc import ABC, abstractmethod
 from typing import Dict, List, Optional, Tuple, Union
 
+from sqlalchemy.orm.session import Session
+
+from anchore_engine.common.schemas import FeedAPIGroupRecord, FeedAPIRecord
 from anchore_engine.db import FeedGroupMetadata, FeedMetadata
+from anchore_engine.db import get_thread_scoped_session as get_session
 from anchore_engine.services.policy_engine.engine.feeds import IFeedSource
 from anchore_engine.services.policy_engine.engine.feeds.client import (
     FeedServiceClient,
@@ -10,17 +14,221 @@ from anchore_engine.services.policy_engine.engine.feeds.client import (
     get_grype_db_client,
 )
 from anchore_engine.services.policy_engine.engine.feeds.config import SyncConfig
+from anchore_engine.services.policy_engine.engine.feeds.db import get_all_feeds
 from anchore_engine.services.policy_engine.engine.feeds.feeds import (
     DataFeed,
     GrypeDBFeed,
 )
-from anchore_engine.services.policy_engine.engine.feeds.sync import (
-    DataFeeds,
-    SourceFeeds,
-)
 from anchore_engine.subsys import logger
 
 GRYPE_DB_FEED_NAME = GrypeDBFeed.__feed_name__
+
+
+class MetadataSyncUtils:
+    @staticmethod
+    def _pivot_and_filter_feeds_by_config(
+        to_sync: list, source_found: list, db_found: list
+    ) -> Dict[str, FeedMetadata]:
+        """
+        Filters FeedMetadata records to only include those that are configured
+
+        :param to_sync: list of feed names requested to be synced
+        :param source_found: list of feed names available as returned by the upstream source
+        :param db_found: list of db records that were updated as result of upstream metadata sync (this is to handle db update failures)
+        :return: dict of feed names to FeedMetadata records
+        :rtype: Dict[str, FeedMetadata]
+        """
+        available = set(to_sync).intersection(set(source_found))
+        return {x.name: x for x in db_found if x.name in available}
+
+    @staticmethod
+    def _sync_feed_metadata(
+        db: Session,
+        feed_api_record: Dict[str, Union[FeedAPIRecord, List[FeedAPIGroupRecord]]],
+        db_feeds: Dict[str, FeedMetadata],
+        operation_id: Optional[str] = None,
+    ) -> Dict[str, FeedMetadata]:
+        """
+        Add FeedMetadata records to DB if they don't already exist
+
+        :param db: database session
+        :type db: Session
+        :param feed_api_record: data from API client
+        :type feed_api_record: Dict[str, Union[FeedAPIRecord, List[FeedAPIGroupRecord]]]
+        :param db_feeds: map of feed names to FeedMetadata
+        :type db_feeds: Dict[str, FeedMetadata]
+        :param operation_id: UUID4 hexadecimal string
+        :type operation_id: Optional[str]
+        :return: map of feed names to FeedMetadata that has been updated or created in the DB
+        :rtype: Dict[str, FeedMetadata]
+        """
+        api_feed = feed_api_record["meta"]
+        db_feed = db_feeds.get(api_feed.name)
+        # Do this instead of a db.merge() to ensure no timestamps are reset or overwritten
+        if not db_feed:
+            logger.debug(
+                "Adding new feed metadata record to db: {} (operation_id={})".format(
+                    api_feed.name, operation_id
+                )
+            )
+            db_feed = FeedMetadata(
+                name=api_feed.name,
+                description=api_feed.description,
+                access_tier=api_feed.access_tier,
+                enabled=True,
+            )
+            db.add(db_feed)
+            db.flush()
+            return {api_feed.name: db_feed}
+        else:
+            logger.debug(
+                "Feed metadata already in db: {} (operation_id={})".format(
+                    api_feed.name, operation_id
+                )
+            )
+            return db_feeds
+
+    @staticmethod
+    def _sync_feed_group_metadata(
+        db: Session,
+        feed_api_record: Dict[str, Union[FeedAPIRecord, List[FeedAPIGroupRecord]]],
+        db_feeds: Dict[str, FeedMetadata],
+        operation_id: Optional[str] = None,
+    ) -> None:
+        """
+        Add FeedGroupMetadata records to DB if they don't already exist
+
+        :param db: database session
+        :type db: Session
+        :param feed_api_record: data from API client
+        :type feed_api_record: Dict[str, Union[FeedAPIRecord, List[FeedAPIGroupRecord]]]
+        :param db_feeds: map of feed names to FeedMetadata tied to DB session
+        :type db_feeds: Dict[str, FeedMetadata]
+        :param operation_id: UUID4 hexadecimal string
+        :type operation_id: Optional[str]
+        """
+        api_feed = feed_api_record["meta"]
+        db_feed = db_feeds.get(api_feed.name)
+        # Check for any update
+        db_feed.description = api_feed.description
+        db_feed.access_tier = api_feed.access_tier
+
+        db_groups = {x.name: x for x in db_feed.groups}
+        for api_group in feed_api_record.get("groups", []):
+            db_group = db_groups.get(api_group.name)
+            # Do this instead of a db.merge() to ensure no timestamps are reset or overwritten
+            if not db_group:
+                logger.debug(
+                    "Adding new feed metadata record to db: {} (operation_id={})".format(
+                        api_group.name, operation_id
+                    )
+                )
+                db_group = FeedGroupMetadata(
+                    name=api_group.name,
+                    description=api_group.description,
+                    access_tier=api_group.access_tier,
+                    feed=db_feed,
+                    enabled=True,
+                )
+                db_group.last_sync = None
+                db.add(db_group)
+            else:
+                logger.debug(
+                    "Feed group metadata already in db: {} (operation_id={})".format(
+                        api_group.name, operation_id
+                    )
+                )
+
+            db_group.access_tier = api_group.access_tier
+            db_group.description = api_group.description
+
+    @staticmethod
+    def sync_metadata(
+        source_feeds: Dict[
+            str, Dict[str, Union[FeedAPIRecord, List[FeedAPIGroupRecord]]]
+        ],
+        to_sync: List[str] = None,
+        operation_id: Optional[str] = None,
+        groups: bool = True,
+    ) -> Tuple[Dict[str, FeedMetadata], List[Tuple[str, Union[str, BaseException]]]]:
+        """
+        Get metadata from source and sync db metadata records to that (e.g. add any new groups or feeds)
+        Executes as a unit-of-work for db, so will commit result and returns the records found on upstream source.
+
+        If a record exists in db but was not found upstream, it is not returned
+
+        :param source_feeds: mapping containing FeedAPIRecord and FeedAPIGroupRecord
+        :type source_feeds: Dict[str, Dict[str, Union[FeedAPIRecord, List[FeedAPIGroupRecord]]]]
+        :param to_sync: list of string feed names to sync metadata on
+        :type to_sync: List[str]
+        :param operation_id: UUID4 hexadecimal string
+        :type operation_id: Optional[str]
+        :param groups: whether or not to sync group metadata (defaults to True, which will sync group metadata)
+        :type groups: bool
+        :return: tuple, first element: dict of names mapped to db records post-sync only including records successfully updated by upstream, second element is a list of tuples where each tuple is (failed_feed_name, error_obj)
+        :rtype: Tuple[Dict[str, FeedMetadata], List[Tuple[str, Union[str, BaseException]]]
+        """
+
+        if not to_sync:
+            return {}, []
+
+        db = get_session()
+        try:
+            logger.info(
+                "Syncing feed and group metadata from upstream source (operation_id={})".format(
+                    operation_id
+                )
+            )
+            failed = []
+            db_feeds = MetadataSyncUtils._pivot_and_filter_feeds_by_config(
+                to_sync, list(source_feeds.keys()), get_all_feeds(db)
+            )
+
+            for feed_name, feed_api_record in source_feeds.items():
+                try:
+                    logger.info(
+                        "Syncing metadata for feed: {} (operation_id={})".format(
+                            feed_name, operation_id
+                        )
+                    )
+                    feed_metadata_map = MetadataSyncUtils._sync_feed_metadata(
+                        db, feed_api_record, db_feeds, operation_id
+                    )
+                    if groups:
+                        MetadataSyncUtils._sync_feed_group_metadata(
+                            db, feed_api_record, feed_metadata_map, operation_id
+                        )
+                except Exception as e:
+                    logger.exception("Error syncing feed {}".format(feed_name))
+                    logger.warn(
+                        "Could not sync metadata for feed: {} (operation_id={})".format(
+                            feed_name, operation_id
+                        )
+                    )
+                    failed.append((feed_name, e))
+                finally:
+                    db.flush()
+
+            # Reload
+            db_feeds = MetadataSyncUtils._pivot_and_filter_feeds_by_config(
+                to_sync, list(source_feeds.keys()), get_all_feeds(db)
+            )
+
+            db.commit()
+            logger.info(
+                "Metadata sync from feeds upstream source complete (operation_id={})".format(
+                    operation_id
+                )
+            )
+            return db_feeds, failed
+        except Exception as e:
+            logger.error(
+                "Rolling back feed metadata update due to error: {} (operation_id={})".format(
+                    e, operation_id
+                )
+            )
+            db.rollback()
+            raise
 
 
 class SyncUtilProvider(ABC):
@@ -82,23 +290,29 @@ class SyncUtilProvider(ABC):
 
     @abstractmethod
     def sync_metadata(
-        self, source_feeds: SourceFeeds, operation_id: Optional[str]
+        self,
+        source_feeds: Dict[
+            str, Dict[str, Union[FeedAPIRecord, List[FeedAPIGroupRecord]]]
+        ],
+        operation_id: Optional[str],
     ) -> Tuple[Dict[str, FeedMetadata], List[Tuple[str, Union[str, BaseException]]]]:
         """
-        Wraps DataFeeds.sync_metadata so that it may be called with arguments appropriate for the provider.
+        Wraps MetadataSyncUtils.sync_metadata so that it may be called with arguments appropriate for the provider.
 
         :param source_feeds: mapping containing FeedAPIRecord and FeedAPIGroupRecord
-        :type source_feeds: SourceFeeds
+        :type source_feeds: Dict[str, Dict[str, Union[FeedAPIRecord, List[FeedAPIGroupRecord]]]]
         :param operation_id: UUID4 hexadecimal string
         :type operation_id: Optional[str]
-        :return: response of DataFeeds.sync_metadata()
+        :return: response of MetadataSyncUtils.sync_metadata()
         :rtype: Tuple[Dict[str, FeedMetadata], List[Tuple[str, Union[str, BaseException]]]]
         """
         ...
 
     @staticmethod
     def get_groups_to_download(
-        source_feeds: SourceFeeds,
+        source_feeds: Dict[
+            str, Dict[str, Union[FeedAPIRecord, List[FeedAPIGroupRecord]]]
+        ],
         feeds_to_sync: List[DataFeed],
         operation_id: str,
     ) -> List[FeedGroupMetadata]:
@@ -106,7 +320,7 @@ class SyncUtilProvider(ABC):
         Returns a list of FeedGroupMetadata for each feed group to download.
 
         :param source_feeds: mapping containing FeedAPIRecord and FeedAPIGroupRecord
-        :type source_feeds: SourceFeeds
+        :type source_feeds: Dict[str, Dict[str, Union[FeedAPIRecord, List[FeedAPIGroupRecord]]]]
         :param feeds_to_sync: ordered list of DataFeed(s) to sync
         :type feeds_to_sync: List[DataFeed]
         :param operation_id: UUID4 hexadecimal string
@@ -149,24 +363,30 @@ class LegacySyncUtilProvider(SyncUtilProvider):
         return get_feeds_client(sync_config)
 
     def sync_metadata(
-        self, source_feeds: SourceFeeds, operation_id: Optional[str]
+        self,
+        source_feeds: Dict[
+            str, Dict[str, Union[FeedAPIRecord, List[FeedAPIGroupRecord]]]
+        ],
+        operation_id: Optional[str],
     ) -> Tuple[Dict[str, FeedMetadata], List[Tuple[str, Union[str, BaseException]]]]:
         """
-        Wraps DataFeeds.sync_metadata so that it may be called with arguments appropriate for the provider.
+        Wraps MetadataSyncUtils.sync_metadata so that it may be called with arguments appropriate for the provider.
         In this case, we want to make sure that syncing FeedGroupMetadata is enabled for the legacy feeds.
 
         :param source_feeds: mapping containing FeedAPIRecord and FeedAPIGroupRecord
-        :type source_feeds: SourceFeeds
+        :type source_feeds: Dict[str, Dict[str, Union[FeedAPIRecord, List[FeedAPIGroupRecord]]]]
         :param operation_id: UUID4 hexadecimal string
         :type operation_id: Optional[str]
-        :return: response of DataFeeds.sync_metadata()
+        :return: response of MetadataSyncUtils.sync_metadata()
         :rtype: Tuple[Dict[str, FeedMetadata], List[Tuple[str, Union[str, BaseException]]]]
         """
-        return DataFeeds.sync_metadata(source_feeds, self.to_sync, operation_id)
+        return MetadataSyncUtils.sync_metadata(source_feeds, self.to_sync, operation_id)
 
     @staticmethod
     def get_groups_to_download(
-        source_feeds: SourceFeeds,
+        source_feeds: Dict[
+            str, Dict[str, Union[FeedAPIRecord, List[FeedAPIGroupRecord]]]
+        ],
         feeds_to_sync: List[DataFeed],
         operation_id: str,
     ) -> List[FeedGroupMetadata]:
@@ -175,7 +395,7 @@ class LegacySyncUtilProvider(SyncUtilProvider):
         enabled == True.
 
         :param source_feeds: mapping containing FeedAPIRecord and FeedAPIGroupRecord
-        :type source_feeds: SourceFeeds
+        :type source_feeds: Dict[str, Dict[str, Union[FeedAPIRecord, List[FeedAPIGroupRecord]]]]
         :param feeds_to_sync: ordered list of DataFeed(s) to sync
         :type feeds_to_sync: List[DataFeed]
         :param operation_id: UUID4 hexadecimal string
@@ -248,26 +468,32 @@ class GrypeDBSyncUtilProvider(SyncUtilProvider):
         return get_grype_db_client(grype_db_sync_config)
 
     def sync_metadata(
-        self, source_feeds: SourceFeeds, operation_id: Optional[str]
+        self,
+        source_feeds: Dict[
+            str, Dict[str, Union[FeedAPIRecord, List[FeedAPIGroupRecord]]]
+        ],
+        operation_id: Optional[str],
     ) -> Tuple[Dict[str, FeedMetadata], List[Tuple[str, Union[str, BaseException]]]]:
         """
-        Wraps DataFeeds.sync_metadata so that it may be called with arguments appropriate for the provider.
+        Wraps MetadataSyncUtils.sync_metadata so that it may be called with arguments appropriate for the provider.
         In this case, we want to make sure that syncing FeedGroupMetadata is disabled for grypedb feed.
 
         :param source_feeds: mapping containing FeedAPIRecord and FeedAPIGroupRecord
-        :type source_feeds: SourceFeeds
+        :type source_feeds: Dict[str, Dict[str, Union[FeedAPIRecord, List[FeedAPIGroupRecord]]]]
         :param operation_id: UUID4 hexadecimal string
         :type operation_id: Optional[str]
-        :return: response of DataFeeds.sync_metadata()
+        :return: response of MetadataSyncUtils.sync_metadata()
         :rtype: Tuple[Dict[str, FeedMetadata], List[Tuple[str, Union[str, BaseException]]]]
         """
-        return DataFeeds.sync_metadata(
+        return MetadataSyncUtils.sync_metadata(
             source_feeds, self.to_sync, operation_id, groups=False
         )
 
     @staticmethod
     def get_groups_to_download(
-        source_feeds: SourceFeeds,
+        source_feeds: Dict[
+            str, Dict[str, Union[FeedAPIRecord, List[FeedAPIGroupRecord]]]
+        ],
         feeds_to_sync: List[DataFeed],
         operation_id: str,
     ) -> List[FeedGroupMetadata]:
@@ -277,7 +503,7 @@ class GrypeDBSyncUtilProvider(SyncUtilProvider):
         Uses FeedMetadata from feeds_to_sync. Expects only one record is present for grypedb.
 
         :param source_feeds: mapping containing FeedAPIRecord and FeedAPIGroupRecord
-        :type source_feeds: SourceFeeds
+        :type source_feeds: Dict[str, Dict[str, Union[FeedAPIRecord, List[FeedAPIGroupRecord]]]]
         :param feeds_to_sync: ordered list of DataFeed(s) to sync
         :type feeds_to_sync: List[DataFeed]
         :param operation_id: UUID4 hexadecimal string

--- a/anchore_engine/services/policy_engine/engine/feeds/sync_utils.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/sync_utils.py
@@ -4,6 +4,8 @@ from typing import Dict, List, Optional, Tuple
 from anchore_engine.db import FeedGroupMetadata, FeedMetadata
 from anchore_engine.services.policy_engine.engine.feeds import IFeedSource
 from anchore_engine.services.policy_engine.engine.feeds.client import (
+    FeedServiceClient,
+    GrypeDBServiceClient,
     get_feeds_client,
     get_grype_db_client,
 )
@@ -136,12 +138,12 @@ class LegacySyncUtilProvider(SyncUtilProvider):
             if feed_name != GRYPE_DB_FEED_NAME
         }
 
-    def get_client(self) -> IFeedSource:
+    def get_client(self) -> FeedServiceClient:
         """
         Instantiates the FeedServiceClient
 
         :return: instance of FeedServiceClient
-        :rtype: IFeedSource
+        :rtype: FeedServiceClient
         """
         sync_config = list(self._sync_configs.values())[0]
         return get_feeds_client(sync_config)
@@ -235,12 +237,12 @@ class GrypeDBSyncUtilProvider(SyncUtilProvider):
             return {GRYPE_DB_FEED_NAME: grype_sync_config}
         return {}
 
-    def get_client(self) -> IFeedSource:
+    def get_client(self) -> GrypeDBServiceClient:
         """
         Instantiates the GrypeDBServiceClient
 
         :return: instance of GrypeDBServiceClient
-        :rtype: IFeedSource
+        :rtype: GrypeDBServiceClient
         """
         grype_db_sync_config = self._sync_configs.get(GRYPE_DB_FEED_NAME)
         return get_grype_db_client(grype_db_sync_config)

--- a/anchore_engine/services/policy_engine/engine/feeds/sync_utils.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/sync_utils.py
@@ -1,192 +1,14 @@
 from abc import ABC, abstractmethod
-from typing import Optional
 
-from anchore_engine.common.schemas import GrypeDBListing
-from anchore_engine.db import FeedGroupMetadata, FeedMetadata
-from anchore_engine.db import get_thread_scoped_session as get_session
+from anchore_engine.db import FeedGroupMetadata
 from anchore_engine.services.policy_engine.engine.feeds.client import (
     get_feeds_client,
     get_grype_db_client,
 )
-from anchore_engine.services.policy_engine.engine.feeds.db import get_all_feeds
+from anchore_engine.services.policy_engine.engine.feeds.sync import DataFeeds
 from anchore_engine.subsys import logger
 
 GRYPE_DB_FEED_NAME = "grypedb"
-
-
-class MetadataSyncUtils:
-    @staticmethod
-    def get_grype_db_listing(
-        feed_group_information, grypedb_feed_name
-    ) -> GrypeDBListing:
-        for feed_name, feed_api_record in feed_group_information.items():
-            if feed_name == grypedb_feed_name:
-                return next(group.grype_listing for group in feed_api_record["groups"])
-
-    @staticmethod
-    def _pivot_and_filter_feeds_by_config(
-        to_sync: list, source_found: list, db_found: list
-    ):
-        """
-
-        :param to_sync: list of feed names requested to be synced
-        :param source_found: list of feed names available as returned by the upstream source
-        :param db_found: list of db records that were updated as result of upstream metadata sync (this is to handle db update failures)
-        :return:
-        """
-        available = set(to_sync).intersection(set(source_found))
-        return {x.name: x for x in db_found if x.name in available}
-
-    @staticmethod
-    def _sync_feed_metadata(
-        db,
-        feed_api_record,
-        db_feeds,
-        operation_id: Optional[str] = None,
-    ) -> None:
-        api_feed = feed_api_record["meta"]
-        db_feed = db_feeds.get(api_feed.name)
-        # Do this instead of a db.merge() to ensure no timestamps are reset or overwritten
-        if not db_feed:
-            logger.debug(
-                "Adding new feed metadata record to db: {} (operation_id={})".format(
-                    api_feed.name, operation_id
-                )
-            )
-            db_feed = FeedMetadata(
-                name=api_feed.name,
-                description=api_feed.description,
-                access_tier=api_feed.access_tier,
-                enabled=True,
-            )
-            db.add(db_feed)
-            db.flush()
-        else:
-            logger.debug(
-                "Feed metadata already in db: {} (operation_id={})".format(
-                    api_feed.name, operation_id
-                )
-            )
-
-    @staticmethod
-    def _sync_feed_group_metadata(
-        db,
-        feed_api_record,
-        db_feeds,
-        operation_id: Optional[str] = None,
-    ):
-        api_feed = feed_api_record["meta"]
-        db_feed = db_feeds.get(api_feed.name)
-        # Check for any update
-        db_feed.description = api_feed.description
-        db_feed.access_tier = api_feed.access_tier
-
-        db_groups = {x.name: x for x in db_feed.groups}
-        for api_group in feed_api_record.get("groups", []):
-            db_group = db_groups.get(api_group.name)
-            # Do this instead of a db.merge() to ensure no timestamps are reset or overwritten
-            if not db_group:
-                logger.debug(
-                    "Adding new feed metadata record to db: {} (operation_id={})".format(
-                        api_group.name, operation_id
-                    )
-                )
-                db_group = FeedGroupMetadata(
-                    name=api_group.name,
-                    description=api_group.description,
-                    access_tier=api_group.access_tier,
-                    feed=db_feed,
-                    enabled=True,
-                )
-                db_group.last_sync = None
-                db.add(db_group)
-            else:
-                logger.debug(
-                    "Feed group metadata already in db: {} (operation_id={})".format(
-                        api_group.name, operation_id
-                    )
-                )
-
-            db_group.access_tier = api_group.access_tier
-            db_group.description = api_group.description
-
-    @staticmethod
-    def sync_metadata(
-        source_feeds,
-        to_sync: list = None,
-        operation_id: Optional[str] = None,
-        groups: bool = True,
-    ) -> tuple:
-        """
-        Get metadata from source and sync db metadata records to that (e.g. add any new groups or feeds)
-        Executes as a unit-of-work for db, so will commit result and returns the records found on upstream source.
-
-        If a record exists in db but was not found upstream, it is not returned
-
-        :param to_sync: list of string feed names to sync metadata on
-        :return: tuple, first element: dict of names mapped to db records post-sync only including records successfully updated by upstream, second element is a list of tuples where each tuple is (failed_feed_name, error_obj)
-        """
-
-        if not to_sync:
-            return {}, []
-
-        db = get_session()
-        try:
-            logger.info(
-                "Syncing feed and group metadata from upstream source (operation_id={})".format(
-                    operation_id
-                )
-            )
-            failed = []
-            db_feeds = MetadataSyncUtils._pivot_and_filter_feeds_by_config(
-                to_sync, list(source_feeds.keys()), get_all_feeds(db)
-            )
-
-            for feed_name, feed_api_record in source_feeds.items():
-                try:
-                    logger.info(
-                        "Syncing metadata for feed: {} (operation_id={})".format(
-                            feed_name, operation_id
-                        )
-                    )
-                    MetadataSyncUtils._sync_feed_metadata(
-                        db, feed_api_record, db_feeds, operation_id
-                    )
-                    if groups:
-                        MetadataSyncUtils._sync_feed_group_metadata(
-                            db, feed_api_record, db_feeds, operation_id
-                        )
-                except Exception as e:
-                    logger.exception("Error syncing feed {}".format(feed_name))
-                    logger.warn(
-                        "Could not sync metadata for feed: {} (operation_id={})".format(
-                            feed_name, operation_id
-                        )
-                    )
-                    failed.append((feed_name, e))
-                finally:
-                    db.flush()
-
-            # Reload
-            db_feeds = MetadataSyncUtils._pivot_and_filter_feeds_by_config(
-                to_sync, list(source_feeds.keys()), get_all_feeds(db)
-            )
-
-            db.commit()
-            logger.info(
-                "Metadata sync from feeds upstream source complete (operation_id={})".format(
-                    operation_id
-                )
-            )
-            return db_feeds, failed
-        except Exception as e:
-            logger.error(
-                "Rolling back feed metadata update due to error: {} (operation_id={})".format(
-                    e, operation_id
-                )
-            )
-            db.rollback()
-            raise
 
 
 class SyncUtilProvider(ABC):
@@ -233,7 +55,7 @@ class LegacySyncUtilProvider(SyncUtilProvider):
         return get_feeds_client(sync_config)
 
     def sync_metadata(self, source_feeds, operation_id):
-        return MetadataSyncUtils.sync_metadata(source_feeds, self.to_sync, operation_id)
+        return DataFeeds.sync_metadata(source_feeds, self.to_sync, operation_id)
 
     def get_groups_to_download(self, source_feeds, feeds_to_sync, operation_id):
         # Do the fetches
@@ -280,7 +102,7 @@ class GrypeDBSyncUtilProvider(SyncUtilProvider):
         return get_grype_db_client(grype_db_sync_config)
 
     def sync_metadata(self, source_feeds, operation_id):
-        return MetadataSyncUtils.sync_metadata(
+        return DataFeeds.sync_metadata(
             source_feeds, self.to_sync, operation_id, groups=False
         )
 

--- a/tests/integration/services/policy_engine/conftest.py
+++ b/tests/integration/services/policy_engine/conftest.py
@@ -1,12 +1,21 @@
 import os
+from typing import Callable, List
+from unittest.mock import MagicMock
+
 import pytest
 
-from anchore_engine.subsys import logger
-from tests.integration.services.policy_engine.utils import LocalTestDataEnvironment
-from anchore_engine.services.policy_engine.engine.tasks import ImageLoadTask
 from anchore_engine.db import end_session
-from tests.fixtures import anchore_db, cls_anchore_db
 from anchore_engine.services.policy_engine import init_feed_registry
+from anchore_engine.services.policy_engine.engine.feeds.config import (
+    compute_selected_configs_to_sync,
+)
+from anchore_engine.services.policy_engine.engine.feeds.feeds import FeedSyncResult
+from anchore_engine.services.policy_engine.engine.feeds.sync import DataFeeds
+from anchore_engine.services.policy_engine.engine.tasks import ImageLoadTask
+from anchore_engine.services.policy_engine.engine.vulns.providers import LegacyProvider
+from anchore_engine.subsys import logger
+from tests.fixtures import anchore_db, cls_anchore_db
+from tests.integration.services.policy_engine.utils import LocalTestDataEnvironment
 
 
 def _init_te(init_feeds=True):
@@ -75,3 +84,45 @@ def test_data_env_with_images_loaded(test_data_env):
 
     # Ensure the next init_db() call initializes fully
     end_session()
+
+
+def run_legacy_sync(
+    test_env: LocalTestDataEnvironment, to_sync: List[str]
+) -> List[FeedSyncResult]:
+    DataFeeds.__scratch_dir__ = "/tmp"
+    feed_url = os.getenv("ANCHORE_GRYPE_DB_URL", "https://ancho.re/v1/service/feeds")
+    data_clause = {}
+    for feed_name in to_sync:
+        data_clause[feed_name] = {"enabled": True, "url": feed_url}
+    config = {
+        "provider": "legacy",
+        "sync": {
+            "enabled": os.getenv("ANCHORE_FEEDS_ENABLED", True),
+            "ssl_verify": os.getenv("ANCHORE_FEEDS_SSL_VERIFY", True),
+            "connection_timeout_seconds": 3,
+            "read_timeout_seconds": 60,
+            "data": data_clause,
+        },
+    }
+    vulnerabilities_provider = LegacyProvider()
+    default_sync_config = vulnerabilities_provider.get_default_sync_config()
+    sync_configs = compute_selected_configs_to_sync(
+        provider="legacy",
+        vulnerabilities_config=config,
+        default_provider_sync_config=default_sync_config,
+    )
+    sync_utils = vulnerabilities_provider.get_sync_utils(sync_configs)
+    sync_utils.get_client = MagicMock(return_value=test_env.feed_client)
+    return DataFeeds.sync(sync_util_provider=sync_utils)
+
+
+@pytest.fixture()
+def run_legacy_sync_for_feeds(
+    test_data_env,
+) -> Callable[[List[str]], List[FeedSyncResult]]:
+    test_env = test_data_env
+
+    def run_legacy_sync_nested(to_sync: List[str]) -> List[FeedSyncResult]:
+        return run_legacy_sync(test_env, to_sync)
+
+    return run_legacy_sync_nested

--- a/tests/integration/services/policy_engine/engine/policy/gates/__init__.py
+++ b/tests/integration/services/policy_engine/engine/policy/gates/__init__.py
@@ -1,11 +1,13 @@
 import unittest
+
 import pytest
+
 from anchore_engine.db import Image, get_thread_scoped_session
-from anchore_engine.services.policy_engine.engine.tasks import ImageLoadTask
-from anchore_engine.services.policy_engine.engine.policy.gate import ExecutionContext
 from anchore_engine.services.policy_engine import _init_distro_mappings
-from anchore_engine.services.policy_engine.engine.feeds.sync import DataFeeds
+from anchore_engine.services.policy_engine.engine.policy.gate import ExecutionContext
+from anchore_engine.services.policy_engine.engine.tasks import ImageLoadTask
 from anchore_engine.subsys import logger
+from tests.integration.services.policy_engine.conftest import run_legacy_sync
 
 
 def load_images(request):
@@ -37,10 +39,8 @@ def cls_fully_loaded_test_env(cls_test_data_env2, request):
     :return:
     """
     _init_distro_mappings()
-    DataFeeds.__scratch_dir__ = "/tmp"
-    DataFeeds.sync(
-        to_sync=["vulnerabilities", "packages", "nvdv2", "vulndb"],
-        feed_client=request.cls.test_env.feed_client,
+    run_legacy_sync(
+        request.cls.test_env, ["vulnerabilities", "packages", "nvdv2", "vulndb"]
     )
     load_images(request)
 

--- a/tests/integration/services/policy_engine/feeds/test_feeds.py
+++ b/tests/integration/services/policy_engine/feeds/test_feeds.py
@@ -11,6 +11,9 @@ from anchore_engine.services.policy_engine.engine.feeds.feeds import (
     feed_instance_by_name,
 )
 from anchore_engine.services.policy_engine.engine.feeds.sync import DataFeeds
+from anchore_engine.services.policy_engine.engine.feeds.sync_utils import (
+    MetadataSyncUtils,
+)
 from anchore_engine.subsys import logger
 
 logger.enable_test_logging()
@@ -59,7 +62,7 @@ def test_package_sync(run_legacy_sync_for_feeds):
 
 def test_group_lookups(test_data_env):
     source_feeds = DataFeeds.get_feed_group_information(test_data_env.feed_client)
-    r = DataFeeds.sync_metadata(source_feeds=source_feeds)
+    r = MetadataSyncUtils.sync_metadata(source_feeds=source_feeds)
     assert (
         r == empty_metadata_sync_result
     ), "No metadata should be returned from sync with empty to_sync input"
@@ -67,7 +70,7 @@ def test_group_lookups(test_data_env):
     source_feeds = DataFeeds.get_feed_group_information(
         feed_client=test_data_env.feed_client, to_sync=to_sync
     )
-    r = DataFeeds.sync_metadata(source_feeds=source_feeds, to_sync=to_sync)
+    r = MetadataSyncUtils.sync_metadata(source_feeds=source_feeds, to_sync=to_sync)
     assert (
         r and len(r[0]) == 1
     ), "Metadata should be returned from sync with non-empty to_sync list"
@@ -89,16 +92,17 @@ def test_sync_repo(test_data_env, test_data_path):
         DataFeeds.sync_from_fetched(repo, catalog_client=None)
     source_feeds = DataFeeds.get_feed_group_information(test_data_env.feed_client)
     assert (
-        DataFeeds.sync_metadata(source_feeds=source_feeds) == empty_metadata_sync_result
+        MetadataSyncUtils.sync_metadata(source_feeds=source_feeds)
+        == empty_metadata_sync_result
     )
     to_sync = ["vulnerabilities"]
     source_feeds = DataFeeds.get_feed_group_information(
         feed_client=test_data_env.feed_client, to_sync=to_sync
     )
     assert (
-        DataFeeds.sync_metadata(source_feeds=source_feeds, to_sync=to_sync)[0].get(
-            "vulnerabilities"
-        )
+        MetadataSyncUtils.sync_metadata(source_feeds=source_feeds, to_sync=to_sync)[
+            0
+        ].get("vulnerabilities")
         is not None
     )
     assert DataFeeds.sync_from_fetched(repo, catalog_client=None)
@@ -106,7 +110,7 @@ def test_sync_repo(test_data_env, test_data_path):
 
 def test_metadata_sync(test_data_env):
     source_feeds = DataFeeds.get_feed_group_information(test_data_env.feed_client)
-    r = DataFeeds.sync_metadata(source_feeds=source_feeds)
+    r = MetadataSyncUtils.sync_metadata(source_feeds=source_feeds)
     assert (
         r == empty_metadata_sync_result
     ), "Expected empty dict result from metadata sync with no to_sync directive"
@@ -114,7 +118,7 @@ def test_metadata_sync(test_data_env):
     source_feeds = DataFeeds.get_feed_group_information(
         test_data_env.feed_client, to_sync=to_sync
     )
-    r = DataFeeds.sync_metadata(
+    r = MetadataSyncUtils.sync_metadata(
         source_feeds=source_feeds,
         to_sync=to_sync,
     )

--- a/tests/integration/services/policy_engine/feeds/test_sync.py
+++ b/tests/integration/services/policy_engine/feeds/test_sync.py
@@ -1,20 +1,13 @@
-from anchore_engine.services.policy_engine.engine.feeds.sync import DataFeeds
 from anchore_engine.subsys import logger
 
 logger.enable_test_logging()
 
 
-def test_sync_fail(test_data_env):
-    DataFeeds.__scratch_dir__ = "/tmp"
+def test_sync_fail(test_data_env, run_legacy_sync_for_feeds):
     # No such feed
-    result = DataFeeds.sync(to_sync=["nvd"], feed_client=test_data_env.feed_client)
-    assert len(result) == 1
-    assert result[0].status == "failure"
+    result = run_legacy_sync_for_feeds(["nvd"])
+    assert len(result) == 0
 
-    DataFeeds.__scratch_dir__ = "/tmp"
-    result = DataFeeds.sync(
-        to_sync=["vulnerabilities", "packages", "nvdv2", "vulndb"],
-        feed_client=test_data_env.feed_client,
-    )
-    assert len(result) == 4
+    result = run_legacy_sync_for_feeds(["vulnerabilities", "packages", "nvdv2"])
+    assert len(result) == 3
     assert not any(filter(lambda x: x.status == "failure", result))

--- a/tests/integration/services/policy_engine/test_vulnerabilities.py
+++ b/tests/integration/services/policy_engine/test_vulnerabilities.py
@@ -1,22 +1,15 @@
-import pytest
 import datetime
 import json
-from anchore_engine.subsys import logger
+
+from anchore_engine.db import Image, end_session, get_thread_scoped_session
 from anchore_engine.services.policy_engine.engine import vulnerabilities
-from anchore_engine.db import get_thread_scoped_session, end_session, Image
-from anchore_engine.services.policy_engine.engine.tasks import (
-    ImageLoadTask,
-)
+from anchore_engine.services.policy_engine.engine.tasks import ImageLoadTask
 from anchore_engine.services.policy_engine.engine.vulns.providers import (
     get_vulnerabilities_provider,
 )
-from anchore_engine.services.policy_engine.engine.feeds.sync import DataFeeds
+from anchore_engine.subsys import logger
+from tests.integration.services.policy_engine.conftest import run_legacy_sync
 from tests.integration.services.policy_engine.utils import reset_feed_sync_time
-from anchore_engine.services.policy_engine import (
-    _init_distro_mappings,
-    init_feed_registry,
-)
-
 
 logger.enable_test_logging()
 
@@ -65,10 +58,7 @@ def sync_feeds(test_env, up_to=None):
         test_env.set_max_feed_time(up_to)
 
     logger.info("Syncing vuln and packages")
-    DataFeeds.__scratch_dir__ = "/tmp"
-    DataFeeds.sync(
-        feed_client=test_env.feed_client, to_sync=["vulnerabilities", "packages"]
-    )
+    run_legacy_sync(test_env, ["vulnerabilities", "packages"])
     logger.info("Sync complete")
 
 

--- a/tests/unit/anchore_engine/services/policy_engine/engine/feeds/test_config.py
+++ b/tests/unit/anchore_engine/services/policy_engine/engine/feeds/test_config.py
@@ -1,15 +1,18 @@
+from dataclasses import dataclass
+from typing import List
+
 import pytest
 
 from anchore_engine.configuration import localconfig
 from anchore_engine.services.policy_engine.engine.feeds.config import (
     compute_selected_configs_to_sync,
-    get_section_for_vulnerabilities,
     get_provider_name,
+    get_section_for_vulnerabilities,
     is_sync_enabled,
 )
 from anchore_engine.services.policy_engine.engine.vulns.providers import (
-    LegacyProvider,
     GrypeProvider,
+    LegacyProvider,
 )
 
 
@@ -250,3 +253,126 @@ def test_get_provider(test_input, expected):
 )
 def test_is_sync_enabled(test_input, expected):
     assert is_sync_enabled(test_input) == expected
+
+
+@dataclass
+class FeedConfiguration:
+    feed_name: str
+    enabled: bool
+
+
+def get_config_for_params(provider: str, feed_configurations: List[FeedConfiguration]):
+    return {
+        "provider": provider,
+        "sync": {
+            "enabled": True,
+            "ssl_verify": True,
+            "connection_timeout_seconds": 3,
+            "read_timeout_seconds": 60,
+            "data": {
+                feed_configuration.feed_name: {
+                    "enabled": feed_configuration.enabled,
+                    "url": "www.anchore.com",
+                }
+                for feed_configuration in feed_configurations
+            },
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "provider, feed_configurations, expected_to_sync_after_compute",
+    [
+        (  # Legacy provider with one invalid config (vulndb), one grype config, and two legacy configs
+            "legacy",
+            [
+                FeedConfiguration("vulnerabilities", True),
+                FeedConfiguration("nvdv2", True),
+                FeedConfiguration("vulndb", True),
+                FeedConfiguration("grypedb", True),
+            ],
+            ["nvdv2", "vulnerabilities"],
+        ),
+        (  # Grype provider with one invalid config (vulndb) one grype config, and two legacy configs
+            "grype",
+            [
+                FeedConfiguration("vulnerabilities", True),
+                FeedConfiguration("nvdv2", True),
+                FeedConfiguration("vulndb", True),
+                FeedConfiguration("grypedb", True),
+            ],
+            ["grypedb"],
+        ),
+        (  # Legacy provider with two disabled configs and one grypedb config that is enabled
+            "legacy",
+            [
+                FeedConfiguration("vulnerabilities", False),
+                FeedConfiguration("nvdv2", False),
+                FeedConfiguration("grypedb", True),
+            ],
+            [],
+        ),
+        (  # Grype provider disabled grypedb config and two legacy configs enabled
+            "grype",
+            [
+                FeedConfiguration("vulnerabilities", True),
+                FeedConfiguration("nvdv2", True),
+                FeedConfiguration("grypedb", False),
+            ],
+            [],
+        ),
+        (  # Legacy provider all disabled configs
+            "legacy",
+            [
+                FeedConfiguration("vulnerabilities", False),
+                FeedConfiguration("nvdv2", False),
+                FeedConfiguration("grypedb", False),
+            ],
+            [],
+        ),
+        (  # Grype provider with all disabled configs
+            "grype",
+            [
+                FeedConfiguration("vulnerabilities", False),
+                FeedConfiguration("nvdv2", False),
+                FeedConfiguration("grypedb", False),
+            ],
+            [],
+        ),
+        (  # Grype provider with packages and grypedb enabled
+            "grype",
+            [
+                FeedConfiguration("vulnerabilities", False),
+                FeedConfiguration("nvdv2", False),
+                FeedConfiguration("grypedb", True),
+                FeedConfiguration("packages", True),
+            ],
+            ["grypedb", "packages"],
+        ),
+        (  # legacy provider with packages and grypedb enabled
+            "legacy",
+            [
+                FeedConfiguration("vulnerabilities", False),
+                FeedConfiguration("nvdv2", False),
+                FeedConfiguration("grypedb", True),
+                FeedConfiguration("packages", True),
+            ],
+            ["packages"],
+        ),
+    ],
+)
+def test_compute_selected_configs_to_sync(
+    provider: str,
+    feed_configurations: List[FeedConfiguration],
+    expected_to_sync_after_compute: List[str],
+):
+    if provider == "legacy":
+        vulnerabilities_provider = LegacyProvider()
+    else:
+        vulnerabilities_provider = GrypeProvider()
+    sync_configs = compute_selected_configs_to_sync(
+        provider=vulnerabilities_provider.get_config_name(),
+        vulnerabilities_config=get_config_for_params(provider, feed_configurations),
+        default_provider_sync_config=vulnerabilities_provider.get_default_sync_config(),
+    )
+    assert set(sync_configs.keys()) == set(expected_to_sync_after_compute)

--- a/tests/unit/anchore_engine/services/policy_engine/engine/feeds/test_sync.py
+++ b/tests/unit/anchore_engine/services/policy_engine/engine/feeds/test_sync.py
@@ -1,14 +1,16 @@
-import pytest
 import datetime
+
+import pytest
+
+from anchore_engine.db.entities.policy_engine import FeedMetadata
+from anchore_engine.services.policy_engine import init_feed_registry
 from anchore_engine.services.policy_engine.engine.feeds.feeds import feed_registry
 from anchore_engine.services.policy_engine.engine.feeds.sync import (
     DataFeeds,
-    FeedMetadata,
-    VulnerabilityFeed,
     NvdV2Feed,
     PackagesFeed,
+    VulnerabilityFeed,
 )
-from anchore_engine.services.policy_engine import init_feed_registry
 
 
 @pytest.fixture

--- a/tests/unit/anchore_engine/services/policy_engine/engine/feeds/test_sync.py
+++ b/tests/unit/anchore_engine/services/policy_engine/engine/feeds/test_sync.py
@@ -6,10 +6,12 @@ from anchore_engine.db.entities.policy_engine import FeedMetadata
 from anchore_engine.services.policy_engine import init_feed_registry
 from anchore_engine.services.policy_engine.engine.feeds.feeds import feed_registry
 from anchore_engine.services.policy_engine.engine.feeds.sync import (
-    DataFeeds,
     NvdV2Feed,
     PackagesFeed,
     VulnerabilityFeed,
+)
+from anchore_engine.services.policy_engine.engine.feeds.sync_utils import (
+    MetadataSyncUtils,
 )
 
 
@@ -116,7 +118,7 @@ def test_pivot_and_filter_feeds_by_config(feed_db_records):
 
     for input in matrix:
         assert (
-            DataFeeds._pivot_and_filter_feeds_by_config(
+            MetadataSyncUtils._pivot_and_filter_feeds_by_config(
                 input["to_sync"], input["source_found"], input["db_found"]
             )
             == input["expected_result"]

--- a/tests/unit/anchore_engine/services/policy_engine/engine/feeds/test_sync_utils.py
+++ b/tests/unit/anchore_engine/services/policy_engine/engine/feeds/test_sync_utils.py
@@ -1,0 +1,271 @@
+from dataclasses import dataclass
+from typing import Dict, List, Type
+
+import pytest
+
+from anchore_engine.common.models.schemas import (
+    FeedAPIGroupRecord,
+    FeedAPIRecord,
+    GrypeDBListing,
+)
+from anchore_engine.db import FeedGroupMetadata, FeedMetadata
+from anchore_engine.db.entities.common import anchore_now_datetime
+from anchore_engine.services.policy_engine.engine.feeds import FeedList
+from anchore_engine.services.policy_engine.engine.feeds.client import (
+    FeedServiceClient,
+    GrypeDBServiceClient,
+    IFeedSource,
+)
+from anchore_engine.services.policy_engine.engine.feeds.config import (
+    SyncConfig,
+    compute_selected_configs_to_sync,
+)
+from anchore_engine.services.policy_engine.engine.feeds.feeds import (
+    GrypeDBFeed,
+    VulnerabilityFeed,
+)
+from anchore_engine.services.policy_engine.engine.feeds.sync_utils import (
+    GrypeDBSyncUtilProvider,
+    LegacySyncUtilProvider,
+    SyncUtilProvider,
+)
+from anchore_engine.services.policy_engine.engine.vulns.providers import (
+    GrypeProvider,
+    LegacyProvider,
+)
+
+
+@dataclass
+class FeedConfiguration:
+    feed_name: str
+    enabled: bool
+
+
+def get_config_for_params(provider: str, feed_configurations: List[FeedConfiguration]):
+    return {
+        "provider": provider,
+        "sync": {
+            "enabled": True,
+            "ssl_verify": True,
+            "connection_timeout_seconds": 3,
+            "read_timeout_seconds": 60,
+            "data": {
+                feed_configuration.feed_name: {
+                    "enabled": feed_configuration.enabled,
+                    "url": "www.anchore.com",
+                }
+                for feed_configuration in feed_configurations
+            },
+        },
+    }
+
+
+class TestSyncUtilProvider:
+    @pytest.mark.parametrize(
+        "provider, feed_configurations, expected_to_sync_after_compute, expected_to_sync_after_filtering",
+        [
+            (  # Legacy provider with one invalid config (vulndb), one grype config, and two legacy configs
+                "legacy",
+                [
+                    FeedConfiguration("vulnerabilities", True),
+                    FeedConfiguration("nvdv2", True),
+                    FeedConfiguration("vulndb", True),
+                    FeedConfiguration("grypedb", True),
+                ],
+                ["nvdv2", "vulnerabilities"],
+                ["nvdv2", "vulnerabilities"],
+            ),
+            (  # Grype provider with one invalid config (vulndb) one grype config, and two legacy configs
+                "grype",
+                [
+                    FeedConfiguration("vulnerabilities", True),
+                    FeedConfiguration("nvdv2", True),
+                    FeedConfiguration("vulndb", True),
+                    FeedConfiguration("grypedb", True),
+                ],
+                ["grypedb"],
+                ["grypedb"],
+            ),
+            (  # Legacy provider with two disabled configs and one grypedb config that is enabled
+                "legacy",
+                [
+                    FeedConfiguration("vulnerabilities", False),
+                    FeedConfiguration("nvdv2", False),
+                    FeedConfiguration("grypedb", True),
+                ],
+                [],
+                [],
+            ),
+            (  # Grype provider disabled grypedb config and two legacy configs enabled
+                "grype",
+                [
+                    FeedConfiguration("vulnerabilities", True),
+                    FeedConfiguration("nvdv2", True),
+                    FeedConfiguration("grypedb", False),
+                ],
+                [],
+                [],
+            ),
+            (  # Legacy provider all disabled configs
+                "legacy",
+                [
+                    FeedConfiguration("vulnerabilities", False),
+                    FeedConfiguration("nvdv2", False),
+                    FeedConfiguration("grypedb", False),
+                ],
+                [],
+                [],
+            ),
+            (  # Grype provider with all disabled configs
+                "grype",
+                [
+                    FeedConfiguration("vulnerabilities", False),
+                    FeedConfiguration("nvdv2", False),
+                    FeedConfiguration("grypedb", False),
+                ],
+                [],
+                [],
+            ),
+            (  # Grype provider with packages and grypedb enabled
+                "grype",
+                [
+                    FeedConfiguration("vulnerabilities", False),
+                    FeedConfiguration("nvdv2", False),
+                    FeedConfiguration("grypedb", True),
+                    FeedConfiguration("packages", True),
+                ],
+                ["grypedb", "packages"],
+                ["grypedb"],
+            ),
+            (  # legacy provider with packages and grypedb enabled
+                "legacy",
+                [
+                    FeedConfiguration("vulnerabilities", False),
+                    FeedConfiguration("nvdv2", False),
+                    FeedConfiguration("grypedb", True),
+                    FeedConfiguration("packages", True),
+                ],
+                ["packages"],
+                ["packages"],
+            ),
+        ],
+    )
+    def test_config_filtering(
+        self,
+        provider: str,
+        feed_configurations: List[FeedConfiguration],
+        expected_to_sync_after_compute: List[str],
+        expected_to_sync_after_filtering: List[str],
+    ):
+        """
+        This is a bit confusing and probably should be changed, which is why i've written a test for it.
+        There are two SyncUtilProviders.
+        The LegacySyncUtilProvider works for all feeds that follow the legacy format.
+        The GrypeDBSyncUtilProvider works for the GrypeDB feed format.
+        However, the VulnerabilitiesProvider has two implementations.
+        The LegacyProvider contains all vulnerability logic that changes when the provider is set to "legacy"
+        The GrypeProvider contains all vulnerability logic that changes when the provider is set to "grype"
+        As such, the GrypeProvider actually returns both "packages" and "grypedb" SyncConfigs,
+        while "packages" is actually a Legacy style feed.
+        Meanwhile, the "packages" feed can only be synced by the LegacySyncUtilProvider.
+        The solution is likely to wrap the entire sync method with the SyncUtilProvider, that way LegacySyncUtilProvider
+        can just do legacy feeds, while GrypeDBSyncUtilProvider will first do "grypedb" feed with the grype logic
+        and then do "packages" feed with the legacy logic.
+        """
+        if provider == "legacy":
+            vulnerabilities_provider = LegacyProvider()
+        else:
+            vulnerabilities_provider = GrypeProvider()
+        sync_configs = compute_selected_configs_to_sync(
+            provider=vulnerabilities_provider.get_config_name(),
+            vulnerabilities_config=get_config_for_params(provider, feed_configurations),
+            default_provider_sync_config=vulnerabilities_provider.get_default_sync_config(),
+        )
+        assert set(sync_configs.keys()) == set(expected_to_sync_after_compute)
+        sync_utils_provider = vulnerabilities_provider.get_sync_utils(sync_configs)
+        filtered_configs = sync_utils_provider._get_filtered_sync_configs(sync_configs)
+        assert set(filtered_configs) == set(expected_to_sync_after_filtering)
+
+    @pytest.mark.parametrize(
+        "sync_util_provider, sync_configs, expected_client_class",
+        [
+            (
+                LegacySyncUtilProvider,
+                {"vulnerabilities": SyncConfig(url="www.anchore.com", enabled=True)},
+                FeedServiceClient,
+            ),
+            (
+                GrypeDBSyncUtilProvider,
+                {"grypedb": SyncConfig(url="www.anchore.com", enabled=True)},
+                GrypeDBServiceClient,
+            ),
+        ],
+    )
+    def test_get_client(
+        self,
+        sync_util_provider: Type[SyncUtilProvider],
+        sync_configs: Dict[str, SyncConfig],
+        expected_client_class: Type[IFeedSource],
+    ):
+        client = sync_util_provider(sync_configs).get_client()
+        assert isinstance(client, expected_client_class)
+
+    def test_get_groups_to_download_grype(self):
+        source_feeds = {
+            "grypedb": {
+                "meta": FeedList(
+                    feeds=[
+                        FeedAPIRecord(
+                            name="grypedb",
+                            description="grypedb feed",
+                            access_tier="0",
+                        )
+                    ]
+                ),
+                "groups": [
+                    FeedAPIGroupRecord(
+                        name="grypedb:vulnerabilities",
+                        description="grypedb:vulnerabilities group",
+                        access_tier="0",
+                        grype_listing=GrypeDBListing(
+                            built=anchore_now_datetime(),
+                            version="2",
+                            url="www.anchore.com",
+                            checksum="sha256:xxx",
+                        ),
+                    )
+                ],
+            }
+        }
+        feeds_to_sync = [GrypeDBFeed(metadata=FeedMetadata(name="grypedb"))]
+        sync_config = {"grypedb": SyncConfig(enabled=True, url="www.anchore.com")}
+        groups_to_download = GrypeDBSyncUtilProvider(
+            sync_config
+        ).get_groups_to_download(source_feeds, feeds_to_sync, "0")
+        assert len(groups_to_download) == 1
+        group = groups_to_download[0]
+        assert group.enabled
+        assert group.feed_name == "grypedb"
+        assert group.name == "grypedb:vulnerabilities"
+
+    def test_get_groups_to_download_legacy(self):
+        feed_group_metadata = [
+            FeedGroupMetadata(name="vulnerabilities:alpine:3.10", enabled=True),
+            FeedGroupMetadata(name="vulnerabilities:alpine:3.11", enabled=True),
+        ]
+        feeds_to_sync = [
+            VulnerabilityFeed(
+                metadata=FeedMetadata(
+                    name="vulnerabilities",
+                    enabled=True,
+                    groups=feed_group_metadata,
+                )
+            )
+        ]
+        sync_config = {
+            "vulnerabilities": SyncConfig(enabled=True, url="www.anchore.com")
+        }
+        groups_to_download = LegacySyncUtilProvider(sync_config).get_groups_to_download(
+            {}, feeds_to_sync, "0"
+        )
+        assert groups_to_download == feed_group_metadata


### PR DESCRIPTION
<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**:

The feed sync implementation was heavily tied to individual FeedGroupMetadata records. Meaning, if one wanted to sync a DataFeed, one had to first create at least one FeedGroupMetadata for that DataFeed. This is what we were doing for Grype DB. As a result, there was a meaningless group record created called `grypedb:vulnerabilities`. The objective is to expose feed group information to the user that reflects the contents of the Grype DB sqlite file. As such, this workflow needed to change. The changes in this PR allow GrypeDBFeed to sync without being tied to or creating a new FeedGroupMetadata record in the database. All of the logic that changes depending on whether the provider is set to grype has been abstracted through the VulnerabilityProvider implementations. There, a new get_sync_utils() method returns an implementation of SyncUtilProvider, of which there is one for Grype and one for Legacy. These SyncUtilProviders contain the key differences between the two workflows, and the DataFeeds.sync() method has been updated to use them.

-  Update GrypeDBServiceClient so that list_feed_groups returns listing information. (Also add new serializable data model to FeedAPIGroupRecord for GrypeDBListing)
-  Split sync_metadata logic so that FeedGroupMetadata sync can be turned off. Update tasks.FeedsUpdateTask and sync.sync() so that all logic differences between legacy and grype flows are implemented through the providers.VulnerabilityProvider abstraction. This allows Grype feed sync to proceed without the creation of  FeedGroupMetadata objects.
-  Make GrypeDBFeed a subclass of DataFeeds instead. Move common logic shared across all feeds from AnchoreServiceFeed to DataFeeds. Remove all use of FeedGroupMetadata from GrypeDBFeed.
-  Update delete_feed, delete_group, toggle_feed_enabled, and toggle_group_enabled api controllers to return HTTP 501 if feed is grypedb feed. 
    - GrypeDB groups will be tied to a single copy of the Grype database, and cannot be deleted, but the whole feed can.
    - GrypeDB feed can be deleted and resynced, but the implementation doesn't yet have enough safety controls around the operation to be confident in the functionality.
    - Enabling/disabling the grypedb feed when grype is the provider will remove the main source of vuln info and may cause unexpected behavior.
- Updated integration tests to adjust for API changes.
- Added docstrings and correct type hints.
- Add new unit tests for SyncUtilProviders

**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #:



