### PR TITLE
Installs Anchore CLI into a virtual environment in /anchore-cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -181,7 +181,8 @@ RUN set -ex && \
 RUN set -ex && \
     python3 -m venv /anchore-cli && \
     source /anchore-cli/bin/activate && \
-    pip3 install --no-index --find-links=./ /build_output/cli_wheels/*.whl
+    pip3 install --no-index --find-links=./ /build_output/cli_wheels/*.whl && \
+    deactivate
 
 # Perform the anchore-engine build and install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY . /buildsource
 WORKDIR /buildsource
 
 RUN set -ex && \
-    mkdir -p /build_output /build_output/deps /build_output/configs /build_output/wheels
+    mkdir -p /build_output /build_output/deps /build_output/configs /build_output/wheels /build_output/cli_wheels
 
 RUN set -ex && \
     echo "installing OS dependencies" && \
@@ -25,7 +25,7 @@ RUN set -ex && \
 RUN set -ex && \
     echo "installing anchore" && \
     pip3 wheel --wheel-dir=/build_output/wheels . && \
-    pip3 wheel --wheel-dir=/build_output/wheels/ git+git://github.com/anchore/anchore-cli.git@$CLI_COMMIT\#egg=anchorecli && \
+    pip3 wheel --wheel-dir=/build_output/cli_wheels/ git+git://github.com/anchore/anchore-cli.git@$CLI_COMMIT\#egg=anchorecli && \
     cp ./LICENSE /build_output/ && \
     cp ./conf/default_config.yaml /build_output/configs/default_config.yaml && \
     cp ./docker-entrypoint.sh /build_output/configs/docker-entrypoint.sh && \
@@ -176,6 +176,12 @@ RUN set -ex && \
 
 
 # Perform any base OS specific setup
+
+# Perform the cli install into a virtual env
+RUN set -ex && \
+    python3 -m venv /anchore-cli && \
+    source /anchore-cli/bin/activate && \
+    pip3 install --no-index --find-links=./ /build_output/cli_wheels/*.whl
 
 # Perform the anchore-engine build and install
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,10 +5,6 @@ if [[ "${SET_HOSTID_TO_HOSTNAME}" == "true" ]]; then
     export ANCHORE_HOST_ID=${HOSTNAME}
 fi
 
-if [[ -f "/opt/rh/rh-python36/enable" ]]; then
-    source /opt/rh/rh-python36/enable
-fi
-
 # check if /home/anchore/certs/ exists & has files in it
 if [[ -d "/home/anchore/certs" ]] && [[ ! -z "$(ls -A /home/anchore/certs)" ]]; then
     mkdir -p /home/anchore/certs_override/python
@@ -31,5 +27,8 @@ if [[ -d "/home/anchore/certs" ]] && [[ ! -z "$(ls -A /home/anchore/certs)" ]]; 
     export REQUESTS_CA_BUNDLE=/home/anchore/certs_override/python/cacert.pem
     export SSL_CERT_DIR=/home/anchore/certs_override/os/
 fi
+
+# Add the CLI virtual env bin path
+export PATH=$PATH:/anchore-cli/bin
 
 exec "$@"

--- a/scripts/ci/test-functional
+++ b/scripts/ci/test-functional
@@ -17,8 +17,8 @@ tox_env="${TOX_ENV:-$default_tox_envs}"
 for e in $(echo "${tox_env}"); do
     docker-compose -f ${CI_COMPOSE_FILE} exec job-runner bash -c "\
         set -x && \
-        anchore-cli --u admin --p foobar --url http://engine-api:8228/v1 system wait --feedsready '' && \
-        anchore-cli --u admin --p foobar --url http://engine-api:8228/v1 system status && \
+        /anchore-cli/bin/anchore-cli --u admin --p foobar --url http://engine-api:8228/v1 system wait --feedsready '' && \
+        /anchore-cli/bin/anchore-cli --u admin --p foobar --url http://engine-api:8228/v1 system status && \
         /home/anchore/.local/bin/tox -e '${e}' -vv tests/functional --result-json .tox/test-reports.log ;\
         "
 done


### PR DESCRIPTION
Fixes #1074 by creating a virtual env in /anchore-cli that isolates the cli requirements from those of anchore-engine so they cannot conflict.

This PR does not change the operation of Anchore Engine itself since the CLI is never invoked by any service. The CLI is included for convenience only so users can exec into a running container and use it to debug.