### PR TITLE
Support vendor_only flag in grype provider

### DIFF
--- a/anchore_engine/services/apiext/api/controllers/utils.py
+++ b/anchore_engine/services/apiext/api/controllers/utils.py
@@ -311,15 +311,10 @@ def make_response_vulnerability_report(vulnerability_type, vulnerability_report)
     for vuln_match in vuln_matches:
         vulnerability_dict = vuln_match.get("vulnerability", {})
         artifact_dict = vuln_match.get("artifact", {})
-        fix_list = vuln_match.get("fixes", [])
+        fix_dict = vuln_match.get("fix", {})
         fix_versions = (
-            [
-                item["version"]
-                for item in fix_list
-                if item["version"] and item["version"] != "None"
-                for item in fix_list
-            ]
-            if fix_list
+            [item for item in fix_dict.get("versions", []) if item and item != "None"]
+            if fix_dict
             else []
         )
         fixed_in_version = ", ".join(fix_versions) if fix_versions else "None"

--- a/anchore_engine/services/policy_engine/engine/vulns/mappers.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/mappers.py
@@ -117,11 +117,7 @@ class PackageMapper:
 
         vuln_id = vuln.get("id")
         fix_ver = vuln.get("fixedInVersion")
-        if fix_ver:
-            fix_observed_at = now
-        else:
-            fix_ver = "None"  # barf needed for policy evals and external api
-            fix_observed_at = None
+        fix_observed_at = now if fix_ver else None
 
         engine_nvd_scores = []
         engine_vendor_scores = []  # TODO replace with grype data when available
@@ -184,8 +180,6 @@ class PackageMapper:
                 feed_group=feed_group,
                 cvss_scores_nvd=engine_nvd_scores,
                 cvss_scores_vendor=[],
-                created_at=now,  # TODO replace with grype data when available
-                last_modified=now,  # TODO replace with grype data when available
             ),
             artifact=Artifact(
                 name=pkg_name,
@@ -195,13 +189,12 @@ class PackageMapper:
                 cpe="None",  # TODO replace with grype data when available
                 cpe23="None",  # TODO replace with grype data when available
             ),
-            fixes=[
-                FixedArtifact(
-                    version=fix_ver,
-                    wont_fix=False,  # TODO replace with grype data when available
-                    observed_at=fix_observed_at,
-                )
-            ],
+            fix=FixedArtifact(
+                versions=[fix_ver] if fix_ver else [],
+                wont_fix=False,  # TODO replace with grype data when available
+                observed_at=fix_observed_at,
+                advisories=[],  # TODO replace with grype data when available
+            ),
             match=Match(detected_at=now),
         )
 

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:406413437f26223183d133ccc7186f24c827729e1b21adc7330dd43fcdc030b3.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:406413437f26223183d133ccc7186f24c827729e1b21adc7330dd43fcdc030b3.json
@@ -1,4274 +1,4185 @@
 [
   {
-    "artifact": {
-      "name": "aiohttp",
-      "pkg_type": "python",
-      "pkg_path": "/usr/local/lib/python3.7/dist-packages/aiohttp",
-      "version": "3.7.3",
-      "cpe23": "None",
-      "cpe": "None"
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "3.7.4"
+      ],
+      "observed_at": "2021-03-31T17:30:49Z"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
     },
     "vulnerability": {
-      "vulnerability_id": "GHSA-v6wp-4m6f-gcjg",
-      "created_at": "2021-03-31T17:30:49Z",
-      "feed_group": "github:python",
-      "link": "https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
+      "feed_group": "github:python",
+      "vulnerability_id": "GHSA-v6wp-4m6f-gcjg",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
-            "exploitability_score": 2.8,
-            "impact_score": 2.7,
-            "base_score": 6.1
-          },
-          "id": "CVE-2021-21330",
           "cvss_v2": {
             "exploitability_score": 8.6,
             "impact_score": 4.9,
             "base_score": 5.8
+          },
+          "id": "CVE-2021-21330",
+          "cvss_v3": {
+            "exploitability_score": 2.8,
+            "impact_score": 2.7,
+            "base_score": 6.1
           }
         }
       ],
-      "description": "NA",
-      "severity": "Low",
-      "last_modified": "2021-03-31T17:30:49Z",
-      "feed": "vulnerabilities"
+      "severity": "Low"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "3.7.3",
+      "cpe23": "None",
+      "name": "aiohttp",
+      "pkg_path": "/usr/local/lib/python3.7/dist-packages/aiohttp",
+      "pkg_type": "python"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": "2021-03-31T17:30:49Z",
-        "version": "3.7.4",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "apt",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "1.8.2.2",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2011-3374",
-      "created_at": "2020-03-27T23:00:32Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2011-3374",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2011-3374",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2011-3374",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
-            "exploitability_score": 2.2,
-            "impact_score": 1.4,
-            "base_score": 3.7
-          },
-          "id": "CVE-2011-3374",
           "cvss_v2": {
             "exploitability_score": 8.6,
             "impact_score": 2.9,
             "base_score": 4.3
+          },
+          "id": "CVE-2011-3374",
+          "cvss_v3": {
+            "exploitability_score": 2.2,
+            "impact_score": 1.4,
+            "base_score": 3.7
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T23:00:32Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "1.8.2.2",
+      "cpe23": "None",
+      "name": "apt",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "bash",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "5.0-4",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2019-18276",
-      "created_at": "2020-03-27T22:58:42Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18276",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18276",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2019-18276",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
-            "exploitability_score": 1.8,
-            "impact_score": 5.9,
-            "base_score": 7.8
-          },
-          "id": "CVE-2019-18276",
           "cvss_v2": {
             "exploitability_score": 3.9,
             "impact_score": 10.0,
             "base_score": 7.2
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-07-05T09:12:19Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "coreutils",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "8.30-3",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2017-18018",
-      "created_at": "2020-03-27T22:59:57Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-18018",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 1.0,
-            "impact_score": 3.6,
-            "base_score": 4.7
           },
-          "id": "CVE-2017-18018",
-          "cvss_v2": {
-            "exploitability_score": 3.4,
-            "impact_score": 2.9,
-            "base_score": 1.9
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:59:57Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "guava",
-      "pkg_type": "java",
-      "pkg_path": "/sandbox/target/my-app-1.jar:guava",
-      "version": "23.0",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "GHSA-5mg8-w23w-74h3",
-      "created_at": "2021-03-31T17:30:52Z",
-      "feed_group": "github:java",
-      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 1.8,
-            "impact_score": 1.4,
-            "base_score": 3.3
-          },
-          "id": "CVE-2020-8908",
-          "cvss_v2": {
-            "exploitability_score": 3.9,
-            "impact_score": 2.9,
-            "base_score": 2.1
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Medium",
-      "last_modified": "2021-03-31T17:30:52Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": "2021-03-31T17:30:52Z",
-        "version": "30.0-jre",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "guava",
-      "pkg_type": "java",
-      "pkg_path": "/sandbox/target/my-app-1.jar:guava",
-      "version": "23.0",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j",
-      "created_at": "2020-06-16T09:10:15Z",
-      "feed_group": "github:java",
-      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 2.2,
-            "impact_score": 3.6,
-            "base_score": 5.9
-          },
-          "id": "CVE-2018-10237",
-          "cvss_v2": {
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "base_score": 4.3
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Medium",
-      "last_modified": "2020-06-16T09:10:15Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": "2020-06-16T09:10:15Z",
-        "version": "24.1.1-jre",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "guava",
-      "pkg_type": "java",
-      "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
-      "version": "23.0",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "GHSA-5mg8-w23w-74h3",
-      "created_at": "2021-03-31T17:30:52Z",
-      "feed_group": "github:java",
-      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 1.8,
-            "impact_score": 1.4,
-            "base_score": 3.3
-          },
-          "id": "CVE-2020-8908",
-          "cvss_v2": {
-            "exploitability_score": 3.9,
-            "impact_score": 2.9,
-            "base_score": 2.1
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Medium",
-      "last_modified": "2021-03-31T17:30:52Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": "2021-03-31T17:30:52Z",
-        "version": "30.0-jre",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "guava",
-      "pkg_type": "java",
-      "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
-      "version": "23.0",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j",
-      "created_at": "2020-06-16T09:10:15Z",
-      "feed_group": "github:java",
-      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 2.2,
-            "impact_score": 3.6,
-            "base_score": 5.9
-          },
-          "id": "CVE-2018-10237",
-          "cvss_v2": {
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "base_score": 4.3
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Medium",
-      "last_modified": "2020-06-16T09:10:15Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": "2020-06-16T09:10:15Z",
-        "version": "24.1.1-jre",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libapt-pkg5.0",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "1.8.2.2",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2011-3374",
-      "created_at": "2020-03-27T23:00:32Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2011-3374",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 2.2,
-            "impact_score": 1.4,
-            "base_score": 3.7
-          },
-          "id": "CVE-2011-3374",
-          "cvss_v2": {
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "base_score": 4.3
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T23:00:32Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libc6",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.28-10",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2010-4051",
-      "created_at": "2020-03-27T23:00:05Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4051",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": -1.0,
-            "impact_score": -1.0,
-            "base_score": -1.0
-          },
-          "id": "CVE-2010-4051",
-          "cvss_v2": {
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "base_score": 5.0
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T23:00:05Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libc6",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.28-10",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2010-4052",
-      "created_at": "2020-03-27T23:00:05Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4052",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": -1.0,
-            "impact_score": -1.0,
-            "base_score": -1.0
-          },
-          "id": "CVE-2010-4052",
-          "cvss_v2": {
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "base_score": 5.0
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T23:00:05Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libc6",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.28-10",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2010-4756",
-      "created_at": "2020-03-27T23:00:06Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4756",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": -1.0,
-            "impact_score": -1.0,
-            "base_score": -1.0
-          },
-          "id": "CVE-2010-4756",
-          "cvss_v2": {
-            "exploitability_score": 8.0,
-            "impact_score": 2.9,
-            "base_score": 4.0
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T23:00:06Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libc6",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.28-10",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2018-20796",
-      "created_at": "2020-03-27T23:00:05Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2018-20796",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "base_score": 7.5
-          },
-          "id": "CVE-2018-20796",
-          "cvss_v2": {
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "base_score": 5.0
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T23:00:05Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libc6",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.28-10",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2019-1010022",
-      "created_at": "2020-03-27T23:00:06Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010022",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 3.9,
-            "impact_score": 5.9,
-            "base_score": 9.8
-          },
-          "id": "CVE-2019-1010022",
-          "cvss_v2": {
-            "exploitability_score": 10.0,
-            "impact_score": 6.4,
-            "base_score": 7.5
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T23:00:06Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libc6",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.28-10",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2019-1010023",
-      "created_at": "2020-03-27T23:00:05Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010023",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 2.8,
-            "impact_score": 5.9,
-            "base_score": 8.8
-          },
-          "id": "CVE-2019-1010023",
-          "cvss_v2": {
-            "exploitability_score": 8.6,
-            "impact_score": 6.4,
-            "base_score": 6.8
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T23:00:05Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libc6",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.28-10",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2019-1010024",
-      "created_at": "2020-03-27T23:00:05Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010024",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 3.9,
-            "impact_score": 1.4,
-            "base_score": 5.3
-          },
-          "id": "CVE-2019-1010024",
-          "cvss_v2": {
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "base_score": 5.0
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T23:00:05Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libc6",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.28-10",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2019-1010025",
-      "created_at": "2020-03-27T23:00:05Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010025",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 3.9,
-            "impact_score": 1.4,
-            "base_score": 5.3
-          },
-          "id": "CVE-2019-1010025",
-          "cvss_v2": {
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "base_score": 5.0
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T23:00:05Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libc6",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.28-10",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2019-9192",
-      "created_at": "2020-03-27T23:00:05Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9192",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "base_score": 7.5
-          },
-          "id": "CVE-2019-9192",
-          "cvss_v2": {
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "base_score": 5.0
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T23:00:05Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libc-bin",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.28-10",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2010-4051",
-      "created_at": "2020-03-27T23:00:05Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4051",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": -1.0,
-            "impact_score": -1.0,
-            "base_score": -1.0
-          },
-          "id": "CVE-2010-4051",
-          "cvss_v2": {
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "base_score": 5.0
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T23:00:05Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libc-bin",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.28-10",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2010-4052",
-      "created_at": "2020-03-27T23:00:05Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4052",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": -1.0,
-            "impact_score": -1.0,
-            "base_score": -1.0
-          },
-          "id": "CVE-2010-4052",
-          "cvss_v2": {
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "base_score": 5.0
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T23:00:05Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libc-bin",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.28-10",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2010-4756",
-      "created_at": "2020-03-27T23:00:06Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4756",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": -1.0,
-            "impact_score": -1.0,
-            "base_score": -1.0
-          },
-          "id": "CVE-2010-4756",
-          "cvss_v2": {
-            "exploitability_score": 8.0,
-            "impact_score": 2.9,
-            "base_score": 4.0
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T23:00:06Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libc-bin",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.28-10",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2018-20796",
-      "created_at": "2020-03-27T23:00:05Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2018-20796",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "base_score": 7.5
-          },
-          "id": "CVE-2018-20796",
-          "cvss_v2": {
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "base_score": 5.0
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T23:00:05Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libc-bin",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.28-10",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2019-1010022",
-      "created_at": "2020-03-27T23:00:06Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010022",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 3.9,
-            "impact_score": 5.9,
-            "base_score": 9.8
-          },
-          "id": "CVE-2019-1010022",
-          "cvss_v2": {
-            "exploitability_score": 10.0,
-            "impact_score": 6.4,
-            "base_score": 7.5
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T23:00:06Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libc-bin",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.28-10",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2019-1010023",
-      "created_at": "2020-03-27T23:00:05Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010023",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 2.8,
-            "impact_score": 5.9,
-            "base_score": 8.8
-          },
-          "id": "CVE-2019-1010023",
-          "cvss_v2": {
-            "exploitability_score": 8.6,
-            "impact_score": 6.4,
-            "base_score": 6.8
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T23:00:05Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libc-bin",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.28-10",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2019-1010024",
-      "created_at": "2020-03-27T23:00:05Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010024",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 3.9,
-            "impact_score": 1.4,
-            "base_score": 5.3
-          },
-          "id": "CVE-2019-1010024",
-          "cvss_v2": {
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "base_score": 5.0
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T23:00:05Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libc-bin",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.28-10",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2019-1010025",
-      "created_at": "2020-03-27T23:00:05Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010025",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 3.9,
-            "impact_score": 1.4,
-            "base_score": 5.3
-          },
-          "id": "CVE-2019-1010025",
-          "cvss_v2": {
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "base_score": 5.0
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T23:00:05Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libc-bin",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.28-10",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2019-9192",
-      "created_at": "2020-03-27T23:00:05Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9192",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "base_score": 7.5
-          },
-          "id": "CVE-2019-9192",
-          "cvss_v2": {
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "base_score": 5.0
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T23:00:05Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libgcrypt20",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "1.8.4-5",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2018-6829",
-      "created_at": "2020-03-27T22:56:27Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2018-6829",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "base_score": 7.5
-          },
-          "id": "CVE-2018-6829",
-          "cvss_v2": {
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "base_score": 5.0
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:56:27Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libglib2.0-0",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.58.3-2+deb10u2",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2012-0039",
-      "created_at": "2020-03-27T23:01:10Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2012-0039",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": -1.0,
-            "impact_score": -1.0,
-            "base_score": -1.0
-          },
-          "id": "CVE-2012-0039",
-          "cvss_v2": {
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "base_score": 5.0
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T23:01:10Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libglib2.0-0",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.58.3-2+deb10u2",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2020-35457",
-      "created_at": "2020-12-16T09:16:22Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-35457",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
+          "id": "CVE-2019-18276",
           "cvss_v3": {
             "exploitability_score": 1.8,
             "impact_score": 5.9,
             "base_score": 7.8
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "5.0-4",
+      "cpe23": "None",
+      "name": "bash",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-18018",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2017-18018",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 3.4,
+            "impact_score": 2.9,
+            "base_score": 1.9
           },
-          "id": "CVE-2020-35457",
+          "id": "CVE-2017-18018",
+          "cvss_v3": {
+            "exploitability_score": 1.0,
+            "impact_score": 3.6,
+            "base_score": 4.7
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "8.30-3",
+      "cpe23": "None",
+      "name": "coreutils",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "30.0-jre"
+      ],
+      "observed_at": "2021-03-31T17:30:52Z"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
+      "feed_group": "github:java",
+      "vulnerability_id": "GHSA-5mg8-w23w-74h3",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "base_score": 2.1
+          },
+          "id": "CVE-2020-8908",
+          "cvss_v3": {
+            "exploitability_score": 1.8,
+            "impact_score": 1.4,
+            "base_score": 3.3
+          }
+        }
+      ],
+      "severity": "Medium"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "23.0",
+      "cpe23": "None",
+      "name": "guava",
+      "pkg_path": "/sandbox/target/my-app-1.jar:guava",
+      "pkg_type": "java"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "24.1.1-jre"
+      ],
+      "observed_at": "2020-06-16T09:10:15Z"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
+      "feed_group": "github:java",
+      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "base_score": 4.3
+          },
+          "id": "CVE-2018-10237",
+          "cvss_v3": {
+            "exploitability_score": 2.2,
+            "impact_score": 3.6,
+            "base_score": 5.9
+          }
+        }
+      ],
+      "severity": "Medium"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "23.0",
+      "cpe23": "None",
+      "name": "guava",
+      "pkg_path": "/sandbox/target/my-app-1.jar:guava",
+      "pkg_type": "java"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "30.0-jre"
+      ],
+      "observed_at": "2021-03-31T17:30:52Z"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
+      "feed_group": "github:java",
+      "vulnerability_id": "GHSA-5mg8-w23w-74h3",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "base_score": 2.1
+          },
+          "id": "CVE-2020-8908",
+          "cvss_v3": {
+            "exploitability_score": 1.8,
+            "impact_score": 1.4,
+            "base_score": 3.3
+          }
+        }
+      ],
+      "severity": "Medium"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "23.0",
+      "cpe23": "None",
+      "name": "guava",
+      "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
+      "pkg_type": "java"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "24.1.1-jre"
+      ],
+      "observed_at": "2020-06-16T09:10:15Z"
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
+      "feed_group": "github:java",
+      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "base_score": 4.3
+          },
+          "id": "CVE-2018-10237",
+          "cvss_v3": {
+            "exploitability_score": 2.2,
+            "impact_score": 3.6,
+            "base_score": 5.9
+          }
+        }
+      ],
+      "severity": "Medium"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "23.0",
+      "cpe23": "None",
+      "name": "guava",
+      "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
+      "pkg_type": "java"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2011-3374",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2011-3374",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "base_score": 4.3
+          },
+          "id": "CVE-2011-3374",
+          "cvss_v3": {
+            "exploitability_score": 2.2,
+            "impact_score": 1.4,
+            "base_score": 3.7
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "1.8.2.2",
+      "cpe23": "None",
+      "name": "libapt-pkg5.0",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4051",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2010-4051",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          },
+          "id": "CVE-2010-4051",
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "name": "libc6",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4052",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2010-4052",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          },
+          "id": "CVE-2010-4052",
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "name": "libc6",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4756",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2010-4756",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 8.0,
+            "impact_score": 2.9,
+            "base_score": 4.0
+          },
+          "id": "CVE-2010-4756",
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "name": "libc6",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2018-20796",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2018-20796",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          },
+          "id": "CVE-2018-20796",
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "base_score": 7.5
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "name": "libc6",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010022",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2019-1010022",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 6.4,
+            "base_score": 7.5
+          },
+          "id": "CVE-2019-1010022",
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 5.9,
+            "base_score": 9.8
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "name": "libc6",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010023",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2019-1010023",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 6.4,
+            "base_score": 6.8
+          },
+          "id": "CVE-2019-1010023",
+          "cvss_v3": {
+            "exploitability_score": 2.8,
+            "impact_score": 5.9,
+            "base_score": 8.8
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "name": "libc6",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010024",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2019-1010024",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          },
+          "id": "CVE-2019-1010024",
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 1.4,
+            "base_score": 5.3
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "name": "libc6",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010025",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2019-1010025",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          },
+          "id": "CVE-2019-1010025",
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 1.4,
+            "base_score": 5.3
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "name": "libc6",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9192",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2019-9192",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          },
+          "id": "CVE-2019-9192",
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "base_score": 7.5
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "name": "libc6",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4051",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2010-4051",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          },
+          "id": "CVE-2010-4051",
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "name": "libc-bin",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4052",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2010-4052",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          },
+          "id": "CVE-2010-4052",
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "name": "libc-bin",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4756",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2010-4756",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 8.0,
+            "impact_score": 2.9,
+            "base_score": 4.0
+          },
+          "id": "CVE-2010-4756",
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "name": "libc-bin",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2018-20796",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2018-20796",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          },
+          "id": "CVE-2018-20796",
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "base_score": 7.5
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "name": "libc-bin",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010022",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2019-1010022",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 6.4,
+            "base_score": 7.5
+          },
+          "id": "CVE-2019-1010022",
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 5.9,
+            "base_score": 9.8
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "name": "libc-bin",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010023",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2019-1010023",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 6.4,
+            "base_score": 6.8
+          },
+          "id": "CVE-2019-1010023",
+          "cvss_v3": {
+            "exploitability_score": 2.8,
+            "impact_score": 5.9,
+            "base_score": 8.8
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "name": "libc-bin",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010024",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2019-1010024",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          },
+          "id": "CVE-2019-1010024",
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 1.4,
+            "base_score": 5.3
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "name": "libc-bin",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010025",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2019-1010025",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          },
+          "id": "CVE-2019-1010025",
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 1.4,
+            "base_score": 5.3
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "name": "libc-bin",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9192",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2019-9192",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          },
+          "id": "CVE-2019-9192",
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "base_score": 7.5
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.28-10",
+      "cpe23": "None",
+      "name": "libc-bin",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2018-6829",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2018-6829",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          },
+          "id": "CVE-2018-6829",
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "base_score": 7.5
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "1.8.4-5",
+      "cpe23": "None",
+      "name": "libgcrypt20",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2012-0039",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2012-0039",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          },
+          "id": "CVE-2012-0039",
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.58.3-2+deb10u2",
+      "cpe23": "None",
+      "name": "libglib2.0-0",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-35457",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2020-35457",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
           "cvss_v2": {
             "exploitability_score": 3.9,
             "impact_score": 6.4,
             "base_score": 4.6
+          },
+          "id": "CVE-2020-35457",
+          "cvss_v3": {
+            "exploitability_score": 1.8,
+            "impact_score": 5.9,
+            "base_score": 7.8
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-12-18T09:16:42Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.58.3-2+deb10u2",
+      "cpe23": "None",
+      "name": "libglib2.0-0",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libgnutls30",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "3.6.7-4+deb10u6",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2011-3389",
-      "created_at": "2020-03-27T22:56:32Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2011-3389",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2011-3389",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2011-3389",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
-            "exploitability_score": -1.0,
-            "impact_score": -1.0,
-            "base_score": -1.0
-          },
-          "id": "CVE-2011-3389",
           "cvss_v2": {
             "exploitability_score": 8.6,
             "impact_score": 2.9,
             "base_score": 4.3
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Medium",
-      "last_modified": "2020-03-27T22:56:32Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libgssapi-krb5-2",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "1.17-3+deb10u1",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2004-0971",
-      "created_at": "2020-03-27T22:58:44Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2004-0971",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
+          },
+          "id": "CVE-2011-3389",
           "cvss_v3": {
             "exploitability_score": -1.0,
             "impact_score": -1.0,
             "base_score": -1.0
-          },
-          "id": "CVE-2004-0971",
+          }
+        }
+      ],
+      "severity": "Medium"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "3.6.7-4+deb10u6",
+      "cpe23": "None",
+      "name": "libgnutls30",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2004-0971",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2004-0971",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
           "cvss_v2": {
             "exploitability_score": 3.9,
             "impact_score": 2.9,
             "base_score": 2.1
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:58:44Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libgssapi-krb5-2",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "1.17-3+deb10u1",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2018-5709",
-      "created_at": "2020-03-27T22:58:44Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2018-5709",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "base_score": 7.5
           },
-          "id": "CVE-2018-5709",
-          "cvss_v2": {
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "base_score": 5.0
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:58:44Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libldap-common",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.4.47+dfsg-3+deb10u6",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2015-3276",
-      "created_at": "2020-03-27T22:58:11Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2015-3276",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
+          "id": "CVE-2004-0971",
           "cvss_v3": {
             "exploitability_score": -1.0,
             "impact_score": -1.0,
             "base_score": -1.0
-          },
-          "id": "CVE-2015-3276",
-          "cvss_v2": {
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "base_score": 5.0
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:58:11Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "1.17-3+deb10u1",
+      "cpe23": "None",
+      "name": "libgssapi-krb5-2",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libldap-common",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.4.47+dfsg-3+deb10u6",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2017-14159",
-      "created_at": "2020-03-27T22:58:11Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-14159",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2018-5709",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2018-5709",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
-            "exploitability_score": 1.0,
-            "impact_score": 3.6,
-            "base_score": 4.7
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
           },
-          "id": "CVE-2017-14159",
+          "id": "CVE-2018-5709",
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "base_score": 7.5
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "1.17-3+deb10u1",
+      "cpe23": "None",
+      "name": "libgssapi-krb5-2",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2015-3276",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2015-3276",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          },
+          "id": "CVE-2015-3276",
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.4.47+dfsg-3+deb10u6",
+      "cpe23": "None",
+      "name": "libldap-common",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-14159",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2017-14159",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
           "cvss_v2": {
             "exploitability_score": 3.4,
             "impact_score": 2.9,
             "base_score": 1.9
+          },
+          "id": "CVE-2017-14159",
+          "cvss_v3": {
+            "exploitability_score": 1.0,
+            "impact_score": 3.6,
+            "base_score": 4.7
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:58:11Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.4.47+dfsg-3+deb10u6",
+      "cpe23": "None",
+      "name": "libldap-common",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libldap-common",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.4.47+dfsg-3+deb10u6",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2017-17740",
-      "created_at": "2020-03-27T22:58:11Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17740",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17740",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2017-17740",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "base_score": 7.5
-          },
-          "id": "CVE-2017-17740",
           "cvss_v2": {
             "exploitability_score": 10.0,
             "impact_score": 2.9,
             "base_score": 5.0
+          },
+          "id": "CVE-2017-17740",
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "base_score": 7.5
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:58:11Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.4.47+dfsg-3+deb10u6",
+      "cpe23": "None",
+      "name": "libldap-common",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libldap-common",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.4.47+dfsg-3+deb10u6",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2020-15719",
-      "created_at": "2020-07-17T09:11:26Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-15719",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-15719",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2020-15719",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
+          "cvss_v2": {
+            "exploitability_score": 4.9,
+            "impact_score": 4.9,
+            "base_score": 4.0
+          },
+          "id": "CVE-2020-15719",
           "cvss_v3": {
             "exploitability_score": 1.6,
             "impact_score": 2.5,
             "base_score": 4.2
-          },
-          "id": "CVE-2020-15719",
-          "cvss_v2": {
-            "exploitability_score": 4.9,
-            "impact_score": 4.9,
-            "base_score": 4.0
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-08-05T09:09:49Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.4.47+dfsg-3+deb10u6",
+      "cpe23": "None",
+      "name": "libldap-common",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libnss-systemd",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "241-7~deb10u7",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2013-4392",
-      "created_at": "2020-03-27T22:58:49Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2013-4392",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
-            "exploitability_score": -1.0,
-            "impact_score": -1.0,
-            "base_score": -1.0
-          },
-          "id": "CVE-2013-4392",
           "cvss_v2": {
             "exploitability_score": 3.4,
             "impact_score": 4.9,
             "base_score": 3.3
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:58:49Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libnss-systemd",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "241-7~deb10u7",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2019-20386",
-      "created_at": "2020-03-27T22:58:48Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 0.9,
-            "impact_score": 1.4,
-            "base_score": 2.4
           },
-          "id": "CVE-2019-20386",
-          "cvss_v2": {
-            "exploitability_score": 3.9,
-            "impact_score": 2.9,
-            "base_score": 2.1
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-05-12T09:09:42Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libnss-systemd",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "241-7~deb10u7",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2020-13776",
-      "created_at": "2020-06-04T09:09:58Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 0.8,
-            "impact_score": 5.9,
-            "base_score": 6.7
-          },
-          "id": "CVE-2020-13776",
-          "cvss_v2": {
-            "exploitability_score": 1.9,
-            "impact_score": 10.0,
-            "base_score": 6.2
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-06-21T09:10:36Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libpcre3",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2:8.39-12",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2017-11164",
-      "created_at": "2020-03-27T23:00:01Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-11164",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "base_score": 7.5
-          },
-          "id": "CVE-2017-11164",
-          "cvss_v2": {
-            "exploitability_score": 10.0,
-            "impact_score": 6.9,
-            "base_score": 7.8
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T23:00:01Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libpcre3",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2:8.39-12",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2017-16231",
-      "created_at": "2020-03-27T23:00:01Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-16231",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 1.8,
-            "impact_score": 3.6,
-            "base_score": 5.5
-          },
-          "id": "CVE-2017-16231",
-          "cvss_v2": {
-            "exploitability_score": 3.9,
-            "impact_score": 2.9,
-            "base_score": 2.1
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T23:00:01Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libpcre3",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2:8.39-12",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2017-7245",
-      "created_at": "2020-03-27T23:00:01Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-7245",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 1.8,
-            "impact_score": 5.9,
-            "base_score": 7.8
-          },
-          "id": "CVE-2017-7245",
-          "cvss_v2": {
-            "exploitability_score": 8.6,
-            "impact_score": 6.4,
-            "base_score": 6.8
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T23:00:01Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libpcre3",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2:8.39-12",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2017-7246",
-      "created_at": "2020-03-27T23:00:01Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-7246",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 1.8,
-            "impact_score": 5.9,
-            "base_score": 7.8
-          },
-          "id": "CVE-2017-7246",
-          "cvss_v2": {
-            "exploitability_score": 8.6,
-            "impact_score": 6.4,
-            "base_score": 6.8
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T23:00:01Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libpcre3",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2:8.39-12",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2019-20838",
-      "created_at": "2020-06-16T09:09:31Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20838",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "base_score": 7.5
-          },
-          "id": "CVE-2019-20838",
-          "cvss_v2": {
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "base_score": 4.3
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-07-02T09:10:45Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libpython2.7-minimal",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.7.16-2+deb10u1",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2013-7040",
-      "created_at": "2020-03-27T23:00:31Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-7040",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
+          "id": "CVE-2013-4392",
           "cvss_v3": {
             "exploitability_score": -1.0,
             "impact_score": -1.0,
             "base_score": -1.0
-          },
-          "id": "CVE-2013-7040",
-          "cvss_v2": {
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "base_score": 4.3
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T23:00:31Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "241-7~deb10u7",
+      "cpe23": "None",
+      "name": "libnss-systemd",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libpython2.7-minimal",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.7.16-2+deb10u1",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2017-17522",
-      "created_at": "2020-03-27T22:58:28Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2019-20386",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
+          "cvss_v2": {
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "base_score": 2.1
+          },
+          "id": "CVE-2019-20386",
           "cvss_v3": {
-            "exploitability_score": 2.8,
+            "exploitability_score": 0.9,
+            "impact_score": 1.4,
+            "base_score": 2.4
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "241-7~deb10u7",
+      "cpe23": "None",
+      "name": "libnss-systemd",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2020-13776",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 1.9,
+            "impact_score": 10.0,
+            "base_score": 6.2
+          },
+          "id": "CVE-2020-13776",
+          "cvss_v3": {
+            "exploitability_score": 0.8,
             "impact_score": 5.9,
-            "base_score": 8.8
-          },
-          "id": "CVE-2017-17522",
-          "cvss_v2": {
-            "exploitability_score": 8.6,
-            "impact_score": 6.4,
-            "base_score": 6.8
+            "base_score": 6.7
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:58:28Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "241-7~deb10u7",
+      "cpe23": "None",
+      "name": "libnss-systemd",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libpython2.7-minimal",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.7.16-2+deb10u1",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2019-18348",
-      "created_at": "2020-03-27T22:58:28Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
       "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 2.8,
-            "impact_score": 2.7,
-            "base_score": 6.1
-          },
-          "id": "CVE-2019-18348",
-          "cvss_v2": {
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "base_score": 4.3
-          }
-        }
-      ],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-11164",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2017-11164",
       "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:58:28Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libpython2.7-minimal",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.7.16-2+deb10u1",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2019-9674",
-      "created_at": "2020-03-27T22:58:28Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
-      "cvss_scores_vendor": [],
       "cvss_scores_nvd": [
         {
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 6.9,
+            "base_score": 7.8
+          },
+          "id": "CVE-2017-11164",
           "cvss_v3": {
             "exploitability_score": 3.9,
             "impact_score": 3.6,
             "base_score": 7.5
-          },
-          "id": "CVE-2019-9674",
-          "cvss_v2": {
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "base_score": 5.0
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:58:28Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2:8.39-12",
+      "cpe23": "None",
+      "name": "libpcre3",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libpython2.7-minimal",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.7.16-2+deb10u1",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2021-23336",
-      "created_at": "2021-03-31T17:06:44Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2021-23336",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-16231",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2017-16231",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
+          "cvss_v2": {
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "base_score": 2.1
+          },
+          "id": "CVE-2017-16231",
+          "cvss_v3": {
+            "exploitability_score": 1.8,
+            "impact_score": 3.6,
+            "base_score": 5.5
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2:8.39-12",
+      "cpe23": "None",
+      "name": "libpcre3",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-7245",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2017-7245",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 6.4,
+            "base_score": 6.8
+          },
+          "id": "CVE-2017-7245",
+          "cvss_v3": {
+            "exploitability_score": 1.8,
+            "impact_score": 5.9,
+            "base_score": 7.8
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2:8.39-12",
+      "cpe23": "None",
+      "name": "libpcre3",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-7246",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2017-7246",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 6.4,
+            "base_score": 6.8
+          },
+          "id": "CVE-2017-7246",
+          "cvss_v3": {
+            "exploitability_score": 1.8,
+            "impact_score": 5.9,
+            "base_score": 7.8
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2:8.39-12",
+      "cpe23": "None",
+      "name": "libpcre3",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20838",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2019-20838",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "base_score": 4.3
+          },
+          "id": "CVE-2019-20838",
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "base_score": 7.5
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2:8.39-12",
+      "cpe23": "None",
+      "name": "libpcre3",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-7040",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2013-7040",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "base_score": 4.3
+          },
+          "id": "CVE-2013-7040",
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.7.16-2+deb10u1",
+      "cpe23": "None",
+      "name": "libpython2.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2017-17522",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 6.4,
+            "base_score": 6.8
+          },
+          "id": "CVE-2017-17522",
+          "cvss_v3": {
+            "exploitability_score": 2.8,
+            "impact_score": 5.9,
+            "base_score": 8.8
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.7.16-2+deb10u1",
+      "cpe23": "None",
+      "name": "libpython2.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2019-18348",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "base_score": 4.3
+          },
+          "id": "CVE-2019-18348",
+          "cvss_v3": {
+            "exploitability_score": 2.8,
+            "impact_score": 2.7,
+            "base_score": 6.1
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.7.16-2+deb10u1",
+      "cpe23": "None",
+      "name": "libpython2.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2019-9674",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          },
+          "id": "CVE-2019-9674",
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "base_score": 7.5
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.7.16-2+deb10u1",
+      "cpe23": "None",
+      "name": "libpython2.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2021-23336",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2021-23336",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 4.9,
+            "impact_score": 4.9,
+            "base_score": 4.0
+          },
+          "id": "CVE-2021-23336",
           "cvss_v3": {
             "exploitability_score": 1.6,
             "impact_score": 4.2,
             "base_score": 5.9
-          },
-          "id": "CVE-2021-23336",
-          "cvss_v2": {
-            "exploitability_score": 4.9,
-            "impact_score": 4.9,
-            "base_score": 4.0
           }
         }
       ],
-      "description": "NA",
-      "severity": "Medium",
-      "last_modified": "2021-03-31T17:06:44Z",
-      "feed": "vulnerabilities"
+      "severity": "Medium"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.7.16-2+deb10u1",
+      "cpe23": "None",
+      "name": "libpython2.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libpython3.7-minimal",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "3.7.3-2+deb10u3",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2017-17522",
-      "created_at": "2020-03-27T22:58:28Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2017-17522",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
-            "exploitability_score": 2.8,
-            "impact_score": 5.9,
-            "base_score": 8.8
-          },
-          "id": "CVE-2017-17522",
           "cvss_v2": {
             "exploitability_score": 8.6,
             "impact_score": 6.4,
             "base_score": 6.8
+          },
+          "id": "CVE-2017-17522",
+          "cvss_v3": {
+            "exploitability_score": 2.8,
+            "impact_score": 5.9,
+            "base_score": 8.8
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:58:28Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "3.7.3-2+deb10u3",
+      "cpe23": "None",
+      "name": "libpython3.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libpython3.7-minimal",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "3.7.3-2+deb10u3",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2019-18348",
-      "created_at": "2020-03-27T22:58:28Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2019-18348",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
-            "exploitability_score": 2.8,
-            "impact_score": 2.7,
-            "base_score": 6.1
-          },
-          "id": "CVE-2019-18348",
           "cvss_v2": {
             "exploitability_score": 8.6,
             "impact_score": 2.9,
             "base_score": 4.3
+          },
+          "id": "CVE-2019-18348",
+          "cvss_v3": {
+            "exploitability_score": 2.8,
+            "impact_score": 2.7,
+            "base_score": 6.1
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:58:28Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "3.7.3-2+deb10u3",
+      "cpe23": "None",
+      "name": "libpython3.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libpython3.7-minimal",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "3.7.3-2+deb10u3",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2019-9674",
-      "created_at": "2020-03-27T22:58:28Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2019-9674",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "base_score": 7.5
-          },
-          "id": "CVE-2019-9674",
           "cvss_v2": {
             "exploitability_score": 10.0,
             "impact_score": 2.9,
             "base_score": 5.0
+          },
+          "id": "CVE-2019-9674",
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "base_score": 7.5
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:58:28Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
     },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
     "artifact": {
-      "name": "libpython3.7-minimal",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
+      "cpe": "None",
       "version": "3.7.3-2+deb10u3",
       "cpe23": "None",
-      "cpe": "None"
+      "name": "libpython3.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
     },
     "vulnerability": {
-      "vulnerability_id": "CVE-2020-27619",
-      "created_at": "2020-10-23T09:09:58Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-27619",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-27619",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2020-27619",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
-            "exploitability_score": 3.9,
-            "impact_score": 5.9,
-            "base_score": 9.8
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 6.4,
+            "base_score": 7.5
           },
           "id": "CVE-2020-27619",
-          "cvss_v2": {
-            "exploitability_score": 10.0,
-            "impact_score": 6.4,
-            "base_score": 7.5
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-11-04T09:11:01Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libseccomp2",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.3.3-4",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2019-9893",
-      "created_at": "2020-03-27T22:56:22Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9893",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
           "cvss_v3": {
             "exploitability_score": 3.9,
             "impact_score": 5.9,
             "base_score": 9.8
-          },
-          "id": "CVE-2019-9893",
-          "cvss_v2": {
-            "exploitability_score": 10.0,
-            "impact_score": 6.4,
-            "base_score": 7.5
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:56:22Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "3.7.3-2+deb10u3",
+      "cpe23": "None",
+      "name": "libpython3.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libssl1.1",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "1.1.1d-0+deb10u6",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2007-6755",
-      "created_at": "2020-03-27T22:56:38Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2007-6755",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9893",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2019-9893",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
-            "exploitability_score": -1.0,
-            "impact_score": -1.0,
-            "base_score": -1.0
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 6.4,
+            "base_score": 7.5
           },
-          "id": "CVE-2007-6755",
+          "id": "CVE-2019-9893",
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 5.9,
+            "base_score": 9.8
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.3.3-4",
+      "cpe23": "None",
+      "name": "libseccomp2",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2007-6755",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2007-6755",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
           "cvss_v2": {
             "exploitability_score": 8.6,
             "impact_score": 4.9,
             "base_score": 5.8
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:56:38Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libssl1.1",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "1.1.1d-0+deb10u6",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2010-0928",
-      "created_at": "2020-03-27T22:56:38Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2010-0928",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
+          },
+          "id": "CVE-2007-6755",
           "cvss_v3": {
             "exploitability_score": -1.0,
             "impact_score": -1.0,
             "base_score": -1.0
-          },
-          "id": "CVE-2010-0928",
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "1.1.1d-0+deb10u6",
+      "cpe23": "None",
+      "name": "libssl1.1",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-0928",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2010-0928",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
           "cvss_v2": {
             "exploitability_score": 1.9,
             "impact_score": 6.9,
             "base_score": 4.0
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:56:38Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libsystemd0",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "241-7~deb10u7",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2013-4392",
-      "created_at": "2020-03-27T22:58:49Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
+          },
+          "id": "CVE-2010-0928",
           "cvss_v3": {
             "exploitability_score": -1.0,
             "impact_score": -1.0,
             "base_score": -1.0
-          },
-          "id": "CVE-2013-4392",
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "1.1.1d-0+deb10u6",
+      "cpe23": "None",
+      "name": "libssl1.1",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2013-4392",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
           "cvss_v2": {
             "exploitability_score": 3.4,
             "impact_score": 4.9,
             "base_score": 3.3
+          },
+          "id": "CVE-2013-4392",
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:58:49Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "241-7~deb10u7",
+      "cpe23": "None",
+      "name": "libsystemd0",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libsystemd0",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "241-7~deb10u7",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2019-20386",
-      "created_at": "2020-03-27T22:58:48Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2019-20386",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
-            "exploitability_score": 0.9,
-            "impact_score": 1.4,
-            "base_score": 2.4
-          },
-          "id": "CVE-2019-20386",
           "cvss_v2": {
             "exploitability_score": 3.9,
             "impact_score": 2.9,
             "base_score": 2.1
+          },
+          "id": "CVE-2019-20386",
+          "cvss_v3": {
+            "exploitability_score": 0.9,
+            "impact_score": 1.4,
+            "base_score": 2.4
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-05-12T09:09:42Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "241-7~deb10u7",
+      "cpe23": "None",
+      "name": "libsystemd0",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libsystemd0",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "241-7~deb10u7",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2020-13776",
-      "created_at": "2020-06-04T09:09:58Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2020-13776",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
-            "exploitability_score": 0.8,
-            "impact_score": 5.9,
-            "base_score": 6.7
-          },
-          "id": "CVE-2020-13776",
           "cvss_v2": {
             "exploitability_score": 1.9,
             "impact_score": 10.0,
             "base_score": 6.2
+          },
+          "id": "CVE-2020-13776",
+          "cvss_v3": {
+            "exploitability_score": 0.8,
+            "impact_score": 5.9,
+            "base_score": 6.7
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-06-21T09:10:36Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "241-7~deb10u7",
+      "cpe23": "None",
+      "name": "libsystemd0",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libtasn1-6",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "4.13-3",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2018-1000654",
-      "created_at": "2020-03-27T22:57:42Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2018-1000654",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2018-1000654",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2018-1000654",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
-            "exploitability_score": 1.8,
-            "impact_score": 3.6,
-            "base_score": 5.5
-          },
-          "id": "CVE-2018-1000654",
           "cvss_v2": {
             "exploitability_score": 8.6,
             "impact_score": 6.9,
             "base_score": 7.1
+          },
+          "id": "CVE-2018-1000654",
+          "cvss_v3": {
+            "exploitability_score": 1.8,
+            "impact_score": 3.6,
+            "base_score": 5.5
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:57:42Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "4.13-3",
+      "cpe23": "None",
+      "name": "libtasn1-6",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libudev1",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "241-7~deb10u6",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2013-4392",
-      "created_at": "2020-03-27T22:58:49Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2013-4392",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
-            "exploitability_score": -1.0,
-            "impact_score": -1.0,
-            "base_score": -1.0
-          },
-          "id": "CVE-2013-4392",
           "cvss_v2": {
             "exploitability_score": 3.4,
             "impact_score": 4.9,
             "base_score": 3.3
+          },
+          "id": "CVE-2013-4392",
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:58:49Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "241-7~deb10u6",
+      "cpe23": "None",
+      "name": "libudev1",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libudev1",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "241-7~deb10u6",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2019-20386",
-      "created_at": "2020-03-27T22:58:48Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2019-20386",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
-            "exploitability_score": 0.9,
-            "impact_score": 1.4,
-            "base_score": 2.4
-          },
-          "id": "CVE-2019-20386",
           "cvss_v2": {
             "exploitability_score": 3.9,
             "impact_score": 2.9,
             "base_score": 2.1
+          },
+          "id": "CVE-2019-20386",
+          "cvss_v3": {
+            "exploitability_score": 0.9,
+            "impact_score": 1.4,
+            "base_score": 2.4
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-05-12T09:09:42Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "241-7~deb10u6",
+      "cpe23": "None",
+      "name": "libudev1",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "libudev1",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "241-7~deb10u6",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2020-13776",
-      "created_at": "2020-06-04T09:09:58Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2020-13776",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
-            "exploitability_score": 0.8,
-            "impact_score": 5.9,
-            "base_score": 6.7
-          },
-          "id": "CVE-2020-13776",
           "cvss_v2": {
             "exploitability_score": 1.9,
             "impact_score": 10.0,
             "base_score": 6.2
+          },
+          "id": "CVE-2020-13776",
+          "cvss_v3": {
+            "exploitability_score": 0.8,
+            "impact_score": 5.9,
+            "base_score": 6.7
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-06-21T09:10:36Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "241-7~deb10u6",
+      "cpe23": "None",
+      "name": "libudev1",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "login",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "1:4.5-1.1",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2007-5686",
-      "created_at": "2020-03-27T22:57:11Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2007-5686",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2007-5686",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2007-5686",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
-            "exploitability_score": -1.0,
-            "impact_score": -1.0,
-            "base_score": -1.0
-          },
-          "id": "CVE-2007-5686",
           "cvss_v2": {
             "exploitability_score": 3.9,
             "impact_score": 6.9,
             "base_score": 4.9
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:57:11Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "login",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "1:4.5-1.1",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2013-4235",
-      "created_at": "2020-03-27T22:57:12Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4235",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 1.0,
-            "impact_score": 3.6,
-            "base_score": 4.7
           },
-          "id": "CVE-2013-4235",
-          "cvss_v2": {
-            "exploitability_score": 3.4,
-            "impact_score": 4.9,
-            "base_score": 3.3
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:57:12Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "login",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "1:4.5-1.1",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2019-19882",
-      "created_at": "2020-03-27T22:57:12Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-19882",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 1.8,
-            "impact_score": 5.9,
-            "base_score": 7.8
-          },
-          "id": "CVE-2019-19882",
-          "cvss_v2": {
-            "exploitability_score": 3.4,
-            "impact_score": 10.0,
-            "base_score": 6.9
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:57:12Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "openssl",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "1.1.1d-0+deb10u6",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2007-6755",
-      "created_at": "2020-03-27T22:56:38Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2007-6755",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
+          "id": "CVE-2007-5686",
           "cvss_v3": {
             "exploitability_score": -1.0,
             "impact_score": -1.0,
             "base_score": -1.0
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "1:4.5-1.1",
+      "cpe23": "None",
+      "name": "login",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4235",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2013-4235",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 3.4,
+            "impact_score": 4.9,
+            "base_score": 3.3
           },
-          "id": "CVE-2007-6755",
+          "id": "CVE-2013-4235",
+          "cvss_v3": {
+            "exploitability_score": 1.0,
+            "impact_score": 3.6,
+            "base_score": 4.7
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "1:4.5-1.1",
+      "cpe23": "None",
+      "name": "login",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-19882",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2019-19882",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 3.4,
+            "impact_score": 10.0,
+            "base_score": 6.9
+          },
+          "id": "CVE-2019-19882",
+          "cvss_v3": {
+            "exploitability_score": 1.8,
+            "impact_score": 5.9,
+            "base_score": 7.8
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "1:4.5-1.1",
+      "cpe23": "None",
+      "name": "login",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2007-6755",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2007-6755",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
           "cvss_v2": {
             "exploitability_score": 8.6,
             "impact_score": 4.9,
             "base_score": 5.8
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:56:38Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "openssl",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "1.1.1d-0+deb10u6",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2010-0928",
-      "created_at": "2020-03-27T22:56:38Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2010-0928",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
+          },
+          "id": "CVE-2007-6755",
           "cvss_v3": {
             "exploitability_score": -1.0,
             "impact_score": -1.0,
             "base_score": -1.0
-          },
-          "id": "CVE-2010-0928",
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "1.1.1d-0+deb10u6",
+      "cpe23": "None",
+      "name": "openssl",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-0928",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2010-0928",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
           "cvss_v2": {
             "exploitability_score": 1.9,
             "impact_score": 6.9,
             "base_score": 4.0
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:56:38Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "passwd",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "1:4.5-1.1",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2007-5686",
-      "created_at": "2020-03-27T22:57:11Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2007-5686",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
+          },
+          "id": "CVE-2010-0928",
           "cvss_v3": {
             "exploitability_score": -1.0,
             "impact_score": -1.0,
             "base_score": -1.0
-          },
-          "id": "CVE-2007-5686",
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "1.1.1d-0+deb10u6",
+      "cpe23": "None",
+      "name": "openssl",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2007-5686",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2007-5686",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
           "cvss_v2": {
             "exploitability_score": 3.9,
             "impact_score": 6.9,
             "base_score": 4.9
+          },
+          "id": "CVE-2007-5686",
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:57:11Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "1:4.5-1.1",
+      "cpe23": "None",
+      "name": "passwd",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "passwd",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "1:4.5-1.1",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2013-4235",
-      "created_at": "2020-03-27T22:57:12Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4235",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4235",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2013-4235",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
+          "cvss_v2": {
+            "exploitability_score": 3.4,
+            "impact_score": 4.9,
+            "base_score": 3.3
+          },
+          "id": "CVE-2013-4235",
           "cvss_v3": {
             "exploitability_score": 1.0,
             "impact_score": 3.6,
             "base_score": 4.7
-          },
-          "id": "CVE-2013-4235",
-          "cvss_v2": {
-            "exploitability_score": 3.4,
-            "impact_score": 4.9,
-            "base_score": 3.3
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:57:12Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "1:4.5-1.1",
+      "cpe23": "None",
+      "name": "passwd",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "passwd",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "1:4.5-1.1",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2019-19882",
-      "created_at": "2020-03-27T22:57:12Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-19882",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-19882",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2019-19882",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
-            "exploitability_score": 1.8,
-            "impact_score": 5.9,
-            "base_score": 7.8
-          },
-          "id": "CVE-2019-19882",
           "cvss_v2": {
             "exploitability_score": 3.4,
             "impact_score": 10.0,
             "base_score": 6.9
+          },
+          "id": "CVE-2019-19882",
+          "cvss_v3": {
+            "exploitability_score": 1.8,
+            "impact_score": 5.9,
+            "base_score": 7.8
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:57:12Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "1:4.5-1.1",
+      "cpe23": "None",
+      "name": "passwd",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2011-4116",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2011-4116",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          },
+          "id": "CVE-2011-4116",
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "base_score": 7.5
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
     "artifact": {
+      "cpe": "None",
+      "version": "5.28.1-6+deb10u1",
+      "cpe23": "None",
       "name": "perl",
-      "pkg_type": "dpkg",
       "pkg_path": "pkgdb",
-      "version": "5.28.1-6+deb10u1",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2011-4116",
-      "created_at": "2020-03-27T22:57:40Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2011-4116",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "base_score": 7.5
-          },
-          "id": "CVE-2011-4116",
-          "cvss_v2": {
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "base_score": 5.0
-          }
-        }
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:57:40Z",
-      "feed": "vulnerabilities"
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2011-4116",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2011-4116",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "base_score": 5.0
+          },
+          "id": "CVE-2011-4116",
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "base_score": 7.5
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
     "artifact": {
+      "cpe": "None",
+      "version": "5.28.1-6+deb10u1",
+      "cpe23": "None",
       "name": "perl-base",
-      "pkg_type": "dpkg",
       "pkg_path": "pkgdb",
-      "version": "5.28.1-6+deb10u1",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2011-4116",
-      "created_at": "2020-03-27T22:57:40Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2011-4116",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "base_score": 7.5
-          },
-          "id": "CVE-2011-4116",
-          "cvss_v2": {
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "base_score": 5.0
-          }
-        }
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:57:40Z",
-      "feed": "vulnerabilities"
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "python",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.7.16-1",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2008-4108",
-      "created_at": "2020-03-27T22:57:42Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2008-4108",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2008-4108",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2008-4108",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
-            "exploitability_score": -1.0,
-            "impact_score": -1.0,
-            "base_score": -1.0
-          },
-          "id": "CVE-2008-4108",
           "cvss_v2": {
             "exploitability_score": 3.9,
             "impact_score": 10.0,
             "base_score": 7.2
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:57:42Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "python2.7-minimal",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.7.16-2+deb10u1",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2013-7040",
-      "created_at": "2020-03-27T23:00:31Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-7040",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
+          },
+          "id": "CVE-2008-4108",
           "cvss_v3": {
             "exploitability_score": -1.0,
             "impact_score": -1.0,
             "base_score": -1.0
-          },
-          "id": "CVE-2013-7040",
-          "cvss_v2": {
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "base_score": 4.3
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T23:00:31Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.7.16-1",
+      "cpe23": "None",
+      "name": "python",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "python2.7-minimal",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.7.16-2+deb10u1",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2017-17522",
-      "created_at": "2020-03-27T22:58:28Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-7040",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2013-7040",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
-            "exploitability_score": 2.8,
-            "impact_score": 5.9,
-            "base_score": 8.8
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "base_score": 4.3
           },
-          "id": "CVE-2017-17522",
+          "id": "CVE-2013-7040",
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.7.16-2+deb10u1",
+      "cpe23": "None",
+      "name": "python2.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2017-17522",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
           "cvss_v2": {
             "exploitability_score": 8.6,
             "impact_score": 6.4,
             "base_score": 6.8
+          },
+          "id": "CVE-2017-17522",
+          "cvss_v3": {
+            "exploitability_score": 2.8,
+            "impact_score": 5.9,
+            "base_score": 8.8
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:58:28Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.7.16-2+deb10u1",
+      "cpe23": "None",
+      "name": "python2.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "python2.7-minimal",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.7.16-2+deb10u1",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2019-18348",
-      "created_at": "2020-03-27T22:58:28Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2019-18348",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
-            "exploitability_score": 2.8,
-            "impact_score": 2.7,
-            "base_score": 6.1
-          },
-          "id": "CVE-2019-18348",
           "cvss_v2": {
             "exploitability_score": 8.6,
             "impact_score": 2.9,
             "base_score": 4.3
+          },
+          "id": "CVE-2019-18348",
+          "cvss_v3": {
+            "exploitability_score": 2.8,
+            "impact_score": 2.7,
+            "base_score": 6.1
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:58:28Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.7.16-2+deb10u1",
+      "cpe23": "None",
+      "name": "python2.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "python2.7-minimal",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.7.16-2+deb10u1",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2019-9674",
-      "created_at": "2020-03-27T22:58:28Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2019-9674",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "base_score": 7.5
-          },
-          "id": "CVE-2019-9674",
           "cvss_v2": {
             "exploitability_score": 10.0,
             "impact_score": 2.9,
             "base_score": 5.0
+          },
+          "id": "CVE-2019-9674",
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "base_score": 7.5
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:58:28Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.7.16-2+deb10u1",
+      "cpe23": "None",
+      "name": "python2.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "python2.7-minimal",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "2.7.16-2+deb10u1",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2021-23336",
-      "created_at": "2021-03-31T17:06:44Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2021-23336",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2021-23336",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2021-23336",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
-            "exploitability_score": 1.6,
-            "impact_score": 4.2,
-            "base_score": 5.9
-          },
-          "id": "CVE-2021-23336",
           "cvss_v2": {
             "exploitability_score": 4.9,
             "impact_score": 4.9,
             "base_score": 4.0
+          },
+          "id": "CVE-2021-23336",
+          "cvss_v3": {
+            "exploitability_score": 1.6,
+            "impact_score": 4.2,
+            "base_score": 5.9
           }
         }
       ],
-      "description": "NA",
-      "severity": "Medium",
-      "last_modified": "2021-03-31T17:06:44Z",
-      "feed": "vulnerabilities"
+      "severity": "Medium"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "2.7.16-2+deb10u1",
+      "cpe23": "None",
+      "name": "python2.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "python3.7-minimal",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "3.7.3-2+deb10u3",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2017-17522",
-      "created_at": "2020-03-27T22:58:28Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2017-17522",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
-            "exploitability_score": 2.8,
-            "impact_score": 5.9,
-            "base_score": 8.8
-          },
-          "id": "CVE-2017-17522",
           "cvss_v2": {
             "exploitability_score": 8.6,
             "impact_score": 6.4,
             "base_score": 6.8
+          },
+          "id": "CVE-2017-17522",
+          "cvss_v3": {
+            "exploitability_score": 2.8,
+            "impact_score": 5.9,
+            "base_score": 8.8
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:58:28Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "3.7.3-2+deb10u3",
+      "cpe23": "None",
+      "name": "python3.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "python3.7-minimal",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "3.7.3-2+deb10u3",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2019-18348",
-      "created_at": "2020-03-27T22:58:28Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2019-18348",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
-            "exploitability_score": 2.8,
-            "impact_score": 2.7,
-            "base_score": 6.1
-          },
-          "id": "CVE-2019-18348",
           "cvss_v2": {
             "exploitability_score": 8.6,
             "impact_score": 2.9,
             "base_score": 4.3
+          },
+          "id": "CVE-2019-18348",
+          "cvss_v3": {
+            "exploitability_score": 2.8,
+            "impact_score": 2.7,
+            "base_score": 6.1
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:58:28Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "3.7.3-2+deb10u3",
+      "cpe23": "None",
+      "name": "python3.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "python3.7-minimal",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "3.7.3-2+deb10u3",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2019-9674",
-      "created_at": "2020-03-27T22:58:28Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2019-9674",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "base_score": 7.5
-          },
-          "id": "CVE-2019-9674",
           "cvss_v2": {
             "exploitability_score": 10.0,
             "impact_score": 2.9,
             "base_score": 5.0
+          },
+          "id": "CVE-2019-9674",
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "base_score": 7.5
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:58:28Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "3.7.3-2+deb10u3",
+      "cpe23": "None",
+      "name": "python3.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "python3.7-minimal",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "3.7.3-2+deb10u3",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2020-27619",
-      "created_at": "2020-10-23T09:09:58Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-27619",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-27619",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2020-27619",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
-            "exploitability_score": 3.9,
-            "impact_score": 5.9,
-            "base_score": 9.8
-          },
-          "id": "CVE-2020-27619",
           "cvss_v2": {
             "exploitability_score": 10.0,
             "impact_score": 6.4,
             "base_score": 7.5
+          },
+          "id": "CVE-2020-27619",
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 5.9,
+            "base_score": 9.8
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-11-04T09:11:01Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "3.7.3-2+deb10u3",
+      "cpe23": "None",
+      "name": "python3.7-minimal",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "systemd",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "241-7~deb10u7",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2013-4392",
-      "created_at": "2020-03-27T22:58:49Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2013-4392",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
-            "exploitability_score": -1.0,
-            "impact_score": -1.0,
-            "base_score": -1.0
-          },
-          "id": "CVE-2013-4392",
           "cvss_v2": {
             "exploitability_score": 3.4,
             "impact_score": 4.9,
             "base_score": 3.3
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:58:49Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "systemd",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "241-7~deb10u7",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2019-20386",
-      "created_at": "2020-03-27T22:58:48Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 0.9,
-            "impact_score": 1.4,
-            "base_score": 2.4
           },
-          "id": "CVE-2019-20386",
-          "cvss_v2": {
-            "exploitability_score": 3.9,
-            "impact_score": 2.9,
-            "base_score": 2.1
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-05-12T09:09:42Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "systemd",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "241-7~deb10u7",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2020-13776",
-      "created_at": "2020-06-04T09:09:58Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 0.8,
-            "impact_score": 5.9,
-            "base_score": 6.7
-          },
-          "id": "CVE-2020-13776",
-          "cvss_v2": {
-            "exploitability_score": 1.9,
-            "impact_score": 10.0,
-            "base_score": 6.2
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-06-21T09:10:36Z",
-      "feed": "vulnerabilities"
-    },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "tar",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "1.30+dfsg-6",
-      "cpe23": "None",
-      "cpe": "None"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2005-2541",
-      "created_at": "2020-03-27T23:00:35Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2005-2541",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
+          "id": "CVE-2013-4392",
           "cvss_v3": {
             "exploitability_score": -1.0,
             "impact_score": -1.0,
             "base_score": -1.0
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "241-7~deb10u7",
+      "cpe23": "None",
+      "name": "systemd",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2019-20386",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "base_score": 2.1
           },
-          "id": "CVE-2005-2541",
+          "id": "CVE-2019-20386",
+          "cvss_v3": {
+            "exploitability_score": 0.9,
+            "impact_score": 1.4,
+            "base_score": 2.4
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "241-7~deb10u7",
+      "cpe23": "None",
+      "name": "systemd",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2020-13776",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 1.9,
+            "impact_score": 10.0,
+            "base_score": 6.2
+          },
+          "id": "CVE-2020-13776",
+          "cvss_v3": {
+            "exploitability_score": 0.8,
+            "impact_score": 5.9,
+            "base_score": 6.7
+          }
+        }
+      ],
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "241-7~deb10u7",
+      "cpe23": "None",
+      "name": "systemd",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:08Z"
+    },
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2005-2541",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2005-2541",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
           "cvss_v2": {
             "exploitability_score": 10.0,
             "impact_score": 10.0,
             "base_score": 10.0
+          },
+          "id": "CVE-2005-2541",
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "impact_score": -1.0,
+            "base_score": -1.0
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T23:00:35Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "1.30+dfsg-6",
+      "cpe23": "None",
+      "name": "tar",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "tar",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "1.30+dfsg-6",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2019-9923",
-      "created_at": "2020-03-27T23:00:35Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9923",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9923",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2019-9923",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "base_score": 7.5
-          },
-          "id": "CVE-2019-9923",
           "cvss_v2": {
             "exploitability_score": 10.0,
             "impact_score": 2.9,
             "base_score": 5.0
+          },
+          "id": "CVE-2019-9923",
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "base_score": 7.5
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T23:00:35Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "1.30+dfsg-6",
+      "cpe23": "None",
+      "name": "tar",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "tar",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "1.30+dfsg-6",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2021-20193",
-      "created_at": "2021-01-20T09:16:47Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2021-20193",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2021-20193",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2021-20193",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
+          "cvss_v2": {
             "exploitability_score": -1.0,
             "impact_score": -1.0,
             "base_score": -1.0
           },
           "id": "CVE-2021-20193",
-          "cvss_v2": {
+          "cvss_v3": {
             "exploitability_score": -1.0,
             "impact_score": -1.0,
             "base_score": -1.0
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2021-01-21T09:16:38Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "1.30+dfsg-6",
+      "cpe23": "None",
+      "name": "tar",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "None"
+      ],
+      "observed_at": null
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "xdg-user-dirs",
-      "pkg_type": "dpkg",
-      "pkg_path": "pkgdb",
-      "version": "0.17-2",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "CVE-2017-15131",
-      "created_at": "2020-03-27T22:56:32Z",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-15131",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-15131",
+      "feed_group": "debian:10",
+      "vulnerability_id": "CVE-2017-15131",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
-            "exploitability_score": 1.8,
-            "impact_score": 5.9,
-            "base_score": 7.8
-          },
-          "id": "CVE-2017-15131",
           "cvss_v2": {
             "exploitability_score": 3.9,
             "impact_score": 6.4,
             "base_score": 4.6
+          },
+          "id": "CVE-2017-15131",
+          "cvss_v3": {
+            "exploitability_score": 1.8,
+            "impact_score": 5.9,
+            "base_score": 7.8
           }
         }
       ],
-      "description": "NA",
-      "severity": "Negligible",
-      "last_modified": "2020-03-27T22:56:32Z",
-      "feed": "vulnerabilities"
+      "severity": "Negligible"
+    },
+    "artifact": {
+      "cpe": "None",
+      "version": "0.17-2",
+      "cpe23": "None",
+      "name": "xdg-user-dirs",
+      "pkg_path": "pkgdb",
+      "pkg_type": "dpkg"
+    }
+  },
+  {
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [
+        "0.5.0"
+      ],
+      "observed_at": "2021-03-31T17:30:47Z"
     },
     "match": {
       "detected_at": "2021-05-04T07:31:08Z"
     },
-    "fixes": [
-      {
-        "observed_at": null,
-        "version": "None",
-        "wont_fix": false
-      }
-    ]
-  },
-  {
-    "artifact": {
-      "name": "xmldom",
-      "pkg_type": "npm",
-      "pkg_path": "/sandbox/node_modules/xmldom/package.json",
-      "version": "0.4.0",
-      "cpe23": "None",
-      "cpe": "None"
-    },
     "vulnerability": {
-      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv",
-      "created_at": "2021-03-31T17:30:47Z",
-      "feed_group": "github:npm",
-      "link": "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv",
       "cvss_scores_vendor": [],
+      "feed": "vulnerabilities",
+      "link": "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv",
+      "feed_group": "github:npm",
+      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv",
+      "description": "NA",
       "cvss_scores_nvd": [
         {
-          "cvss_v3": {
-            "exploitability_score": 2.8,
-            "impact_score": 1.4,
-            "base_score": 4.3
-          },
-          "id": "CVE-2021-21366",
           "cvss_v2": {
             "exploitability_score": 8.6,
             "impact_score": 2.9,
             "base_score": 4.3
+          },
+          "id": "CVE-2021-21366",
+          "cvss_v3": {
+            "exploitability_score": 2.8,
+            "impact_score": 1.4,
+            "base_score": 4.3
           }
         }
       ],
-      "description": "NA",
-      "severity": "Low",
-      "last_modified": "2021-03-31T17:30:47Z",
-      "feed": "vulnerabilities"
+      "severity": "Low"
     },
-    "match": {
-      "detected_at": "2021-05-04T07:31:08Z"
-    },
-    "fixes": [
-      {
-        "observed_at": "2021-03-31T17:30:47Z",
-        "version": "0.5.0",
-        "wont_fix": false
-      }
-    ]
+    "artifact": {
+      "cpe": "None",
+      "version": "0.4.0",
+      "cpe23": "None",
+      "name": "xmldom",
+      "pkg_path": "/sandbox/node_modules/xmldom/package.json",
+      "pkg_type": "npm"
+    }
   },
   {
-    "artifact": {
-      "name": "ftpd",
-      "pkg_type": "gem",
-      "pkg_path": "/var/lib/gems/2.5.0/specifications/ftpd-0.2.1.gemspec",
-      "version": "0.2.1",
-      "cpe23": "cpe:2.3:a:ftpd:ftpd:0.2.1:*:*:-:-:-:-:-",
-      "cpe": "cpe:a:ftpd:ftpd:0.2.1:*:*"
-    },
-    "vulnerability": {
-      "vulnerability_id": "CVE-2013-2512",
-      "created_at": "2021-03-31T17:11:12Z",
-      "feed_group": "nvdv2:cves",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
-      "cvss_scores_vendor": [],
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "exploitability_score": 3.9,
-            "impact_score": 5.9,
-            "base_score": 9.8
-          },
-          "id": "CVE-2013-2512",
-          "cvss_v2": {
-            "exploitability_score": 10.0,
-            "impact_score": 10.0,
-            "base_score": 10.0
-          }
-        }
-      ],
-      "description": "NA",
-      "severity": "Critical",
-      "last_modified": "2021-03-31T17:11:12Z",
-      "feed": "nvdv2"
+    "fix": {
+      "advisories": [],
+      "wont_fix": false,
+      "versions": [],
+      "observed_at": "2021-05-25T23:03:19Z"
     },
     "match": {
       "detected_at": "2021-03-31T17:11:12Z"
     },
-    "fixes": []
+    "vulnerability": {
+      "cvss_scores_vendor": [],
+      "feed": "nvdv2",
+      "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
+      "feed_group": "nvdv2:cves",
+      "vulnerability_id": "CVE-2013-2512",
+      "description": "NA",
+      "cvss_scores_nvd": [
+        {
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "impact_score": 10.0,
+            "base_score": 10.0
+          },
+          "id": "CVE-2013-2512",
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "impact_score": 5.9,
+            "base_score": 9.8
+          }
+        }
+      ],
+      "severity": "Critical"
+    },
+    "artifact": {
+      "cpe": "cpe:a:ftpd:ftpd:0.2.1:*:*",
+      "version": "0.2.1",
+      "cpe23": "cpe:2.3:a:ftpd:ftpd:0.2.1:*:*:-:-:-:-:-",
+      "name": "ftpd",
+      "pkg_path": "/var/lib/gems/2.5.0/specifications/ftpd-0.2.1.gemspec",
+      "pkg_type": "gem"
+    }
   }
 ]

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:80a31c3ce2e99c3691c27ac3b1753163214494e9b2ca07bfdccf29a5cca2bfbe.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:80a31c3ce2e99c3691c27ac3b1753163214494e9b2ca07bfdccf29a5cca2bfbe.json
@@ -1,318 +1,315 @@
 [
   {
-    "match": {
-      "detected_at": "2021-05-04T07:31:01Z"
+    "fix": {
+      "wont_fix": false,
+      "advisories": [],
+      "versions": [
+        "3.7.4"
+      ],
+      "observed_at": "2021-03-31T17:30:49Z"
     },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": "2021-03-31T17:30:49Z",
-        "version": "3.7.4"
-      }
-    ],
     "artifact": {
+      "version": "3.7.3",
+      "name": "aiohttp",
       "cpe": "None",
       "cpe23": "None",
-      "name": "aiohttp",
       "pkg_path": "/usr/lib/python3.8/site-packages/aiohttp",
-      "pkg_type": "python",
-      "version": "3.7.3"
+      "pkg_type": "python"
     },
     "vulnerability": {
-      "feed_group": "github:python",
-      "severity": "Low",
-      "created_at": "2021-03-31T17:30:49Z",
+      "feed": "vulnerabilities",
       "vulnerability_id": "GHSA-v6wp-4m6f-gcjg",
+      "severity": "Low",
       "description": "NA",
-      "cvss_scores_vendor": [],
-      "link": "https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
-      "last_modified": "2021-03-31T17:30:49Z",
       "cvss_scores_nvd": [
         {
           "id": "CVE-2021-21330",
-          "cvss_v2": {
-            "exploitability_score": 8.6,
-            "impact_score": 4.9,
-            "base_score": 5.8
-          },
           "cvss_v3": {
-            "exploitability_score": 2.8,
             "impact_score": 2.7,
+            "exploitability_score": 2.8,
             "base_score": 6.1
+          },
+          "cvss_v2": {
+            "impact_score": 4.9,
+            "exploitability_score": 8.6,
+            "base_score": 5.8
           }
         }
       ],
-      "feed": "vulnerabilities"
+      "link": "https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
+      "feed_group": "github:python",
+      "cvss_scores_vendor": []
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:01Z"
     }
   },
   {
-    "match": {
-      "detected_at": "2021-05-04T07:31:01Z"
+    "fix": {
+      "wont_fix": false,
+      "advisories": [],
+      "versions": [
+        "30.0-jre"
+      ],
+      "observed_at": "2021-03-31T17:30:52Z"
     },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": "2021-03-31T17:30:52Z",
-        "version": "30.0-jre"
-      }
-    ],
     "artifact": {
+      "version": "23.0",
+      "name": "guava",
       "cpe": "None",
       "cpe23": "None",
-      "name": "guava",
       "pkg_path": "/sandbox/target/my-app-1.jar:guava",
-      "pkg_type": "java",
-      "version": "23.0"
+      "pkg_type": "java"
     },
     "vulnerability": {
-      "feed_group": "github:java",
-      "severity": "Medium",
-      "created_at": "2021-03-31T17:30:52Z",
+      "feed": "vulnerabilities",
       "vulnerability_id": "GHSA-5mg8-w23w-74h3",
+      "severity": "Medium",
       "description": "NA",
-      "cvss_scores_vendor": [],
-      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
-      "last_modified": "2021-03-31T17:30:52Z",
       "cvss_scores_nvd": [
         {
           "id": "CVE-2020-8908",
-          "cvss_v2": {
-            "exploitability_score": 3.9,
-            "impact_score": 2.9,
-            "base_score": 2.1
-          },
           "cvss_v3": {
-            "exploitability_score": 1.8,
             "impact_score": 1.4,
+            "exploitability_score": 1.8,
             "base_score": 3.3
+          },
+          "cvss_v2": {
+            "impact_score": 2.9,
+            "exploitability_score": 3.9,
+            "base_score": 2.1
           }
         }
       ],
-      "feed": "vulnerabilities"
+      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
+      "feed_group": "github:java",
+      "cvss_scores_vendor": []
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:01Z"
     }
   },
   {
-    "match": {
-      "detected_at": "2021-05-04T07:31:01Z"
+    "fix": {
+      "wont_fix": false,
+      "advisories": [],
+      "versions": [
+        "24.1.1-jre"
+      ],
+      "observed_at": "2020-06-16T09:10:15Z"
     },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": "2020-06-16T09:10:15Z",
-        "version": "24.1.1-jre"
-      }
-    ],
     "artifact": {
+      "version": "23.0",
+      "name": "guava",
       "cpe": "None",
       "cpe23": "None",
-      "name": "guava",
       "pkg_path": "/sandbox/target/my-app-1.jar:guava",
-      "pkg_type": "java",
-      "version": "23.0"
+      "pkg_type": "java"
     },
     "vulnerability": {
-      "feed_group": "github:java",
-      "severity": "Medium",
-      "created_at": "2020-06-16T09:10:15Z",
+      "feed": "vulnerabilities",
       "vulnerability_id": "GHSA-mvr2-9pj6-7w5j",
+      "severity": "Medium",
       "description": "NA",
-      "cvss_scores_vendor": [],
-      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
-      "last_modified": "2020-06-16T09:10:15Z",
       "cvss_scores_nvd": [
         {
           "id": "CVE-2018-10237",
-          "cvss_v2": {
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "base_score": 4.3
-          },
           "cvss_v3": {
-            "exploitability_score": 2.2,
             "impact_score": 3.6,
+            "exploitability_score": 2.2,
             "base_score": 5.9
+          },
+          "cvss_v2": {
+            "impact_score": 2.9,
+            "exploitability_score": 8.6,
+            "base_score": 4.3
           }
         }
       ],
-      "feed": "vulnerabilities"
+      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
+      "feed_group": "github:java",
+      "cvss_scores_vendor": []
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:01Z"
     }
   },
   {
-    "match": {
-      "detected_at": "2021-05-04T07:31:01Z"
+    "fix": {
+      "wont_fix": false,
+      "advisories": [],
+      "versions": [
+        "30.0-jre"
+      ],
+      "observed_at": "2021-03-31T17:30:52Z"
     },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": "2021-03-31T17:30:52Z",
-        "version": "30.0-jre"
-      }
-    ],
     "artifact": {
+      "version": "23.0",
+      "name": "guava",
       "cpe": "None",
       "cpe23": "None",
-      "name": "guava",
       "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
-      "pkg_type": "java",
-      "version": "23.0"
+      "pkg_type": "java"
     },
     "vulnerability": {
-      "feed_group": "github:java",
-      "severity": "Medium",
-      "created_at": "2021-03-31T17:30:52Z",
+      "feed": "vulnerabilities",
       "vulnerability_id": "GHSA-5mg8-w23w-74h3",
+      "severity": "Medium",
       "description": "NA",
-      "cvss_scores_vendor": [],
-      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
-      "last_modified": "2021-03-31T17:30:52Z",
       "cvss_scores_nvd": [
         {
           "id": "CVE-2020-8908",
-          "cvss_v2": {
-            "exploitability_score": 3.9,
-            "impact_score": 2.9,
-            "base_score": 2.1
-          },
           "cvss_v3": {
-            "exploitability_score": 1.8,
             "impact_score": 1.4,
+            "exploitability_score": 1.8,
             "base_score": 3.3
+          },
+          "cvss_v2": {
+            "impact_score": 2.9,
+            "exploitability_score": 3.9,
+            "base_score": 2.1
           }
         }
       ],
-      "feed": "vulnerabilities"
+      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
+      "feed_group": "github:java",
+      "cvss_scores_vendor": []
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:01Z"
     }
   },
   {
-    "match": {
-      "detected_at": "2021-05-04T07:31:01Z"
+    "fix": {
+      "wont_fix": false,
+      "advisories": [],
+      "versions": [
+        "24.1.1-jre"
+      ],
+      "observed_at": "2020-06-16T09:10:15Z"
     },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": "2020-06-16T09:10:15Z",
-        "version": "24.1.1-jre"
-      }
-    ],
     "artifact": {
+      "version": "23.0",
+      "name": "guava",
       "cpe": "None",
       "cpe23": "None",
-      "name": "guava",
       "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
-      "pkg_type": "java",
-      "version": "23.0"
+      "pkg_type": "java"
     },
     "vulnerability": {
-      "feed_group": "github:java",
-      "severity": "Medium",
-      "created_at": "2020-06-16T09:10:15Z",
+      "feed": "vulnerabilities",
       "vulnerability_id": "GHSA-mvr2-9pj6-7w5j",
+      "severity": "Medium",
       "description": "NA",
-      "cvss_scores_vendor": [],
-      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
-      "last_modified": "2020-06-16T09:10:15Z",
       "cvss_scores_nvd": [
         {
           "id": "CVE-2018-10237",
-          "cvss_v2": {
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "base_score": 4.3
-          },
           "cvss_v3": {
-            "exploitability_score": 2.2,
             "impact_score": 3.6,
+            "exploitability_score": 2.2,
             "base_score": 5.9
+          },
+          "cvss_v2": {
+            "impact_score": 2.9,
+            "exploitability_score": 8.6,
+            "base_score": 4.3
           }
         }
       ],
-      "feed": "vulnerabilities"
+      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
+      "feed_group": "github:java",
+      "cvss_scores_vendor": []
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:01Z"
     }
   },
   {
-    "match": {
-      "detected_at": "2021-05-04T07:31:01Z"
+    "fix": {
+      "wont_fix": false,
+      "advisories": [],
+      "versions": [
+        "0.5.0"
+      ],
+      "observed_at": "2021-03-31T17:30:47Z"
     },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": "2021-03-31T17:30:47Z",
-        "version": "0.5.0"
-      }
-    ],
     "artifact": {
-      "cpe": "None",
-      "cpe23": "None",
+      "version": "0.4.0",
       "name": "xmldom",
+      "cpe": "None",
+      "cpe23": "None",
       "pkg_path": "/sandbox/node_modules/xmldom/package.json",
-      "pkg_type": "npm",
-      "version": "0.4.0"
+      "pkg_type": "npm"
     },
     "vulnerability": {
-      "feed_group": "github:npm",
-      "severity": "Low",
-      "created_at": "2021-03-31T17:30:47Z",
+      "feed": "vulnerabilities",
       "vulnerability_id": "GHSA-h6q6-9hqw-rwfv",
+      "severity": "Low",
       "description": "NA",
-      "cvss_scores_vendor": [],
-      "link": "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv",
-      "last_modified": "2021-03-31T17:30:47Z",
       "cvss_scores_nvd": [
         {
           "id": "CVE-2021-21366",
-          "cvss_v2": {
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
+          "cvss_v3": {
+            "impact_score": 1.4,
+            "exploitability_score": 2.8,
             "base_score": 4.3
           },
-          "cvss_v3": {
-            "exploitability_score": 2.8,
-            "impact_score": 1.4,
+          "cvss_v2": {
+            "impact_score": 2.9,
+            "exploitability_score": 8.6,
             "base_score": 4.3
           }
         }
       ],
-      "feed": "vulnerabilities"
+      "link": "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv",
+      "feed_group": "github:npm",
+      "cvss_scores_vendor": []
+    },
+    "match": {
+      "detected_at": "2021-05-04T07:31:01Z"
     }
   },
   {
-    "match": {
-      "detected_at": "2021-03-31T17:11:12Z"
+    "fix": {
+      "wont_fix": false,
+      "advisories": [],
+      "versions": [],
+      "observed_at": "2021-05-25T23:02:38Z"
     },
-    "fixes": [],
     "artifact": {
+      "version": "0.2.1",
+      "name": "ftpd",
       "cpe": "cpe:a:ftpd:ftpd:0.2.1:*:*",
       "cpe23": "cpe:2.3:a:ftpd:ftpd:0.2.1:*:*:-:-:-:-:-",
-      "name": "ftpd",
       "pkg_path": "/usr/lib/ruby/gems/2.7.0/specifications/ftpd-0.2.1.gemspec",
-      "pkg_type": "gem",
-      "version": "0.2.1"
+      "pkg_type": "gem"
     },
     "vulnerability": {
-      "feed_group": "nvdv2:cves",
-      "severity": "Critical",
-      "created_at": "2021-03-31T17:11:12Z",
+      "feed": "nvdv2",
       "vulnerability_id": "CVE-2013-2512",
+      "severity": "Critical",
       "description": "NA",
-      "cvss_scores_vendor": [],
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
-      "last_modified": "2021-03-31T17:11:12Z",
       "cvss_scores_nvd": [
         {
           "id": "CVE-2013-2512",
-          "cvss_v2": {
-            "exploitability_score": 10.0,
-            "impact_score": 10.0,
-            "base_score": 10.0
-          },
           "cvss_v3": {
-            "exploitability_score": 3.9,
             "impact_score": 5.9,
+            "exploitability_score": 3.9,
             "base_score": 9.8
+          },
+          "cvss_v2": {
+            "impact_score": 10.0,
+            "exploitability_score": 10.0,
+            "base_score": 10.0
           }
         }
       ],
-      "feed": "nvdv2"
+      "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
+      "feed_group": "nvdv2:cves",
+      "cvss_scores_vendor": []
+    },
+    "match": {
+      "detected_at": "2021-03-31T17:11:12Z"
     }
   }
 ]

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:fe3ca35038008b0eac0fa4e686bd072c9430000ab7d7853001bde5f5b8ccf60c.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:fe3ca35038008b0eac0fa4e686bd072c9430000ab7d7853001bde5f5b8ccf60c.json
@@ -1,1419 +1,1392 @@
 [
   {
+    "fix": {
+      "versions": [
+        "3.7.4"
+      ],
+      "wont_fix": false,
+      "observed_at": "2021-03-31T17:30:49Z",
+      "advisories": []
+    },
     "artifact": {
-      "name": "aiohttp",
+      "pkg_type": "python",
       "pkg_path": "/usr/local/lib64/python3.6/site-packages/aiohttp",
       "version": "3.7.3",
-      "cpe23": "None",
-      "pkg_type": "python",
-      "cpe": "None"
+      "cpe": "None",
+      "name": "aiohttp",
+      "cpe23": "None"
     },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": "2021-03-31T17:30:49Z",
-        "version": "3.7.4"
-      }
-    ],
     "vulnerability": {
+      "cvss_scores_nvd": [
+        {
+          "id": "CVE-2021-21330",
+          "cvss_v3": {
+            "exploitability_score": 2.8,
+            "base_score": 6.1,
+            "impact_score": 2.7
+          },
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "base_score": 5.8,
+            "impact_score": 4.9
+          }
+        }
+      ],
       "cvss_scores_vendor": [],
       "severity": "Low",
       "description": "NA",
-      "vulnerability_id": "GHSA-v6wp-4m6f-gcjg",
-      "last_modified": "2021-03-31T17:30:49Z",
       "feed": "vulnerabilities",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "impact_score": 2.7,
-            "base_score": 6.1,
-            "exploitability_score": 2.8
-          },
-          "cvss_v2": {
-            "impact_score": 4.9,
-            "base_score": 5.8,
-            "exploitability_score": 8.6
-          },
-          "id": "CVE-2021-21330"
-        }
-      ],
-      "created_at": "2021-03-31T17:30:49Z",
+      "feed_group": "github:python",
       "link": "https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
-      "feed_group": "github:python"
+      "vulnerability_id": "GHSA-v6wp-4m6f-gcjg"
     },
     "match": {
       "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
+    "fix": {
+      "versions": [
+        "None"
+      ],
+      "wont_fix": false,
+      "observed_at": null,
+      "advisories": []
+    },
     "artifact": {
-      "name": "binutils",
+      "pkg_type": "rpm",
       "pkg_path": "pkgdb",
       "version": "2.27-44.base.el7",
-      "cpe23": "None",
-      "pkg_type": "rpm",
-      "cpe": "None"
+      "cpe": "None",
+      "name": "binutils",
+      "cpe23": "None"
     },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": null,
-        "version": "None"
-      }
-    ],
     "vulnerability": {
+      "cvss_scores_nvd": [
+        {
+          "id": "CVE-2019-17450",
+          "cvss_v3": {
+            "exploitability_score": 2.8,
+            "base_score": 6.5,
+            "impact_score": 3.6
+          },
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "base_score": 4.3,
+            "impact_score": 2.9
+          }
+        }
+      ],
       "cvss_scores_vendor": [],
       "severity": "Low",
       "description": "NA",
-      "vulnerability_id": "CVE-2019-17450",
-      "last_modified": "2020-03-27T23:41:54Z",
       "feed": "vulnerabilities",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "impact_score": 3.6,
-            "base_score": 6.5,
-            "exploitability_score": 2.8
-          },
-          "cvss_v2": {
-            "impact_score": 2.9,
-            "base_score": 4.3,
-            "exploitability_score": 8.6
-          },
-          "id": "CVE-2019-17450"
-        }
-      ],
-      "created_at": "2020-03-27T23:41:54Z",
+      "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2019-17450",
-      "feed_group": "rhel:7"
+      "vulnerability_id": "CVE-2019-17450"
     },
     "match": {
       "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
+    "fix": {
+      "versions": [
+        "0:7.29.0-59.el7_9.1"
+      ],
+      "wont_fix": false,
+      "observed_at": "2020-11-11T09:10:27Z",
+      "advisories": []
+    },
     "artifact": {
-      "name": "curl",
+      "pkg_type": "rpm",
       "pkg_path": "pkgdb",
       "version": "7.29.0-59.el7",
-      "cpe23": "None",
-      "pkg_type": "rpm",
-      "cpe": "None"
+      "cpe": "None",
+      "name": "curl",
+      "cpe23": "None"
     },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": "2020-11-11T09:10:27Z",
-        "version": "0:7.29.0-59.el7_9.1"
-      }
-    ],
     "vulnerability": {
-      "cvss_scores_vendor": [],
-      "severity": "Medium",
-      "description": "NA",
-      "vulnerability_id": "CVE-2020-8177",
-      "last_modified": "2020-08-04T09:10:43Z",
-      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
+          "id": "CVE-2020-8177",
           "cvss_v3": {
-            "impact_score": 5.2,
+            "exploitability_score": 1.8,
             "base_score": 7.1,
-            "exploitability_score": 1.8
+            "impact_score": 5.2
           },
           "cvss_v2": {
-            "impact_score": 6.4,
+            "exploitability_score": 3.9,
             "base_score": 4.6,
-            "exploitability_score": 3.9
-          },
-          "id": "CVE-2020-8177"
+            "impact_score": 6.4
+          }
         }
       ],
-      "created_at": "2020-06-27T09:10:53Z",
+      "cvss_scores_vendor": [],
+      "severity": "Medium",
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2020-8177",
-      "feed_group": "rhel:7"
+      "vulnerability_id": "CVE-2020-8177"
     },
     "match": {
       "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
+    "fix": {
+      "versions": [
+        "None"
+      ],
+      "wont_fix": false,
+      "observed_at": null,
+      "advisories": []
+    },
     "artifact": {
+      "pkg_type": "rpm",
+      "pkg_path": "pkgdb",
+      "version": "2.17-323.el7_9",
+      "cpe": "None",
       "name": "glibc",
-      "pkg_path": "pkgdb",
-      "version": "2.17-323.el7_9",
-      "cpe23": "None",
-      "pkg_type": "rpm",
-      "cpe": "None"
+      "cpe23": "None"
     },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": null,
-        "version": "None"
-      }
-    ],
     "vulnerability": {
+      "cvss_scores_nvd": [
+        {
+          "id": "CVE-2014-4043",
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "base_score": -1.0,
+            "impact_score": -1.0
+          },
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "base_score": 7.5,
+            "impact_score": 6.4
+          }
+        }
+      ],
       "cvss_scores_vendor": [],
       "severity": "Low",
       "description": "NA",
-      "vulnerability_id": "CVE-2014-4043",
-      "last_modified": "2020-03-27T23:42:55Z",
       "feed": "vulnerabilities",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "impact_score": -1.0,
-            "base_score": -1.0,
-            "exploitability_score": -1.0
-          },
-          "cvss_v2": {
-            "impact_score": 6.4,
-            "base_score": 7.5,
-            "exploitability_score": 10.0
-          },
-          "id": "CVE-2014-4043"
-        }
-      ],
-      "created_at": "2020-03-27T23:42:55Z",
+      "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2014-4043",
-      "feed_group": "rhel:7"
+      "vulnerability_id": "CVE-2014-4043"
     },
     "match": {
       "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
+    "fix": {
+      "versions": [
+        "None"
+      ],
+      "wont_fix": false,
+      "observed_at": null,
+      "advisories": []
+    },
     "artifact": {
+      "pkg_type": "rpm",
+      "pkg_path": "pkgdb",
+      "version": "2.17-323.el7_9",
+      "cpe": "None",
       "name": "glibc-common",
-      "pkg_path": "pkgdb",
-      "version": "2.17-323.el7_9",
-      "cpe23": "None",
-      "pkg_type": "rpm",
-      "cpe": "None"
+      "cpe23": "None"
     },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": null,
-        "version": "None"
-      }
-    ],
     "vulnerability": {
-      "cvss_scores_vendor": [],
-      "severity": "Low",
-      "description": "NA",
-      "vulnerability_id": "CVE-2014-4043",
-      "last_modified": "2020-03-27T23:42:55Z",
-      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
+          "id": "CVE-2014-4043",
           "cvss_v3": {
-            "impact_score": -1.0,
+            "exploitability_score": -1.0,
             "base_score": -1.0,
-            "exploitability_score": -1.0
+            "impact_score": -1.0
           },
           "cvss_v2": {
-            "impact_score": 6.4,
+            "exploitability_score": 10.0,
             "base_score": 7.5,
-            "exploitability_score": 10.0
-          },
-          "id": "CVE-2014-4043"
+            "impact_score": 6.4
+          }
         }
       ],
-      "created_at": "2020-03-27T23:42:55Z",
-      "link": "https://access.redhat.com/security/cve/CVE-2014-4043",
-      "feed_group": "rhel:7"
-    },
-    "match": {
-      "detected_at": "2021-05-04T06:22:33Z"
-    }
-  },
-  {
-    "artifact": {
-      "name": "gnupg2",
-      "pkg_path": "pkgdb",
-      "version": "2.0.22-5.el7_5",
-      "cpe23": "None",
-      "pkg_type": "rpm",
-      "cpe": "None"
-    },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": null,
-        "version": "None"
-      }
-    ],
-    "vulnerability": {
       "cvss_scores_vendor": [],
       "severity": "Low",
       "description": "NA",
-      "vulnerability_id": "CVE-2014-3591",
-      "last_modified": "2020-03-27T23:42:51Z",
       "feed": "vulnerabilities",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "impact_score": 3.6,
-            "base_score": 4.2,
-            "exploitability_score": 0.5
-          },
-          "cvss_v2": {
-            "impact_score": 2.9,
-            "base_score": 1.9,
-            "exploitability_score": 3.4
-          },
-          "id": "CVE-2014-3591"
-        }
-      ],
-      "created_at": "2020-03-27T23:42:51Z",
-      "link": "https://access.redhat.com/security/cve/CVE-2014-3591",
-      "feed_group": "rhel:7"
+      "feed_group": "rhel:7",
+      "link": "https://access.redhat.com/security/cve/CVE-2014-4043",
+      "vulnerability_id": "CVE-2014-4043"
     },
     "match": {
       "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
+    "fix": {
+      "versions": [
+        "None"
+      ],
+      "wont_fix": false,
+      "observed_at": null,
+      "advisories": []
+    },
     "artifact": {
-      "name": "gnupg2",
+      "pkg_type": "rpm",
       "pkg_path": "pkgdb",
       "version": "2.0.22-5.el7_5",
-      "cpe23": "None",
+      "cpe": "None",
+      "name": "gnupg2",
+      "cpe23": "None"
+    },
+    "vulnerability": {
+      "cvss_scores_nvd": [
+        {
+          "id": "CVE-2014-3591",
+          "cvss_v3": {
+            "exploitability_score": 0.5,
+            "base_score": 4.2,
+            "impact_score": 3.6
+          },
+          "cvss_v2": {
+            "exploitability_score": 3.4,
+            "base_score": 1.9,
+            "impact_score": 2.9
+          }
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "severity": "Low",
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "link": "https://access.redhat.com/security/cve/CVE-2014-3591",
+      "vulnerability_id": "CVE-2014-3591"
+    },
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
+    }
+  },
+  {
+    "fix": {
+      "versions": [
+        "None"
+      ],
+      "wont_fix": false,
+      "observed_at": null,
+      "advisories": []
+    },
+    "artifact": {
       "pkg_type": "rpm",
-      "cpe": "None"
+      "pkg_path": "pkgdb",
+      "version": "2.0.22-5.el7_5",
+      "cpe": "None",
+      "name": "gnupg2",
+      "cpe23": "None"
     },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": null,
-        "version": "None"
-      }
-    ],
     "vulnerability": {
-      "cvss_scores_vendor": [],
-      "severity": "Medium",
-      "description": "NA",
-      "vulnerability_id": "CVE-2014-4617",
-      "last_modified": "2020-03-27T23:42:00Z",
-      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
+          "id": "CVE-2014-4617",
           "cvss_v3": {
-            "impact_score": -1.0,
+            "exploitability_score": -1.0,
             "base_score": -1.0,
-            "exploitability_score": -1.0
+            "impact_score": -1.0
           },
           "cvss_v2": {
-            "impact_score": 2.9,
+            "exploitability_score": 10.0,
             "base_score": 5.0,
-            "exploitability_score": 10.0
-          },
-          "id": "CVE-2014-4617"
+            "impact_score": 2.9
+          }
         }
       ],
-      "created_at": "2020-03-27T23:42:00Z",
+      "cvss_scores_vendor": [],
+      "severity": "Medium",
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2014-4617",
-      "feed_group": "rhel:7"
+      "vulnerability_id": "CVE-2014-4617"
     },
     "match": {
       "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
+    "fix": {
+      "versions": [
+        "30.0-jre"
+      ],
+      "wont_fix": false,
+      "observed_at": "2021-03-31T17:30:52Z",
+      "advisories": []
+    },
     "artifact": {
-      "name": "guava",
+      "pkg_type": "java",
       "pkg_path": "/sandbox/target/my-app-1.jar:guava",
       "version": "23.0",
-      "cpe23": "None",
-      "pkg_type": "java",
-      "cpe": "None"
+      "cpe": "None",
+      "name": "guava",
+      "cpe23": "None"
     },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": "2021-03-31T17:30:52Z",
-        "version": "30.0-jre"
-      }
-    ],
     "vulnerability": {
+      "cvss_scores_nvd": [
+        {
+          "id": "CVE-2020-8908",
+          "cvss_v3": {
+            "exploitability_score": 1.8,
+            "base_score": 3.3,
+            "impact_score": 1.4
+          },
+          "cvss_v2": {
+            "exploitability_score": 3.9,
+            "base_score": 2.1,
+            "impact_score": 2.9
+          }
+        }
+      ],
       "cvss_scores_vendor": [],
       "severity": "Medium",
       "description": "NA",
-      "vulnerability_id": "GHSA-5mg8-w23w-74h3",
-      "last_modified": "2021-03-31T17:30:52Z",
       "feed": "vulnerabilities",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "impact_score": 1.4,
-            "base_score": 3.3,
-            "exploitability_score": 1.8
-          },
-          "cvss_v2": {
-            "impact_score": 2.9,
-            "base_score": 2.1,
-            "exploitability_score": 3.9
-          },
-          "id": "CVE-2020-8908"
-        }
-      ],
-      "created_at": "2021-03-31T17:30:52Z",
+      "feed_group": "github:java",
       "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
-      "feed_group": "github:java"
+      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
     },
     "match": {
       "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
+    "fix": {
+      "versions": [
+        "24.1.1-jre"
+      ],
+      "wont_fix": false,
+      "observed_at": "2020-06-16T09:10:15Z",
+      "advisories": []
+    },
     "artifact": {
-      "name": "guava",
+      "pkg_type": "java",
       "pkg_path": "/sandbox/target/my-app-1.jar:guava",
       "version": "23.0",
-      "cpe23": "None",
-      "pkg_type": "java",
-      "cpe": "None"
+      "cpe": "None",
+      "name": "guava",
+      "cpe23": "None"
     },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": "2020-06-16T09:10:15Z",
-        "version": "24.1.1-jre"
-      }
-    ],
     "vulnerability": {
+      "cvss_scores_nvd": [
+        {
+          "id": "CVE-2018-10237",
+          "cvss_v3": {
+            "exploitability_score": 2.2,
+            "base_score": 5.9,
+            "impact_score": 3.6
+          },
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "base_score": 4.3,
+            "impact_score": 2.9
+          }
+        }
+      ],
       "cvss_scores_vendor": [],
       "severity": "Medium",
       "description": "NA",
-      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j",
-      "last_modified": "2020-06-16T09:10:15Z",
       "feed": "vulnerabilities",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "impact_score": 3.6,
-            "base_score": 5.9,
-            "exploitability_score": 2.2
-          },
-          "cvss_v2": {
-            "impact_score": 2.9,
-            "base_score": 4.3,
-            "exploitability_score": 8.6
-          },
-          "id": "CVE-2018-10237"
-        }
-      ],
-      "created_at": "2020-06-16T09:10:15Z",
+      "feed_group": "github:java",
       "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
-      "feed_group": "github:java"
+      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
     },
     "match": {
       "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
+    "fix": {
+      "versions": [
+        "30.0-jre"
+      ],
+      "wont_fix": false,
+      "observed_at": "2021-03-31T17:30:52Z",
+      "advisories": []
+    },
     "artifact": {
-      "name": "guava",
+      "pkg_type": "java",
       "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
       "version": "23.0",
-      "cpe23": "None",
-      "pkg_type": "java",
-      "cpe": "None"
+      "cpe": "None",
+      "name": "guava",
+      "cpe23": "None"
     },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": "2021-03-31T17:30:52Z",
-        "version": "30.0-jre"
-      }
-    ],
     "vulnerability": {
-      "cvss_scores_vendor": [],
-      "severity": "Medium",
-      "description": "NA",
-      "vulnerability_id": "GHSA-5mg8-w23w-74h3",
-      "last_modified": "2021-03-31T17:30:52Z",
-      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
+          "id": "CVE-2020-8908",
           "cvss_v3": {
-            "impact_score": 1.4,
+            "exploitability_score": 1.8,
             "base_score": 3.3,
-            "exploitability_score": 1.8
+            "impact_score": 1.4
           },
           "cvss_v2": {
-            "impact_score": 2.9,
+            "exploitability_score": 3.9,
             "base_score": 2.1,
-            "exploitability_score": 3.9
-          },
-          "id": "CVE-2020-8908"
+            "impact_score": 2.9
+          }
         }
       ],
-      "created_at": "2021-03-31T17:30:52Z",
-      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
-      "feed_group": "github:java"
-    },
-    "match": {
-      "detected_at": "2021-05-04T06:22:33Z"
-    }
-  },
-  {
-    "artifact": {
-      "name": "guava",
-      "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
-      "version": "23.0",
-      "cpe23": "None",
-      "pkg_type": "java",
-      "cpe": "None"
-    },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": "2020-06-16T09:10:15Z",
-        "version": "24.1.1-jre"
-      }
-    ],
-    "vulnerability": {
       "cvss_scores_vendor": [],
       "severity": "Medium",
       "description": "NA",
-      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j",
-      "last_modified": "2020-06-16T09:10:15Z",
       "feed": "vulnerabilities",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "impact_score": 3.6,
-            "base_score": 5.9,
-            "exploitability_score": 2.2
-          },
-          "cvss_v2": {
-            "impact_score": 2.9,
-            "base_score": 4.3,
-            "exploitability_score": 8.6
-          },
-          "id": "CVE-2018-10237"
-        }
-      ],
-      "created_at": "2020-06-16T09:10:15Z",
-      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
-      "feed_group": "github:java"
+      "feed_group": "github:java",
+      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
+      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
     },
     "match": {
       "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
+    "fix": {
+      "versions": [
+        "24.1.1-jre"
+      ],
+      "wont_fix": false,
+      "observed_at": "2020-06-16T09:10:15Z",
+      "advisories": []
+    },
     "artifact": {
-      "name": "libcom_err",
+      "pkg_type": "java",
+      "pkg_path": "/sandbox/target/original-my-app-1.jar:guava",
+      "version": "23.0",
+      "cpe": "None",
+      "name": "guava",
+      "cpe23": "None"
+    },
+    "vulnerability": {
+      "cvss_scores_nvd": [
+        {
+          "id": "CVE-2018-10237",
+          "cvss_v3": {
+            "exploitability_score": 2.2,
+            "base_score": 5.9,
+            "impact_score": 3.6
+          },
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "base_score": 4.3,
+            "impact_score": 2.9
+          }
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "severity": "Medium",
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
+      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
+    },
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
+    }
+  },
+  {
+    "fix": {
+      "versions": [
+        "None"
+      ],
+      "wont_fix": false,
+      "observed_at": null,
+      "advisories": []
+    },
+    "artifact": {
+      "pkg_type": "rpm",
       "pkg_path": "pkgdb",
       "version": "1.42.9-19.el7",
-      "cpe23": "None",
-      "pkg_type": "rpm",
-      "cpe": "None"
+      "cpe": "None",
+      "name": "libcom_err",
+      "cpe23": "None"
     },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": null,
-        "version": "None"
-      }
-    ],
     "vulnerability": {
+      "cvss_scores_nvd": [
+        {
+          "id": "CVE-2015-0247",
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "base_score": -1.0,
+            "impact_score": -1.0
+          },
+          "cvss_v2": {
+            "exploitability_score": 3.9,
+            "base_score": 4.6,
+            "impact_score": 6.4
+          }
+        }
+      ],
       "cvss_scores_vendor": [],
       "severity": "Medium",
       "description": "NA",
-      "vulnerability_id": "CVE-2015-0247",
-      "last_modified": "2020-03-27T23:41:42Z",
       "feed": "vulnerabilities",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "impact_score": -1.0,
-            "base_score": -1.0,
-            "exploitability_score": -1.0
-          },
-          "cvss_v2": {
-            "impact_score": 6.4,
-            "base_score": 4.6,
-            "exploitability_score": 3.9
-          },
-          "id": "CVE-2015-0247"
-        }
-      ],
-      "created_at": "2020-03-27T23:41:42Z",
+      "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2015-0247",
-      "feed_group": "rhel:7"
+      "vulnerability_id": "CVE-2015-0247"
     },
     "match": {
       "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
+    "fix": {
+      "versions": [
+        "0:7.29.0-59.el7_9.1"
+      ],
+      "wont_fix": false,
+      "observed_at": "2020-11-11T09:10:27Z",
+      "advisories": []
+    },
     "artifact": {
-      "name": "libcurl",
+      "pkg_type": "rpm",
       "pkg_path": "pkgdb",
       "version": "7.29.0-59.el7",
-      "cpe23": "None",
-      "pkg_type": "rpm",
-      "cpe": "None"
+      "cpe": "None",
+      "name": "libcurl",
+      "cpe23": "None"
     },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": "2020-11-11T09:10:27Z",
-        "version": "0:7.29.0-59.el7_9.1"
-      }
-    ],
     "vulnerability": {
+      "cvss_scores_nvd": [
+        {
+          "id": "CVE-2020-8177",
+          "cvss_v3": {
+            "exploitability_score": 1.8,
+            "base_score": 7.1,
+            "impact_score": 5.2
+          },
+          "cvss_v2": {
+            "exploitability_score": 3.9,
+            "base_score": 4.6,
+            "impact_score": 6.4
+          }
+        }
+      ],
       "cvss_scores_vendor": [],
       "severity": "Medium",
       "description": "NA",
-      "vulnerability_id": "CVE-2020-8177",
-      "last_modified": "2020-08-04T09:10:43Z",
       "feed": "vulnerabilities",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "impact_score": 5.2,
-            "base_score": 7.1,
-            "exploitability_score": 1.8
-          },
-          "cvss_v2": {
-            "impact_score": 6.4,
-            "base_score": 4.6,
-            "exploitability_score": 3.9
-          },
-          "id": "CVE-2020-8177"
-        }
-      ],
-      "created_at": "2020-06-27T09:10:53Z",
+      "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2020-8177",
-      "feed_group": "rhel:7"
+      "vulnerability_id": "CVE-2020-8177"
     },
     "match": {
       "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
+    "fix": {
+      "versions": [
+        "None"
+      ],
+      "wont_fix": false,
+      "observed_at": null,
+      "advisories": []
+    },
     "artifact": {
-      "name": "libgcrypt",
+      "pkg_type": "rpm",
       "pkg_path": "pkgdb",
       "version": "1.5.3-14.el7",
-      "cpe23": "None",
-      "pkg_type": "rpm",
-      "cpe": "None"
+      "cpe": "None",
+      "name": "libgcrypt",
+      "cpe23": "None"
     },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": null,
-        "version": "None"
-      }
-    ],
     "vulnerability": {
+      "cvss_scores_nvd": [
+        {
+          "id": "CVE-2014-3591",
+          "cvss_v3": {
+            "exploitability_score": 0.5,
+            "base_score": 4.2,
+            "impact_score": 3.6
+          },
+          "cvss_v2": {
+            "exploitability_score": 3.4,
+            "base_score": 1.9,
+            "impact_score": 2.9
+          }
+        }
+      ],
       "cvss_scores_vendor": [],
       "severity": "Low",
       "description": "NA",
-      "vulnerability_id": "CVE-2014-3591",
-      "last_modified": "2020-03-27T23:42:51Z",
       "feed": "vulnerabilities",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "impact_score": 3.6,
-            "base_score": 4.2,
-            "exploitability_score": 0.5
-          },
-          "cvss_v2": {
-            "impact_score": 2.9,
-            "base_score": 1.9,
-            "exploitability_score": 3.4
-          },
-          "id": "CVE-2014-3591"
-        }
-      ],
-      "created_at": "2020-03-27T23:42:51Z",
+      "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2014-3591",
-      "feed_group": "rhel:7"
+      "vulnerability_id": "CVE-2014-3591"
     },
     "match": {
       "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
+    "fix": {
+      "versions": [
+        "None"
+      ],
+      "wont_fix": false,
+      "observed_at": null,
+      "advisories": []
+    },
     "artifact": {
-      "name": "libgcrypt",
+      "pkg_type": "rpm",
       "pkg_path": "pkgdb",
       "version": "1.5.3-14.el7",
-      "cpe23": "None",
-      "pkg_type": "rpm",
-      "cpe": "None"
+      "cpe": "None",
+      "name": "libgcrypt",
+      "cpe23": "None"
     },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": null,
-        "version": "None"
-      }
-    ],
     "vulnerability": {
+      "cvss_scores_nvd": [
+        {
+          "id": "CVE-2014-5270",
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "base_score": -1.0,
+            "impact_score": -1.0
+          },
+          "cvss_v2": {
+            "exploitability_score": 3.9,
+            "base_score": 2.1,
+            "impact_score": 2.9
+          }
+        }
+      ],
       "cvss_scores_vendor": [],
       "severity": "Medium",
       "description": "NA",
-      "vulnerability_id": "CVE-2014-5270",
-      "last_modified": "2020-03-27T23:43:09Z",
       "feed": "vulnerabilities",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "impact_score": -1.0,
-            "base_score": -1.0,
-            "exploitability_score": -1.0
-          },
-          "cvss_v2": {
-            "impact_score": 2.9,
-            "base_score": 2.1,
-            "exploitability_score": 3.9
-          },
-          "id": "CVE-2014-5270"
-        }
-      ],
-      "created_at": "2020-03-27T23:43:09Z",
+      "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2014-5270",
-      "feed_group": "rhel:7"
+      "vulnerability_id": "CVE-2014-5270"
     },
     "match": {
       "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
+    "fix": {
+      "versions": [
+        "None"
+      ],
+      "wont_fix": false,
+      "observed_at": null,
+      "advisories": []
+    },
     "artifact": {
-      "name": "libidn",
+      "pkg_type": "rpm",
       "pkg_path": "pkgdb",
       "version": "1.28-4.el7",
-      "cpe23": "None",
-      "pkg_type": "rpm",
-      "cpe": "None"
+      "cpe": "None",
+      "name": "libidn",
+      "cpe23": "None"
     },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": null,
-        "version": "None"
-      }
-    ],
     "vulnerability": {
+      "cvss_scores_nvd": [
+        {
+          "id": "CVE-2015-2059",
+          "cvss_v3": {
+            "exploitability_score": -1.0,
+            "base_score": -1.0,
+            "impact_score": -1.0
+          },
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "base_score": 7.5,
+            "impact_score": 6.4
+          }
+        }
+      ],
       "cvss_scores_vendor": [],
       "severity": "Low",
       "description": "NA",
-      "vulnerability_id": "CVE-2015-2059",
-      "last_modified": "2020-03-27T23:42:41Z",
       "feed": "vulnerabilities",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "impact_score": -1.0,
-            "base_score": -1.0,
-            "exploitability_score": -1.0
-          },
-          "cvss_v2": {
-            "impact_score": 6.4,
-            "base_score": 7.5,
-            "exploitability_score": 10.0
-          },
-          "id": "CVE-2015-2059"
-        }
-      ],
-      "created_at": "2020-03-27T23:42:41Z",
+      "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2015-2059",
-      "feed_group": "rhel:7"
+      "vulnerability_id": "CVE-2015-2059"
     },
     "match": {
       "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
+    "fix": {
+      "versions": [
+        "None"
+      ],
+      "wont_fix": false,
+      "observed_at": null,
+      "advisories": []
+    },
     "artifact": {
+      "pkg_type": "rpm",
+      "pkg_path": "pkgdb",
+      "version": "3.53.1-3.el7_9",
+      "cpe": "None",
       "name": "nss",
-      "pkg_path": "pkgdb",
-      "version": "3.53.1-3.el7_9",
-      "cpe23": "None",
-      "pkg_type": "rpm",
-      "cpe": "None"
+      "cpe23": "None"
     },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": null,
-        "version": "None"
-      }
-    ],
     "vulnerability": {
+      "cvss_scores_nvd": [
+        {
+          "id": "CVE-2020-12399",
+          "cvss_v3": {
+            "exploitability_score": 0.8,
+            "base_score": 4.4,
+            "impact_score": 3.6
+          },
+          "cvss_v2": {
+            "exploitability_score": 1.9,
+            "base_score": 1.2,
+            "impact_score": 2.9
+          }
+        }
+      ],
       "cvss_scores_vendor": [],
       "severity": "Medium",
       "description": "NA",
-      "vulnerability_id": "CVE-2020-12399",
-      "last_modified": "2020-05-21T09:09:26Z",
       "feed": "vulnerabilities",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "impact_score": 3.6,
-            "base_score": 4.4,
-            "exploitability_score": 0.8
-          },
-          "cvss_v2": {
-            "impact_score": 2.9,
-            "base_score": 1.2,
-            "exploitability_score": 1.9
-          },
-          "id": "CVE-2020-12399"
-        }
-      ],
-      "created_at": "2020-05-21T09:09:26Z",
+      "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2020-12399",
-      "feed_group": "rhel:7"
+      "vulnerability_id": "CVE-2020-12399"
     },
     "match": {
       "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
+    "fix": {
+      "versions": [
+        "None"
+      ],
+      "wont_fix": false,
+      "observed_at": null,
+      "advisories": []
+    },
     "artifact": {
+      "pkg_type": "rpm",
+      "pkg_path": "pkgdb",
+      "version": "3.53.1-3.el7_9",
+      "cpe": "None",
       "name": "nss",
-      "pkg_path": "pkgdb",
-      "version": "3.53.1-3.el7_9",
-      "cpe23": "None",
-      "pkg_type": "rpm",
-      "cpe": "None"
+      "cpe23": "None"
     },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": null,
-        "version": "None"
-      }
-    ],
     "vulnerability": {
+      "cvss_scores_nvd": [
+        {
+          "id": "CVE-2020-25648",
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "base_score": 7.5,
+            "impact_score": 3.6
+          },
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "base_score": 5.0,
+            "impact_score": 2.9
+          }
+        }
+      ],
       "cvss_scores_vendor": [],
       "severity": "Medium",
       "description": "NA",
-      "vulnerability_id": "CVE-2020-25648",
-      "last_modified": "2020-10-20T09:10:21Z",
       "feed": "vulnerabilities",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "impact_score": 3.6,
-            "base_score": 7.5,
-            "exploitability_score": 3.9
-          },
-          "cvss_v2": {
-            "impact_score": 2.9,
-            "base_score": 5.0,
-            "exploitability_score": 10.0
-          },
-          "id": "CVE-2020-25648"
-        }
-      ],
-      "created_at": "2020-10-20T09:10:21Z",
+      "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2020-25648",
-      "feed_group": "rhel:7"
+      "vulnerability_id": "CVE-2020-25648"
     },
     "match": {
       "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
+    "fix": {
+      "versions": [
+        "None"
+      ],
+      "wont_fix": false,
+      "observed_at": null,
+      "advisories": []
+    },
     "artifact": {
+      "pkg_type": "rpm",
+      "pkg_path": "pkgdb",
+      "version": "3.53.1-3.el7_9",
+      "cpe": "None",
       "name": "nss-sysinit",
-      "pkg_path": "pkgdb",
-      "version": "3.53.1-3.el7_9",
-      "cpe23": "None",
-      "pkg_type": "rpm",
-      "cpe": "None"
+      "cpe23": "None"
     },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": null,
-        "version": "None"
-      }
-    ],
     "vulnerability": {
+      "cvss_scores_nvd": [
+        {
+          "id": "CVE-2020-12399",
+          "cvss_v3": {
+            "exploitability_score": 0.8,
+            "base_score": 4.4,
+            "impact_score": 3.6
+          },
+          "cvss_v2": {
+            "exploitability_score": 1.9,
+            "base_score": 1.2,
+            "impact_score": 2.9
+          }
+        }
+      ],
       "cvss_scores_vendor": [],
       "severity": "Medium",
       "description": "NA",
-      "vulnerability_id": "CVE-2020-12399",
-      "last_modified": "2020-05-21T09:09:26Z",
       "feed": "vulnerabilities",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "impact_score": 3.6,
-            "base_score": 4.4,
-            "exploitability_score": 0.8
-          },
-          "cvss_v2": {
-            "impact_score": 2.9,
-            "base_score": 1.2,
-            "exploitability_score": 1.9
-          },
-          "id": "CVE-2020-12399"
-        }
-      ],
-      "created_at": "2020-05-21T09:09:26Z",
+      "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2020-12399",
-      "feed_group": "rhel:7"
+      "vulnerability_id": "CVE-2020-12399"
     },
     "match": {
       "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
+    "fix": {
+      "versions": [
+        "None"
+      ],
+      "wont_fix": false,
+      "observed_at": null,
+      "advisories": []
+    },
     "artifact": {
+      "pkg_type": "rpm",
+      "pkg_path": "pkgdb",
+      "version": "3.53.1-3.el7_9",
+      "cpe": "None",
       "name": "nss-sysinit",
-      "pkg_path": "pkgdb",
-      "version": "3.53.1-3.el7_9",
-      "cpe23": "None",
-      "pkg_type": "rpm",
-      "cpe": "None"
+      "cpe23": "None"
     },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": null,
-        "version": "None"
-      }
-    ],
     "vulnerability": {
+      "cvss_scores_nvd": [
+        {
+          "id": "CVE-2020-25648",
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "base_score": 7.5,
+            "impact_score": 3.6
+          },
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "base_score": 5.0,
+            "impact_score": 2.9
+          }
+        }
+      ],
       "cvss_scores_vendor": [],
       "severity": "Medium",
       "description": "NA",
-      "vulnerability_id": "CVE-2020-25648",
-      "last_modified": "2020-10-20T09:10:21Z",
       "feed": "vulnerabilities",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "impact_score": 3.6,
-            "base_score": 7.5,
-            "exploitability_score": 3.9
-          },
-          "cvss_v2": {
-            "impact_score": 2.9,
-            "base_score": 5.0,
-            "exploitability_score": 10.0
-          },
-          "id": "CVE-2020-25648"
-        }
-      ],
-      "created_at": "2020-10-20T09:10:21Z",
+      "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2020-25648",
-      "feed_group": "rhel:7"
+      "vulnerability_id": "CVE-2020-25648"
     },
     "match": {
       "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
+    "fix": {
+      "versions": [
+        "None"
+      ],
+      "wont_fix": false,
+      "observed_at": null,
+      "advisories": []
+    },
     "artifact": {
-      "name": "nss-tools",
+      "pkg_type": "rpm",
       "pkg_path": "pkgdb",
       "version": "3.53.1-3.el7_9",
-      "cpe23": "None",
-      "pkg_type": "rpm",
-      "cpe": "None"
+      "cpe": "None",
+      "name": "nss-tools",
+      "cpe23": "None"
     },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": null,
-        "version": "None"
-      }
-    ],
     "vulnerability": {
-      "cvss_scores_vendor": [],
-      "severity": "Medium",
-      "description": "NA",
-      "vulnerability_id": "CVE-2020-12399",
-      "last_modified": "2020-05-21T09:09:26Z",
-      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
+          "id": "CVE-2020-12399",
           "cvss_v3": {
-            "impact_score": 3.6,
+            "exploitability_score": 0.8,
             "base_score": 4.4,
-            "exploitability_score": 0.8
+            "impact_score": 3.6
           },
           "cvss_v2": {
-            "impact_score": 2.9,
+            "exploitability_score": 1.9,
             "base_score": 1.2,
-            "exploitability_score": 1.9
-          },
-          "id": "CVE-2020-12399"
+            "impact_score": 2.9
+          }
         }
       ],
-      "created_at": "2020-05-21T09:09:26Z",
-      "link": "https://access.redhat.com/security/cve/CVE-2020-12399",
-      "feed_group": "rhel:7"
-    },
-    "match": {
-      "detected_at": "2021-05-04T06:22:33Z"
-    }
-  },
-  {
-    "artifact": {
-      "name": "nss-tools",
-      "pkg_path": "pkgdb",
-      "version": "3.53.1-3.el7_9",
-      "cpe23": "None",
-      "pkg_type": "rpm",
-      "cpe": "None"
-    },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": null,
-        "version": "None"
-      }
-    ],
-    "vulnerability": {
       "cvss_scores_vendor": [],
       "severity": "Medium",
       "description": "NA",
-      "vulnerability_id": "CVE-2020-25648",
-      "last_modified": "2020-10-20T09:10:21Z",
       "feed": "vulnerabilities",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "impact_score": 3.6,
-            "base_score": 7.5,
-            "exploitability_score": 3.9
-          },
-          "cvss_v2": {
-            "impact_score": 2.9,
-            "base_score": 5.0,
-            "exploitability_score": 10.0
-          },
-          "id": "CVE-2020-25648"
-        }
-      ],
-      "created_at": "2020-10-20T09:10:21Z",
-      "link": "https://access.redhat.com/security/cve/CVE-2020-25648",
-      "feed_group": "rhel:7"
+      "feed_group": "rhel:7",
+      "link": "https://access.redhat.com/security/cve/CVE-2020-12399",
+      "vulnerability_id": "CVE-2020-12399"
     },
     "match": {
       "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
+    "fix": {
+      "versions": [
+        "None"
+      ],
+      "wont_fix": false,
+      "observed_at": null,
+      "advisories": []
+    },
     "artifact": {
-      "name": "openldap",
+      "pkg_type": "rpm",
+      "pkg_path": "pkgdb",
+      "version": "3.53.1-3.el7_9",
+      "cpe": "None",
+      "name": "nss-tools",
+      "cpe23": "None"
+    },
+    "vulnerability": {
+      "cvss_scores_nvd": [
+        {
+          "id": "CVE-2020-25648",
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "base_score": 7.5,
+            "impact_score": 3.6
+          },
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "base_score": 5.0,
+            "impact_score": 2.9
+          }
+        }
+      ],
+      "cvss_scores_vendor": [],
+      "severity": "Medium",
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "link": "https://access.redhat.com/security/cve/CVE-2020-25648",
+      "vulnerability_id": "CVE-2020-25648"
+    },
+    "match": {
+      "detected_at": "2021-05-04T06:22:33Z"
+    }
+  },
+  {
+    "fix": {
+      "versions": [
+        "None"
+      ],
+      "wont_fix": false,
+      "observed_at": null,
+      "advisories": []
+    },
+    "artifact": {
+      "pkg_type": "rpm",
       "pkg_path": "pkgdb",
       "version": "2.4.44-22.el7",
-      "cpe23": "None",
-      "pkg_type": "rpm",
-      "cpe": "None"
+      "cpe": "None",
+      "name": "openldap",
+      "cpe23": "None"
     },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": null,
-        "version": "None"
-      }
-    ],
     "vulnerability": {
+      "cvss_scores_nvd": [
+        {
+          "id": "CVE-2020-25692",
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "base_score": 7.5,
+            "impact_score": 3.6
+          },
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "base_score": 5.0,
+            "impact_score": 2.9
+          }
+        }
+      ],
       "cvss_scores_vendor": [],
       "severity": "Medium",
       "description": "NA",
-      "vulnerability_id": "CVE-2020-25692",
-      "last_modified": "2020-12-10T09:15:58Z",
       "feed": "vulnerabilities",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "impact_score": 3.6,
-            "base_score": 7.5,
-            "exploitability_score": 3.9
-          },
-          "cvss_v2": {
-            "impact_score": 2.9,
-            "base_score": 5.0,
-            "exploitability_score": 10.0
-          },
-          "id": "CVE-2020-25692"
-        }
-      ],
-      "created_at": "2020-11-07T09:10:34Z",
+      "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2020-25692",
-      "feed_group": "rhel:7"
+      "vulnerability_id": "CVE-2020-25692"
     },
     "match": {
       "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
+    "fix": {
+      "versions": [
+        "1:1.0.2k-21.el7_9"
+      ],
+      "wont_fix": false,
+      "observed_at": "2020-12-19T09:16:55Z",
+      "advisories": []
+    },
     "artifact": {
-      "name": "openssl-libs",
+      "pkg_type": "rpm",
       "pkg_path": "pkgdb",
       "version": "1.0.2k-19.el7",
-      "cpe23": "None",
-      "pkg_type": "rpm",
-      "cpe": "None"
+      "cpe": "None",
+      "name": "openssl-libs",
+      "cpe23": "None"
     },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": "2020-12-19T09:16:55Z",
-        "version": "1:1.0.2k-21.el7_9"
-      }
-    ],
     "vulnerability": {
+      "cvss_scores_nvd": [
+        {
+          "id": "CVE-2020-1971",
+          "cvss_v3": {
+            "exploitability_score": 2.2,
+            "base_score": 5.9,
+            "impact_score": 3.6
+          },
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "base_score": 4.3,
+            "impact_score": 2.9
+          }
+        }
+      ],
       "cvss_scores_vendor": [],
       "severity": "High",
       "description": "NA",
-      "vulnerability_id": "CVE-2020-1971",
-      "last_modified": "2020-12-09T09:16:50Z",
       "feed": "vulnerabilities",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "impact_score": 3.6,
-            "base_score": 5.9,
-            "exploitability_score": 2.2
-          },
-          "cvss_v2": {
-            "impact_score": 2.9,
-            "base_score": 4.3,
-            "exploitability_score": 8.6
-          },
-          "id": "CVE-2020-1971"
-        }
-      ],
-      "created_at": "2020-12-09T09:16:50Z",
+      "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2020-1971",
-      "feed_group": "rhel:7"
+      "vulnerability_id": "CVE-2020-1971"
     },
     "match": {
       "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
+    "fix": {
+      "versions": [
+        "None"
+      ],
+      "wont_fix": false,
+      "observed_at": null,
+      "advisories": []
+    },
     "artifact": {
-      "name": "openssl-libs",
+      "pkg_type": "rpm",
       "pkg_path": "pkgdb",
       "version": "1.0.2k-19.el7",
-      "cpe23": "None",
-      "pkg_type": "rpm",
-      "cpe": "None"
+      "cpe": "None",
+      "name": "openssl-libs",
+      "cpe23": "None"
     },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": null,
-        "version": "None"
-      }
-    ],
     "vulnerability": {
+      "cvss_scores_nvd": [
+        {
+          "id": "CVE-2021-23840",
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "base_score": 7.5,
+            "impact_score": 3.6
+          },
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "base_score": 5.0,
+            "impact_score": 2.9
+          }
+        }
+      ],
       "cvss_scores_vendor": [],
       "severity": "Medium",
       "description": "NA",
-      "vulnerability_id": "CVE-2021-23840",
-      "last_modified": "2021-03-31T17:05:26Z",
       "feed": "vulnerabilities",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "impact_score": 3.6,
-            "base_score": 7.5,
-            "exploitability_score": 3.9
-          },
-          "cvss_v2": {
-            "impact_score": 2.9,
-            "base_score": 5.0,
-            "exploitability_score": 10.0
-          },
-          "id": "CVE-2021-23840"
-        }
-      ],
-      "created_at": "2021-03-31T17:05:26Z",
+      "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2021-23840",
-      "feed_group": "rhel:7"
+      "vulnerability_id": "CVE-2021-23840"
     },
     "match": {
       "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
+    "fix": {
+      "versions": [
+        "None"
+      ],
+      "wont_fix": false,
+      "observed_at": null,
+      "advisories": []
+    },
     "artifact": {
-      "name": "openssl-libs",
+      "pkg_type": "rpm",
       "pkg_path": "pkgdb",
       "version": "1.0.2k-19.el7",
-      "cpe23": "None",
-      "pkg_type": "rpm",
-      "cpe": "None"
+      "cpe": "None",
+      "name": "openssl-libs",
+      "cpe23": "None"
     },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": null,
-        "version": "None"
-      }
-    ],
     "vulnerability": {
-      "cvss_scores_vendor": [],
-      "severity": "Medium",
-      "description": "NA",
-      "vulnerability_id": "CVE-2021-23841",
-      "last_modified": "2021-03-31T17:05:26Z",
-      "feed": "vulnerabilities",
       "cvss_scores_nvd": [
         {
+          "id": "CVE-2021-23841",
           "cvss_v3": {
-            "impact_score": 3.6,
+            "exploitability_score": 2.2,
             "base_score": 5.9,
-            "exploitability_score": 2.2
+            "impact_score": 3.6
           },
           "cvss_v2": {
-            "impact_score": 2.9,
+            "exploitability_score": 8.6,
             "base_score": 4.3,
-            "exploitability_score": 8.6
-          },
-          "id": "CVE-2021-23841"
+            "impact_score": 2.9
+          }
         }
       ],
-      "created_at": "2021-03-31T17:05:26Z",
+      "cvss_scores_vendor": [],
+      "severity": "Medium",
+      "description": "NA",
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2021-23841",
-      "feed_group": "rhel:7"
+      "vulnerability_id": "CVE-2021-23841"
     },
     "match": {
       "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
+    "fix": {
+      "versions": [
+        "0:2.7.5-90.el7"
+      ],
+      "wont_fix": false,
+      "observed_at": "2020-11-11T09:10:28Z",
+      "advisories": []
+    },
     "artifact": {
+      "pkg_type": "rpm",
+      "pkg_path": "pkgdb",
+      "version": "2.7.5-89.el7",
+      "cpe": "None",
       "name": "python",
-      "pkg_path": "pkgdb",
-      "version": "2.7.5-89.el7",
-      "cpe23": "None",
-      "pkg_type": "rpm",
-      "cpe": "None"
+      "cpe23": "None"
     },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": "2020-11-11T09:10:28Z",
-        "version": "0:2.7.5-90.el7"
-      }
-    ],
     "vulnerability": {
+      "cvss_scores_nvd": [
+        {
+          "id": "CVE-2019-20907",
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "base_score": 7.5,
+            "impact_score": 3.6
+          },
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "base_score": 5.0,
+            "impact_score": 2.9
+          }
+        }
+      ],
       "cvss_scores_vendor": [],
       "severity": "Medium",
       "description": "NA",
-      "vulnerability_id": "CVE-2019-20907",
-      "last_modified": "2020-07-15T09:10:41Z",
       "feed": "vulnerabilities",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "impact_score": 3.6,
-            "base_score": 7.5,
-            "exploitability_score": 3.9
-          },
-          "cvss_v2": {
-            "impact_score": 2.9,
-            "base_score": 5.0,
-            "exploitability_score": 10.0
-          },
-          "id": "CVE-2019-20907"
-        }
-      ],
-      "created_at": "2020-07-14T09:11:04Z",
+      "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2019-20907",
-      "feed_group": "rhel:7"
+      "vulnerability_id": "CVE-2019-20907"
     },
     "match": {
       "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
+    "fix": {
+      "versions": [
+        "0:2.7.5-90.el7"
+      ],
+      "wont_fix": false,
+      "observed_at": "2020-11-11T09:10:28Z",
+      "advisories": []
+    },
     "artifact": {
+      "pkg_type": "rpm",
+      "pkg_path": "pkgdb",
+      "version": "2.7.5-89.el7",
+      "cpe": "None",
       "name": "python-libs",
-      "pkg_path": "pkgdb",
-      "version": "2.7.5-89.el7",
-      "cpe23": "None",
-      "pkg_type": "rpm",
-      "cpe": "None"
+      "cpe23": "None"
     },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": "2020-11-11T09:10:28Z",
-        "version": "0:2.7.5-90.el7"
-      }
-    ],
     "vulnerability": {
+      "cvss_scores_nvd": [
+        {
+          "id": "CVE-2019-20907",
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "base_score": 7.5,
+            "impact_score": 3.6
+          },
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "base_score": 5.0,
+            "impact_score": 2.9
+          }
+        }
+      ],
       "cvss_scores_vendor": [],
       "severity": "Medium",
       "description": "NA",
-      "vulnerability_id": "CVE-2019-20907",
-      "last_modified": "2020-07-15T09:10:41Z",
       "feed": "vulnerabilities",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "impact_score": 3.6,
-            "base_score": 7.5,
-            "exploitability_score": 3.9
-          },
-          "cvss_v2": {
-            "impact_score": 2.9,
-            "base_score": 5.0,
-            "exploitability_score": 10.0
-          },
-          "id": "CVE-2019-20907"
-        }
-      ],
-      "created_at": "2020-07-14T09:11:04Z",
+      "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2019-20907",
-      "feed_group": "rhel:7"
+      "vulnerability_id": "CVE-2019-20907"
     },
     "match": {
       "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
+    "fix": {
+      "versions": [
+        "0.5.0"
+      ],
+      "wont_fix": false,
+      "observed_at": "2021-03-31T17:30:47Z",
+      "advisories": []
+    },
     "artifact": {
-      "name": "xmldom",
+      "pkg_type": "npm",
       "pkg_path": "/root/.npm/xmldom/0.4.0/package/package.json",
       "version": "0.4.0",
-      "cpe23": "None",
-      "pkg_type": "npm",
-      "cpe": "None"
+      "cpe": "None",
+      "name": "xmldom",
+      "cpe23": "None"
     },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": "2021-03-31T17:30:47Z",
-        "version": "0.5.0"
-      }
-    ],
     "vulnerability": {
+      "cvss_scores_nvd": [
+        {
+          "id": "CVE-2021-21366",
+          "cvss_v3": {
+            "exploitability_score": 2.8,
+            "base_score": 4.3,
+            "impact_score": 1.4
+          },
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "base_score": 4.3,
+            "impact_score": 2.9
+          }
+        }
+      ],
       "cvss_scores_vendor": [],
       "severity": "Low",
       "description": "NA",
-      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv",
-      "last_modified": "2021-03-31T17:30:47Z",
       "feed": "vulnerabilities",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "impact_score": 1.4,
-            "base_score": 4.3,
-            "exploitability_score": 2.8
-          },
-          "cvss_v2": {
-            "impact_score": 2.9,
-            "base_score": 4.3,
-            "exploitability_score": 8.6
-          },
-          "id": "CVE-2021-21366"
-        }
-      ],
-      "created_at": "2021-03-31T17:30:47Z",
+      "feed_group": "github:npm",
       "link": "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv",
-      "feed_group": "github:npm"
+      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv"
     },
     "match": {
       "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
+    "fix": {
+      "versions": [
+        "0.5.0"
+      ],
+      "wont_fix": false,
+      "observed_at": "2021-03-31T17:30:47Z",
+      "advisories": []
+    },
     "artifact": {
-      "name": "xmldom",
+      "pkg_type": "npm",
       "pkg_path": "/sandbox/node_modules/xmldom/package.json",
       "version": "0.4.0",
-      "cpe23": "None",
-      "pkg_type": "npm",
-      "cpe": "None"
+      "cpe": "None",
+      "name": "xmldom",
+      "cpe23": "None"
     },
-    "fixes": [
-      {
-        "wont_fix": false,
-        "observed_at": "2021-03-31T17:30:47Z",
-        "version": "0.5.0"
-      }
-    ],
     "vulnerability": {
+      "cvss_scores_nvd": [
+        {
+          "id": "CVE-2021-21366",
+          "cvss_v3": {
+            "exploitability_score": 2.8,
+            "base_score": 4.3,
+            "impact_score": 1.4
+          },
+          "cvss_v2": {
+            "exploitability_score": 8.6,
+            "base_score": 4.3,
+            "impact_score": 2.9
+          }
+        }
+      ],
       "cvss_scores_vendor": [],
       "severity": "Low",
       "description": "NA",
-      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv",
-      "last_modified": "2021-03-31T17:30:47Z",
       "feed": "vulnerabilities",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "impact_score": 1.4,
-            "base_score": 4.3,
-            "exploitability_score": 2.8
-          },
-          "cvss_v2": {
-            "impact_score": 2.9,
-            "base_score": 4.3,
-            "exploitability_score": 8.6
-          },
-          "id": "CVE-2021-21366"
-        }
-      ],
-      "created_at": "2021-03-31T17:30:47Z",
+      "feed_group": "github:npm",
       "link": "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv",
-      "feed_group": "github:npm"
+      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv"
     },
     "match": {
       "detected_at": "2021-05-04T06:22:33Z"
     }
   },
   {
+    "fix": {
+      "versions": [],
+      "wont_fix": false,
+      "observed_at": "2021-05-25T23:03:37Z",
+      "advisories": []
+    },
     "artifact": {
-      "name": "ftpd",
+      "pkg_type": "gem",
       "pkg_path": "/usr/local/share/gems/specifications/ftpd-0.2.1.gemspec",
       "version": "0.2.1",
-      "cpe23": "cpe:2.3:a:ftpd:ftpd:0.2.1:*:*:-:-:-:-:-",
-      "pkg_type": "gem",
-      "cpe": "cpe:a:ftpd:ftpd:0.2.1:*:*"
+      "cpe": "cpe:a:ftpd:ftpd:0.2.1:*:*",
+      "name": "ftpd",
+      "cpe23": "cpe:2.3:a:ftpd:ftpd:0.2.1:*:*:-:-:-:-:-"
     },
-    "fixes": [],
     "vulnerability": {
+      "cvss_scores_nvd": [
+        {
+          "id": "CVE-2013-2512",
+          "cvss_v3": {
+            "exploitability_score": 3.9,
+            "base_score": 9.8,
+            "impact_score": 5.9
+          },
+          "cvss_v2": {
+            "exploitability_score": 10.0,
+            "base_score": 10.0,
+            "impact_score": 10.0
+          }
+        }
+      ],
       "cvss_scores_vendor": [],
       "severity": "Critical",
       "description": "NA",
-      "vulnerability_id": "CVE-2013-2512",
-      "last_modified": "2021-03-31T17:11:12Z",
       "feed": "nvdv2",
-      "cvss_scores_nvd": [
-        {
-          "cvss_v3": {
-            "impact_score": 5.9,
-            "base_score": 9.8,
-            "exploitability_score": 3.9
-          },
-          "cvss_v2": {
-            "impact_score": 10.0,
-            "base_score": 10.0,
-            "exploitability_score": 10.0
-          },
-          "id": "CVE-2013-2512"
-        }
-      ],
-      "created_at": "2021-03-31T17:11:12Z",
+      "feed_group": "nvdv2:cves",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
-      "feed_group": "nvdv2:cves"
+      "vulnerability_id": "CVE-2013-2512"
     },
     "match": {
       "detected_at": "2021-03-31T17:11:12Z"

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/schema_files/vulnerability_report.schema.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/schema_files/vulnerability_report.schema.json
@@ -33,13 +33,9 @@
           "type": "object",
           "$ref": "#/definitions/artifact"
         },
-        "fixes": {
-          "title": "fixes",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "#/definitions/fixed_artifact"
-          }
+        "fix": {
+          "type": "object",
+          "$ref": "#/definitions/fixed_artifact"
         },
         "match": {
           "type": "object",
@@ -81,19 +77,46 @@
       },
       "type": "object"
     },
+    "vendor_advisory": {
+      "properties": {
+        "id": {
+          "title": "id",
+          "type": "string"
+        },
+        "link": {
+          "title": "link",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "fixed_artifact": {
       "properties": {
         "observed_at": {
           "title": "observed_at",
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
-        "version": {
-          "title": "version",
-          "type": "string"
+        "versions": {
+          "title": "versions",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "wont_fix": {
           "title": "wont_fix",
           "type": "boolean"
+        },
+        "advisories": {
+          "title": "advisories",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/vendor_advisory"
+          }
         }
       },
       "type": "object"

--- a/tests/unit/anchore_engine/services/policy_engine/engine/feeds/test_config.py
+++ b/tests/unit/anchore_engine/services/policy_engine/engine/feeds/test_config.py
@@ -124,8 +124,8 @@ def test_get_selected_configs_to_sync_defaults(provider, test_config, expected):
         pytest.param(
             LegacyProvider,
             {"provider": "legacy", "sync": {"data": {"vulndb": {"enabled": True}}}},
-            {"vulndb"},
-            id="valid-legacy-vulndb",
+            set(),
+            id="invalid-legacy-vulndb",
         ),
         pytest.param(
             GrypeProvider,

--- a/tests/unit/anchore_engine/services/policy_engine/engine/vulnerabilities/test_providers.py
+++ b/tests/unit/anchore_engine/services/policy_engine/engine/vulnerabilities/test_providers.py
@@ -1,0 +1,48 @@
+from anchore_engine.services.policy_engine.api.models import (
+    FixedArtifact,
+    VulnerabilityMatch,
+)
+from anchore_engine.services.policy_engine.engine.vulns.providers import GrypeProvider
+import pytest
+
+
+class TestGrypeProvider:
+    @pytest.mark.parametrize(
+        "test_input",
+        [
+            pytest.param(
+                [VulnerabilityMatch(fix=FixedArtifact(wont_fix="true"))],
+                id="str",
+            ),
+            pytest.param(
+                [VulnerabilityMatch(fix=FixedArtifact(wont_fix="  "))],
+                id="whitespace",
+            ),
+            pytest.param(
+                [VulnerabilityMatch(fix=FixedArtifact(wont_fix=""))],
+                id="blank",
+            ),
+            pytest.param(
+                [VulnerabilityMatch(fix=FixedArtifact(wont_fix=False))],
+                id="boolean_false",
+            ),
+            pytest.param(
+                [VulnerabilityMatch(fix=None)],
+                id="fix_none",
+            ),
+        ],
+    )
+    def test_exclude_wont_fix_false(self, test_input):
+        assert len(GrypeProvider._exclude_wont_fix(test_input)) == 1
+
+    @pytest.mark.parametrize(
+        "test_input",
+        [
+            pytest.param(
+                [VulnerabilityMatch(fix=FixedArtifact(wont_fix=True))],
+                id="boolean_true",
+            ),
+        ],
+    )
+    def test_exclude_wont_fix_true(self, test_input):
+        assert len(GrypeProvider._exclude_wont_fix(test_input)) == 0


### PR DESCRIPTION
This PR adds the logic for filtering based on the vendor_only flag. When this flag is enabled, a vulnerability match will be dropped from the results if the vendor has indicated that the issue won't be fixed