### PR TITLE
Fixes issues caused by policy-engine model update 

### DIFF
--- a/anchore_engine/services/policy_engine/engine/policy/gates/vulnerabilities.py
+++ b/anchore_engine/services/policy_engine/engine/policy/gates/vulnerabilities.py
@@ -325,12 +325,12 @@ class VulnerabilityMatchTrigger(BaseTrigger):
                 if comparison_fn(found_severity_idx, comparison_idx):
                     # package path excludes logic for non-os packages only
                     if new_vuln_pkg_class == "non-os" and package_path_re:
-                        match_found = package_path_re.match(artifact_obj.pkg_path)
+                        match_found = package_path_re.match(artifact_obj.location)
                         if match_found is not None:
                             logger.debug(
                                 "Non-OS vulnerability {} package path {} matches package path exclude {}, skipping".format(
                                     artifact_obj.name,
-                                    artifact_obj.pkg_path,
+                                    artifact_obj.location,
                                     path_exclude_re_value,
                                 )
                             )
@@ -498,7 +498,7 @@ class VulnerabilityMatchTrigger(BaseTrigger):
                     # Gather cvss scores before operating with max
                     vendor_cvss_v3_scores = []
                     for score_obj in vulnerability_obj.cvss:
-                        if score_obj.startswith("3"):
+                        if score_obj.version.startswith("3"):
                             vendor_cvss_v3_scores.append(score_obj)
 
                     if vendor_cvss_v3_scores:
@@ -596,12 +596,12 @@ class VulnerabilityMatchTrigger(BaseTrigger):
                         trigger_fname = None
                         if artifact_obj.pkg_type in ["java", "gem"]:
                             try:
-                                trigger_fname = artifact_obj.pkg_path.split("/")[-1]
+                                trigger_fname = artifact_obj.location.split("/")[-1]
                             except:
                                 trigger_fname = None
                         elif artifact_obj.pkg_type in ["npm"]:
                             try:
-                                trigger_fname = artifact_obj.pkg_path.split("/")[-2]
+                                trigger_fname = artifact_obj.location.split("/")[-2]
                             except:
                                 trigger_fname = None
 
@@ -610,7 +610,7 @@ class VulnerabilityMatchTrigger(BaseTrigger):
                                 [artifact_obj.name, artifact_obj.version]
                             )
 
-                        pkgname = artifact_obj.pkg_path
+                        pkgname = artifact_obj.location
                     else:
                         trigger_fname = artifact_obj.name
                         pkgname = artifact_obj.name

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:406413437f26223183d133ccc7186f24c827729e1b21adc7330dd43fcdc030b3.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:406413437f26223183d133ccc7186f24c827729e1b21adc7330dd43fcdc030b3.json
@@ -4,9 +4,9 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "tar",
+      "name": "libapt-pkg5.0",
       "pkg_type": "dpkg",
-      "version": "1.30+dfsg-6"
+      "version": "1.8.2.2"
     },
     "fix": {
       "advisories": [],
@@ -15,52 +15,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 10.0,
-            "exploitability_score": 10.0,
-            "impact_score": 10.0,
-            "vector": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2005-2541",
-        "severity": "High",
-        "vulnerability_id": "CVE-2005-2541"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2005-2541",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2005-2541"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libpython3.7-minimal",
-      "pkg_type": "dpkg",
-      "version": "3.7.3-2+deb10u3"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
+      "detected_at": "2021-06-02T02:45:55Z"
     },
     "nvd": [
       {
@@ -73,17 +28,17 @@
             "version": "2.0"
           },
           {
-            "base_score": 6.1,
-            "exploitability_score": 2.8,
-            "impact_score": 2.7,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+            "base_score": 3.7,
+            "exploitability_score": 2.2,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
             "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-18348",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2019-18348"
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2011-3374",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2011-3374"
       }
     ],
     "vulnerability": {
@@ -91,9 +46,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2011-3374",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-18348"
+      "vulnerability_id": "CVE-2011-3374"
     }
   },
   {
@@ -101,9 +56,9 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "libglib2.0-0",
+      "name": "libsystemd0",
       "pkg_type": "dpkg",
-      "version": "2.58.3-2+deb10u2"
+      "version": "241-7~deb10u7"
     },
     "fix": {
       "advisories": [],
@@ -112,23 +67,23 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
+      "detected_at": "2021-06-02T02:45:55Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "base_score": 3.3,
+            "exploitability_score": 3.4,
+            "impact_score": 4.9,
+            "vector": "AV:L/AC:M/Au:N/C:P/I:P/A:N",
             "version": "2.0"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2012-0039",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2012-0039"
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-4392",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2013-4392"
       }
     ],
     "vulnerability": {
@@ -136,9 +91,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2012-0039",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2012-0039"
+      "vulnerability_id": "CVE-2013-4392"
     }
   },
   {
@@ -159,7 +114,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
+      "detected_at": "2021-06-02T02:45:55Z"
     },
     "nvd": [
       {
@@ -200,9 +155,9 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "libpython3.7-minimal",
+      "name": "libsystemd0",
       "pkg_type": "dpkg",
-      "version": "3.7.3-2+deb10u3"
+      "version": "241-7~deb10u7"
     },
     "fix": {
       "advisories": [],
@@ -211,30 +166,30 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
+      "detected_at": "2021-06-02T02:45:55Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 7.5,
-            "exploitability_score": 10.0,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+            "base_score": 6.2,
+            "exploitability_score": 1.9,
+            "impact_score": 10.0,
+            "vector": "AV:L/AC:H/Au:N/C:C/I:C/A:C",
             "version": "2.0"
           },
           {
-            "base_score": 9.8,
-            "exploitability_score": 3.9,
+            "base_score": 6.7,
+            "exploitability_score": 0.8,
             "impact_score": 5.9,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H",
             "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-27619",
-        "severity": "Critical",
-        "vulnerability_id": "CVE-2020-27619"
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13776",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2020-13776"
       }
     ],
     "vulnerability": {
@@ -242,61 +197,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-27619",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-27619"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "python2.7-minimal",
-      "pkg_type": "dpkg",
-      "version": "2.7.16-2+deb10u1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9674",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-9674"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-9674"
+      "vulnerability_id": "CVE-2020-13776"
     }
   },
   {
@@ -315,7 +218,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
+      "detected_at": "2021-06-02T02:45:55Z"
     },
     "nvd": [
       {
@@ -349,9 +252,9 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "systemd",
+      "name": "libgnutls30",
       "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
+      "version": "3.6.7-4+deb10u6"
     },
     "fix": {
       "advisories": [],
@@ -360,499 +263,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 3.3,
-            "exploitability_score": 3.4,
-            "impact_score": 4.9,
-            "vector": "AV:L/AC:M/Au:N/C:P/I:P/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-4392",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2013-4392"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2013-4392"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libudev1",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 3.3,
-            "exploitability_score": 3.4,
-            "impact_score": 4.9,
-            "vector": "AV:L/AC:M/Au:N/C:P/I:P/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-4392",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2013-4392"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2013-4392"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "perl-base",
-      "pkg_type": "dpkg",
-      "version": "5.28.1-6+deb10u1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2011-4116",
-        "severity": "High",
-        "vulnerability_id": "CVE-2011-4116"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2011-4116",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2011-4116"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "python2.7-minimal",
-      "pkg_type": "dpkg",
-      "version": "2.7.16-2+deb10u1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 6.8,
-            "exploitability_score": 8.6,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 8.8,
-            "exploitability_score": 2.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-17522",
-        "severity": "High",
-        "vulnerability_id": "CVE-2017-17522"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-17522"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "coreutils",
-      "pkg_type": "dpkg",
-      "version": "8.30-3"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 1.9,
-            "exploitability_score": 3.4,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:M/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 4.7,
-            "exploitability_score": 1.0,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:H/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-18018",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2017-18018"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-18018",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-18018"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libldap-common",
-      "pkg_type": "dpkg",
-      "version": "2.4.47+dfsg-3+deb10u6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-17740",
-        "severity": "High",
-        "vulnerability_id": "CVE-2017-17740"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17740",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-17740"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "bash",
-      "pkg_type": "dpkg",
-      "version": "5.0-4"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.2,
-            "exploitability_score": 3.9,
-            "impact_score": 10.0,
-            "vector": "AV:L/AC:L/Au:N/C:C/I:C/A:C",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.8,
-            "exploitability_score": 1.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-18276",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-18276"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18276",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-18276"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl",
-      "pkg_type": "dpkg",
-      "version": "1.1.1d-0+deb10u6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.0,
-            "exploitability_score": 1.9,
-            "impact_score": 6.9,
-            "vector": "AV:L/AC:H/Au:N/C:C/I:N/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-0928",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2010-0928"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2010-0928",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2010-0928"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libgssapi-krb5-2",
-      "pkg_type": "dpkg",
-      "version": "1.17-3+deb10u1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:L/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2004-0971",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2004-0971"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2004-0971",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2004-0971"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "login",
-      "pkg_type": "dpkg",
-      "version": "1:4.5-1.1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 3.3,
-            "exploitability_score": 3.4,
-            "impact_score": 4.9,
-            "vector": "AV:L/AC:M/Au:N/C:N/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 4.7,
-            "exploitability_score": 1.0,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:H/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-4235",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2013-4235"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4235",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2013-4235"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "python3.7-minimal",
-      "pkg_type": "dpkg",
-      "version": "3.7.3-2+deb10u3"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
+      "detected_at": "2021-06-02T02:45:55Z"
     },
     "nvd": [
       {
@@ -861,21 +272,14 @@
             "base_score": 4.3,
             "exploitability_score": 8.6,
             "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+            "vector": "AV:N/AC:M/Au:N/C:P/I:N/A:N",
             "version": "2.0"
-          },
-          {
-            "base_score": 6.1,
-            "exploitability_score": 2.8,
-            "impact_score": 2.7,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
-            "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-18348",
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2011-3389",
         "severity": "Medium",
-        "vulnerability_id": "CVE-2019-18348"
+        "vulnerability_id": "CVE-2011-3389"
       }
     ],
     "vulnerability": {
@@ -883,113 +287,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-18348"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libgssapi-krb5-2",
-      "pkg_type": "dpkg",
-      "version": "1.17-3+deb10u1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-5709",
-        "severity": "High",
-        "vulnerability_id": "CVE-2018-5709"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2018-5709",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2018-5709"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libtasn1-6",
-      "pkg_type": "dpkg",
-      "version": "4.13-3"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.1,
-            "exploitability_score": 8.6,
-            "impact_score": 6.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:C",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.5,
-            "exploitability_score": 1.8,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-1000654",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2018-1000654"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2018-1000654",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2018-1000654"
+      "link": "https://security-tracker.debian.org/tracker/CVE-2011-3389",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2011-3389"
     }
   },
   {
@@ -1008,23 +308,30 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
+      "detected_at": "2021-06-02T02:45:55Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
+            "base_score": 4.0,
+            "exploitability_score": 4.9,
+            "impact_score": 4.9,
+            "vector": "AV:N/AC:H/Au:N/C:N/I:P/A:P",
             "version": "2.0"
+          },
+          {
+            "base_score": 5.9,
+            "exploitability_score": 1.6,
+            "impact_score": 4.2,
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:H",
+            "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-7040",
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-23336",
         "severity": "Medium",
-        "vulnerability_id": "CVE-2013-7040"
+        "vulnerability_id": "CVE-2021-23336"
       }
     ],
     "vulnerability": {
@@ -1032,9 +339,106 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-7040",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2021-23336",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2021-23336"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libnss-systemd",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 6.2,
+            "exploitability_score": 1.9,
+            "impact_score": 10.0,
+            "vector": "AV:L/AC:H/Au:N/C:C/I:C/A:C",
+            "version": "2.0"
+          },
+          {
+            "base_score": 6.7,
+            "exploitability_score": 0.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13776",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2020-13776"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2013-7040"
+      "vulnerability_id": "CVE-2020-13776"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libudev1",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 3.3,
+            "exploitability_score": 3.4,
+            "impact_score": 4.9,
+            "vector": "AV:L/AC:M/Au:N/C:P/I:P/A:N",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-4392",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2013-4392"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2013-4392"
     }
   },
   {
@@ -1053,7 +457,210 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 6.8,
+            "exploitability_score": 8.6,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.8,
+            "exploitability_score": 1.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-7246",
+        "severity": "High",
+        "vulnerability_id": "CVE-2017-7246"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-7246",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-7246"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/sandbox/node_modules/xmldom/package.json",
+      "name": "xmldom",
+      "pkg_type": "npm",
+      "version": "0.4.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-03-31T17:30:47Z",
+      "versions": [
+        "0.5.0"
+      ],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 4.3,
+            "exploitability_score": 2.8,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21366",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2021-21366"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "github:npm",
+      "link": "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv",
+      "severity": "Low",
+      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libudev1",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 6.2,
+            "exploitability_score": 1.9,
+            "impact_score": 10.0,
+            "vector": "AV:L/AC:H/Au:N/C:C/I:C/A:C",
+            "version": "2.0"
+          },
+          {
+            "base_score": 6.7,
+            "exploitability_score": 0.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13776",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2020-13776"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2020-13776"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libc6",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-4052",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2010-4052"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4052",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2010-4052"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libpcre3",
+      "pkg_type": "dpkg",
+      "version": "2:8.39-12"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
     },
     "nvd": [
       {
@@ -1105,59 +712,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 6.1,
-            "exploitability_score": 2.8,
-            "impact_score": 2.7,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-18348",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2019-18348"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-18348"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libpcre3",
-      "pkg_type": "dpkg",
-      "version": "2:8.39-12"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
+      "detected_at": "2021-06-02T02:45:55Z"
     },
     "nvd": [
       {
@@ -1168,64 +723,12 @@
             "impact_score": 2.9,
             "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
             "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-20838",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-20838"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20838",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-20838"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "login",
-      "pkg_type": "dpkg",
-      "version": "1:4.5-1.1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.9,
-            "exploitability_score": 3.9,
-            "impact_score": 6.9,
-            "vector": "AV:L/AC:L/Au:N/C:C/I:N/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2007-5686",
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-7040",
         "severity": "Medium",
-        "vulnerability_id": "CVE-2007-5686"
+        "vulnerability_id": "CVE-2013-7040"
       }
     ],
     "vulnerability": {
@@ -1233,61 +736,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2007-5686",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-7040",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2007-5686"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc6",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-20796",
-        "severity": "High",
-        "vulnerability_id": "CVE-2018-20796"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2018-20796",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2018-20796"
+      "vulnerability_id": "CVE-2013-7040"
     }
   },
   {
@@ -1306,1641 +757,23 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-20796",
-        "severity": "High",
-        "vulnerability_id": "CVE-2018-20796"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2018-20796",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2018-20796"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "python3.7-minimal",
-      "pkg_type": "dpkg",
-      "version": "3.7.3-2+deb10u3"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9674",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-9674"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-9674"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc-bin",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.3,
-            "exploitability_score": 3.9,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010024",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2019-1010024"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010024",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-1010024"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "tar",
-      "pkg_type": "dpkg",
-      "version": "1.30+dfsg-6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9923",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-9923"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9923",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-9923"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "python",
-      "pkg_type": "dpkg",
-      "version": "2.7.16-1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.2,
-            "exploitability_score": 3.9,
-            "impact_score": 10.0,
-            "vector": "AV:L/AC:L/Au:N/C:C/I:C/A:C",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2008-4108",
-        "severity": "High",
-        "vulnerability_id": "CVE-2008-4108"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2008-4108",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2008-4108"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libglib2.0-0",
-      "pkg_type": "dpkg",
-      "version": "2.58.3-2+deb10u2"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.6,
-            "exploitability_score": 3.9,
-            "impact_score": 6.4,
-            "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.8,
-            "exploitability_score": 1.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-35457",
-        "severity": "High",
-        "vulnerability_id": "CVE-2020-35457"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-35457",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-35457"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libnss-systemd",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 3.3,
-            "exploitability_score": 3.4,
-            "impact_score": 4.9,
-            "vector": "AV:L/AC:M/Au:N/C:P/I:P/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-4392",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2013-4392"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2013-4392"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc-bin",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9192",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-9192"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9192",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-9192"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libseccomp2",
-      "pkg_type": "dpkg",
-      "version": "2.3.3-4"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.5,
-            "exploitability_score": 10.0,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 9.8,
-            "exploitability_score": 3.9,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9893",
-        "severity": "Critical",
-        "vulnerability_id": "CVE-2019-9893"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9893",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-9893"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libpython3.7-minimal",
-      "pkg_type": "dpkg",
-      "version": "3.7.3-2+deb10u3"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9674",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-9674"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-9674"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl",
-      "pkg_type": "dpkg",
-      "version": "1.1.1d-0+deb10u6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.8,
-            "exploitability_score": 8.6,
-            "impact_score": 4.9,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2007-6755",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2007-6755"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2007-6755",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2007-6755"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "tar",
-      "pkg_type": "dpkg",
-      "version": "1.30+dfsg-6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-20193",
-        "severity": "Unknown",
-        "vulnerability_id": "CVE-2021-20193"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2021-20193",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2021-20193"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libpython2.7-minimal",
-      "pkg_type": "dpkg",
-      "version": "2.7.16-2+deb10u1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 6.8,
-            "exploitability_score": 8.6,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 8.8,
-            "exploitability_score": 2.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-17522",
-        "severity": "High",
-        "vulnerability_id": "CVE-2017-17522"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-17522"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc6",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.3,
-            "exploitability_score": 3.9,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010025",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2019-1010025"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010025",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-1010025"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc-bin",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.5,
-            "exploitability_score": 10.0,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 9.8,
-            "exploitability_score": 3.9,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010022",
-        "severity": "Critical",
-        "vulnerability_id": "CVE-2019-1010022"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010022",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-1010022"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libgcrypt20",
-      "pkg_type": "dpkg",
-      "version": "1.8.4-5"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-6829",
-        "severity": "High",
-        "vulnerability_id": "CVE-2018-6829"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2018-6829",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2018-6829"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libudev1",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 6.2,
-            "exploitability_score": 1.9,
-            "impact_score": 10.0,
-            "vector": "AV:L/AC:H/Au:N/C:C/I:C/A:C",
-            "version": "2.0"
-          },
-          {
-            "base_score": 6.7,
-            "exploitability_score": 0.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13776",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2020-13776"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-13776"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "login",
-      "pkg_type": "dpkg",
-      "version": "1:4.5-1.1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 6.9,
-            "exploitability_score": 3.4,
-            "impact_score": 10.0,
-            "vector": "AV:L/AC:M/Au:N/C:C/I:C/A:C",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.8,
-            "exploitability_score": 1.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-19882",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-19882"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-19882",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-19882"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libapt-pkg5.0",
-      "pkg_type": "dpkg",
-      "version": "1.8.2.2"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 3.7,
-            "exploitability_score": 2.2,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2011-3374",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2011-3374"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2011-3374",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2011-3374"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libpcre3",
-      "pkg_type": "dpkg",
-      "version": "2:8.39-12"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 6.8,
-            "exploitability_score": 8.6,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.8,
-            "exploitability_score": 1.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-7246",
-        "severity": "High",
-        "vulnerability_id": "CVE-2017-7246"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-7246",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-7246"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libsystemd0",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 3.3,
-            "exploitability_score": 3.4,
-            "impact_score": 4.9,
-            "vector": "AV:L/AC:M/Au:N/C:P/I:P/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-4392",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2013-4392"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2013-4392"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "/sandbox/node_modules/xmldom/package.json",
-      "name": "xmldom",
-      "pkg_type": "npm",
-      "version": "0.4.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-03-31T17:30:47Z",
-      "versions": [
-        "0.5.0"
-      ],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 4.3,
-            "exploitability_score": 2.8,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21366",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2021-21366"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "github:npm",
-      "link": "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv",
-      "severity": "Low",
-      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc-bin",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 6.8,
-            "exploitability_score": 8.6,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 8.8,
-            "exploitability_score": 2.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010023",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-1010023"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010023",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-1010023"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc6",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.5,
-            "exploitability_score": 10.0,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 9.8,
-            "exploitability_score": 3.9,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010022",
-        "severity": "Critical",
-        "vulnerability_id": "CVE-2019-1010022"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010022",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-1010022"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libudev1",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 2.4,
-            "exploitability_score": 0.9,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-20386",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2019-20386"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-20386"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libssl1.1",
-      "pkg_type": "dpkg",
-      "version": "1.1.1d-0+deb10u6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.8,
-            "exploitability_score": 8.6,
-            "impact_score": 4.9,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2007-6755",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2007-6755"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2007-6755",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2007-6755"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "/sandbox/target/my-app-1.jar:guava",
-      "name": "guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-03-31T17:30:52Z",
-      "versions": [
-        "30.0-jre"
-      ],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 3.3,
-            "exploitability_score": 1.8,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2020-8908"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "github:java",
-      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
-      "severity": "Medium",
-      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "apt",
-      "pkg_type": "dpkg",
-      "version": "1.8.2.2"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 3.7,
-            "exploitability_score": 2.2,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2011-3374",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2011-3374"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2011-3374",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2011-3374"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libpython3.7-minimal",
-      "pkg_type": "dpkg",
-      "version": "3.7.3-2+deb10u3"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 6.8,
-            "exploitability_score": 8.6,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 8.8,
-            "exploitability_score": 2.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-17522",
-        "severity": "High",
-        "vulnerability_id": "CVE-2017-17522"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-17522"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "xdg-user-dirs",
-      "pkg_type": "dpkg",
-      "version": "0.17-2"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.6,
-            "exploitability_score": 3.9,
-            "impact_score": 6.4,
-            "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.8,
-            "exploitability_score": 1.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-15131",
-        "severity": "High",
-        "vulnerability_id": "CVE-2017-15131"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-15131",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-15131"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "passwd",
-      "pkg_type": "dpkg",
-      "version": "1:4.5-1.1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.9,
-            "exploitability_score": 3.9,
-            "impact_score": 6.9,
-            "vector": "AV:L/AC:L/Au:N/C:C/I:N/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2007-5686",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2007-5686"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2007-5686",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2007-5686"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "python2.7-minimal",
-      "pkg_type": "dpkg",
-      "version": "2.7.16-2+deb10u1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
+      "detected_at": "2021-06-02T02:45:55Z"
     },
     "nvd": [
       {
         "cvss": [
           {
             "base_score": 4.0,
-            "exploitability_score": 4.9,
-            "impact_score": 4.9,
-            "vector": "AV:N/AC:H/Au:N/C:N/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.9,
-            "exploitability_score": 1.6,
-            "impact_score": 4.2,
-            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-23336",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2021-23336"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2021-23336",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2021-23336"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc-bin",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
+            "exploitability_score": 8.0,
             "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
+            "vector": "AV:N/AC:L/Au:S/C:N/I:N/A:P",
             "version": "2.0"
-          },
-          {
-            "base_score": 5.3,
-            "exploitability_score": 3.9,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
-            "version": "3.0"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010025",
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-4756",
         "severity": "Medium",
-        "vulnerability_id": "CVE-2019-1010025"
+        "vulnerability_id": "CVE-2010-4756"
       }
     ],
     "vulnerability": {
@@ -2948,610 +781,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010025",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4756",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-1010025"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libnss-systemd",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 6.2,
-            "exploitability_score": 1.9,
-            "impact_score": 10.0,
-            "vector": "AV:L/AC:H/Au:N/C:C/I:C/A:C",
-            "version": "2.0"
-          },
-          {
-            "base_score": 6.7,
-            "exploitability_score": 0.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13776",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2020-13776"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-13776"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "/usr/local/lib/python3.7/dist-packages/aiohttp",
-      "name": "aiohttp",
-      "pkg_type": "python",
-      "version": "3.7.3"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-03-31T17:30:49Z",
-      "versions": [
-        "3.7.4"
-      ],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.8,
-            "exploitability_score": 8.6,
-            "impact_score": 4.9,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 6.1,
-            "exploitability_score": 2.8,
-            "impact_score": 2.7,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21330",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2021-21330"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "github:python",
-      "link": "https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
-      "severity": "Low",
-      "vulnerability_id": "GHSA-v6wp-4m6f-gcjg"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libldap-common",
-      "pkg_type": "dpkg",
-      "version": "2.4.47+dfsg-3+deb10u6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-3276",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2015-3276"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2015-3276",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2015-3276"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc6",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9192",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-9192"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9192",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-9192"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc6",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-4052",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2010-4052"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4052",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2010-4052"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libsystemd0",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 2.4,
-            "exploitability_score": 0.9,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-20386",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2019-20386"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-20386"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "systemd",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 6.2,
-            "exploitability_score": 1.9,
-            "impact_score": 10.0,
-            "vector": "AV:L/AC:H/Au:N/C:C/I:C/A:C",
-            "version": "2.0"
-          },
-          {
-            "base_score": 6.7,
-            "exploitability_score": 0.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13776",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2020-13776"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-13776"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libgnutls30",
-      "pkg_type": "dpkg",
-      "version": "3.6.7-4+deb10u6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2011-3389",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2011-3389"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2011-3389",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2011-3389"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "cpe:a:ftpd:ftpd:0.2.1:*:*",
-      "cpes": [
-        "cpe:2.3:a:ftpd:ftpd:0.2.1:*:*:-:-:-:-:-"
-      ],
-      "location": "/var/lib/gems/2.5.0/specifications/ftpd-0.2.1.gemspec",
-      "name": "ftpd",
-      "pkg_type": "gem",
-      "version": "0.2.1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-03-31T17:11:12Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 10.0,
-          "exploitability_score": 10.0,
-          "impact_score": 10.0,
-          "vector": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
-          "version": "2.0"
-        },
-        {
-          "base_score": 9.8,
-          "exploitability_score": 3.9,
-          "impact_score": 5.9,
-          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-          "version": "3.1"
-        }
-      ],
-      "description": null,
-      "feed": "nvdv2",
-      "feed_group": "nvdv2:cves",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
-      "severity": "Critical",
-      "vulnerability_id": "CVE-2013-2512"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libnss-systemd",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 2.4,
-            "exploitability_score": 0.9,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-20386",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2019-20386"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-20386"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "/sandbox/target/my-app-1.jar:guava",
-      "name": "guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2020-06-16T09:10:15Z",
-      "versions": [
-        "24.1.1-jre"
-      ],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2018-10237"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "github:java",
-      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
-      "severity": "Medium",
-      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libpython2.7-minimal",
-      "pkg_type": "dpkg",
-      "version": "2.7.16-2+deb10u1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9674",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-9674"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-9674"
+      "vulnerability_id": "CVE-2010-4756"
     }
   },
   {
@@ -3570,7 +802,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
+      "detected_at": "2021-06-02T02:45:55Z"
     },
     "nvd": [
       {
@@ -3611,6 +843,504 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
+      "name": "login",
+      "pkg_type": "dpkg",
+      "version": "1:4.5-1.1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 6.9,
+            "exploitability_score": 3.4,
+            "impact_score": 10.0,
+            "vector": "AV:L/AC:M/Au:N/C:C/I:C/A:C",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.8,
+            "exploitability_score": 1.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-19882",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-19882"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-19882",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-19882"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "python2.7-minimal",
+      "pkg_type": "dpkg",
+      "version": "2.7.16-2+deb10u1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.0,
+            "exploitability_score": 4.9,
+            "impact_score": 4.9,
+            "vector": "AV:N/AC:H/Au:N/C:N/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 5.9,
+            "exploitability_score": 1.6,
+            "impact_score": 4.2,
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-23336",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2021-23336"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2021-23336",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2021-23336"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "tar",
+      "pkg_type": "dpkg",
+      "version": "1.30+dfsg-6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-20193",
+        "severity": "Unknown",
+        "vulnerability_id": "CVE-2021-20193"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2021-20193",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2021-20193"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libpython3.7-minimal",
+      "pkg_type": "dpkg",
+      "version": "3.7.3-2+deb10u3"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9674",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-9674"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-9674"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libpython2.7-minimal",
+      "pkg_type": "dpkg",
+      "version": "2.7.16-2+deb10u1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 6.1,
+            "exploitability_score": 2.8,
+            "impact_score": 2.7,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-18348",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2019-18348"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-18348"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libpython2.7-minimal",
+      "pkg_type": "dpkg",
+      "version": "2.7.16-2+deb10u1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 6.8,
+            "exploitability_score": 8.6,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 8.8,
+            "exploitability_score": 2.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-17522",
+        "severity": "High",
+        "vulnerability_id": "CVE-2017-17522"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-17522"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libpcre3",
+      "pkg_type": "dpkg",
+      "version": "2:8.39-12"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 7.8,
+            "exploitability_score": 10.0,
+            "impact_score": 6.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:C",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-11164",
+        "severity": "High",
+        "vulnerability_id": "CVE-2017-11164"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-11164",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-11164"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "login",
+      "pkg_type": "dpkg",
+      "version": "1:4.5-1.1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.9,
+            "exploitability_score": 3.9,
+            "impact_score": 6.9,
+            "vector": "AV:L/AC:L/Au:N/C:C/I:N/A:N",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2007-5686",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2007-5686"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2007-5686",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2007-5686"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "perl",
+      "pkg_type": "dpkg",
+      "version": "5.28.1-6+deb10u1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2011-4116",
+        "severity": "High",
+        "vulnerability_id": "CVE-2011-4116"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2011-4116",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2011-4116"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libudev1",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 2.4,
+            "exploitability_score": 0.9,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-20386",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2019-20386"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-20386"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
       "name": "systemd",
       "pkg_type": "dpkg",
       "version": "241-7~deb10u7"
@@ -3622,7 +1352,747 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 3.3,
+            "exploitability_score": 3.4,
+            "impact_score": 4.9,
+            "vector": "AV:L/AC:M/Au:N/C:P/I:P/A:N",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-4392",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2013-4392"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2013-4392"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libc-bin",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-4052",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2010-4052"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4052",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2010-4052"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "tar",
+      "pkg_type": "dpkg",
+      "version": "1.30+dfsg-6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9923",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-9923"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9923",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-9923"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "openssl",
+      "pkg_type": "dpkg",
+      "version": "1.1.1d-0+deb10u6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.8,
+            "exploitability_score": 8.6,
+            "impact_score": 4.9,
+            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:N",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2007-6755",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2007-6755"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2007-6755",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2007-6755"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libc6",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9192",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-9192"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9192",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-9192"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libssl1.1",
+      "pkg_type": "dpkg",
+      "version": "1.1.1d-0+deb10u6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.8,
+            "exploitability_score": 8.6,
+            "impact_score": 4.9,
+            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:N",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2007-6755",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2007-6755"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2007-6755",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2007-6755"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libpython2.7-minimal",
+      "pkg_type": "dpkg",
+      "version": "2.7.16-2+deb10u1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-7040",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2013-7040"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-7040",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2013-7040"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libc-bin",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 6.8,
+            "exploitability_score": 8.6,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 8.8,
+            "exploitability_score": 2.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010023",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-1010023"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010023",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-1010023"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libc6",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 6.8,
+            "exploitability_score": 8.6,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 8.8,
+            "exploitability_score": 2.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010023",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-1010023"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010023",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-1010023"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "python3.7-minimal",
+      "pkg_type": "dpkg",
+      "version": "3.7.3-2+deb10u3"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 7.5,
+            "exploitability_score": 10.0,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 9.8,
+            "exploitability_score": 3.9,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-27619",
+        "severity": "Critical",
+        "vulnerability_id": "CVE-2020-27619"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-27619",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2020-27619"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libc6",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 5.3,
+            "exploitability_score": 3.9,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010025",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2019-1010025"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010025",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-1010025"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "passwd",
+      "pkg_type": "dpkg",
+      "version": "1:4.5-1.1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.9,
+            "exploitability_score": 3.9,
+            "impact_score": 6.9,
+            "vector": "AV:L/AC:L/Au:N/C:C/I:N/A:N",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2007-5686",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2007-5686"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2007-5686",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2007-5686"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/sandbox/target/my-app-1.jar:guava",
+      "name": "guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2020-06-16T09:10:15Z",
+      "versions": [
+        "24.1.1-jre"
+      ],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 5.9,
+            "exploitability_score": 2.2,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2018-10237"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "python3.7-minimal",
+      "pkg_type": "dpkg",
+      "version": "3.7.3-2+deb10u3"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9674",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-9674"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-9674"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "passwd",
+      "pkg_type": "dpkg",
+      "version": "1:4.5-1.1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 6.9,
+            "exploitability_score": 3.4,
+            "impact_score": 10.0,
+            "vector": "AV:L/AC:M/Au:N/C:C/I:C/A:C",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.8,
+            "exploitability_score": 1.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-19882",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-19882"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-19882",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-19882"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "systemd",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
     },
     "nvd": [
       {
@@ -3674,7 +2144,671 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 7.5,
+            "exploitability_score": 10.0,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 9.8,
+            "exploitability_score": 3.9,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010022",
+        "severity": "Critical",
+        "vulnerability_id": "CVE-2019-1010022"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010022",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-1010022"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libssl1.1",
+      "pkg_type": "dpkg",
+      "version": "1.1.1d-0+deb10u6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.0,
+            "exploitability_score": 1.9,
+            "impact_score": 6.9,
+            "vector": "AV:L/AC:H/Au:N/C:C/I:N/A:N",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-0928",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2010-0928"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-0928",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2010-0928"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "coreutils",
+      "pkg_type": "dpkg",
+      "version": "8.30-3"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 1.9,
+            "exploitability_score": 3.4,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:M/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 4.7,
+            "exploitability_score": 1.0,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:H/A:N",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-18018",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2017-18018"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-18018",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-18018"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libpython3.7-minimal",
+      "pkg_type": "dpkg",
+      "version": "3.7.3-2+deb10u3"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 7.5,
+            "exploitability_score": 10.0,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 9.8,
+            "exploitability_score": 3.9,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-27619",
+        "severity": "Critical",
+        "vulnerability_id": "CVE-2020-27619"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-27619",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2020-27619"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "apt",
+      "pkg_type": "dpkg",
+      "version": "1.8.2.2"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 3.7,
+            "exploitability_score": 2.2,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2011-3374",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2011-3374"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2011-3374",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2011-3374"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libsystemd0",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 2.4,
+            "exploitability_score": 0.9,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-20386",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2019-20386"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-20386"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libc6",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 5.3,
+            "exploitability_score": 3.9,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010024",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2019-1010024"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010024",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-1010024"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libc-bin",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-20796",
+        "severity": "High",
+        "vulnerability_id": "CVE-2018-20796"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2018-20796",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2018-20796"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/usr/local/lib/python3.7/dist-packages/aiohttp",
+      "name": "aiohttp",
+      "pkg_type": "python",
+      "version": "3.7.3"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-03-31T17:30:49Z",
+      "versions": [
+        "3.7.4"
+      ],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.8,
+            "exploitability_score": 8.6,
+            "impact_score": 4.9,
+            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 6.1,
+            "exploitability_score": 2.8,
+            "impact_score": 2.7,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21330",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2021-21330"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "github:python",
+      "link": "https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
+      "severity": "Low",
+      "vulnerability_id": "GHSA-v6wp-4m6f-gcjg"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "python3.7-minimal",
+      "pkg_type": "dpkg",
+      "version": "3.7.3-2+deb10u3"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 6.1,
+            "exploitability_score": 2.8,
+            "impact_score": 2.7,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-18348",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2019-18348"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-18348"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "bash",
+      "pkg_type": "dpkg",
+      "version": "5.0-4"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 7.2,
+            "exploitability_score": 3.9,
+            "impact_score": 10.0,
+            "vector": "AV:L/AC:L/Au:N/C:C/I:C/A:C",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.8,
+            "exploitability_score": 1.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-18276",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-18276"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18276",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-18276"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libpcre3",
+      "pkg_type": "dpkg",
+      "version": "2:8.39-12"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-20838",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-20838"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20838",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-20838"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "tar",
+      "pkg_type": "dpkg",
+      "version": "1.30+dfsg-6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 10.0,
+            "exploitability_score": 10.0,
+            "impact_score": 10.0,
+            "vector": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2005-2541",
+        "severity": "High",
+        "vulnerability_id": "CVE-2005-2541"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2005-2541",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2005-2541"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "python2.7-minimal",
+      "pkg_type": "dpkg",
+      "version": "2.7.16-2+deb10u1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
     },
     "nvd": [
       {
@@ -3695,9 +2829,9 @@
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010023",
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-17522",
         "severity": "High",
-        "vulnerability_id": "CVE-2019-1010023"
+        "vulnerability_id": "CVE-2017-17522"
       }
     ],
     "vulnerability": {
@@ -3705,9 +2839,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010023",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-1010023"
+      "vulnerability_id": "CVE-2017-17522"
     }
   },
   {
@@ -3726,104 +2860,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.0,
-            "exploitability_score": 8.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:S/C:N/I:N/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-4756",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2010-4756"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4756",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2010-4756"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libpcre3",
-      "pkg_type": "dpkg",
-      "version": "2:8.39-12"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.8,
-            "exploitability_score": 10.0,
-            "impact_score": 6.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:C",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-11164",
-        "severity": "High",
-        "vulnerability_id": "CVE-2017-11164"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-11164",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-11164"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc6",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
+      "detected_at": "2021-06-02T02:45:55Z"
     },
     "nvd": [
       {
@@ -3875,30 +2912,174 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-3276",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2015-3276"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2015-3276",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2015-3276"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "perl-base",
+      "pkg_type": "dpkg",
+      "version": "5.28.1-6+deb10u1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2011-4116",
+        "severity": "High",
+        "vulnerability_id": "CVE-2011-4116"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2011-4116",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2011-4116"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "cpe:a:ftpd:ftpd:0.2.1:*:*",
+      "cpes": [
+        "cpe:2.3:a:ftpd:ftpd:0.2.1:*:*:-:-:-:-:-"
+      ],
+      "location": "/var/lib/gems/2.5.0/specifications/ftpd-0.2.1.gemspec",
+      "name": "ftpd",
+      "pkg_type": "gem",
+      "version": "0.2.1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-03-31T17:11:12Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 10.0,
+            "exploitability_score": 10.0,
+            "impact_score": 10.0,
+            "vector": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+            "version": "2.0"
+          },
+          {
+            "base_score": 9.8,
+            "exploitability_score": 3.9,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
+        "severity": "Critical",
+        "vulnerability_id": "CVE-2013-2512"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "nvdv2",
+      "feed_group": "nvdv2:cves",
+      "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
+      "severity": "Critical",
+      "vulnerability_id": "CVE-2013-2512"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "openssl",
+      "pkg_type": "dpkg",
+      "version": "1.1.1d-0+deb10u6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
     },
     "nvd": [
       {
         "cvss": [
           {
             "base_score": 4.0,
-            "exploitability_score": 4.9,
-            "impact_score": 4.9,
-            "vector": "AV:N/AC:H/Au:N/C:P/I:P/A:N",
+            "exploitability_score": 1.9,
+            "impact_score": 6.9,
+            "vector": "AV:L/AC:H/Au:N/C:C/I:N/A:N",
             "version": "2.0"
-          },
-          {
-            "base_score": 4.2,
-            "exploitability_score": 1.6,
-            "impact_score": 2.5,
-            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:N",
-            "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-15719",
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-0928",
         "severity": "Medium",
-        "vulnerability_id": "CVE-2020-15719"
+        "vulnerability_id": "CVE-2010-0928"
       }
     ],
     "vulnerability": {
@@ -3906,9 +3087,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-15719",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-0928",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-15719"
+      "vulnerability_id": "CVE-2010-0928"
     }
   },
   {
@@ -3916,9 +3097,9 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "passwd",
+      "name": "libc-bin",
       "pkg_type": "dpkg",
-      "version": "1:4.5-1.1"
+      "version": "2.28-10"
     },
     "fix": {
       "advisories": [],
@@ -3927,136 +3108,30 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
+      "detected_at": "2021-06-02T02:45:55Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 6.9,
-            "exploitability_score": 3.4,
-            "impact_score": 10.0,
-            "vector": "AV:L/AC:M/Au:N/C:C/I:C/A:C",
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
             "version": "2.0"
           },
           {
-            "base_score": 7.8,
-            "exploitability_score": 1.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-19882",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-19882"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-19882",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-19882"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "/sandbox/target/original-my-app-1.jar:guava",
-      "name": "guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-03-31T17:30:52Z",
-      "versions": [
-        "30.0-jre"
-      ],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 2.1,
+            "base_score": 5.3,
             "exploitability_score": 3.9,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 3.3,
-            "exploitability_score": 1.8,
             "impact_score": 1.4,
-            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2020-8908"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "github:java",
-      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
-      "severity": "Medium",
-      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libldap-common",
-      "pkg_type": "dpkg",
-      "version": "2.4.47+dfsg-3+deb10u6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 1.9,
-            "exploitability_score": 3.4,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:M/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 4.7,
-            "exploitability_score": 1.0,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
             "version": "3.0"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-14159",
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010025",
         "severity": "Medium",
-        "vulnerability_id": "CVE-2017-14159"
+        "vulnerability_id": "CVE-2019-1010025"
       }
     ],
     "vulnerability": {
@@ -4064,9 +3139,54 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-14159",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010025",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-14159"
+      "vulnerability_id": "CVE-2019-1010025"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libc-bin",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-4051",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2010-4051"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4051",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2010-4051"
     }
   },
   {
@@ -4085,7 +3205,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
+      "detected_at": "2021-06-02T02:45:55Z"
     },
     "nvd": [
       {
@@ -4119,7 +3239,7 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "libpython2.7-minimal",
+      "name": "python2.7-minimal",
       "pkg_type": "dpkg",
       "version": "2.7.16-2+deb10u1"
     },
@@ -4130,7 +3250,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
+      "detected_at": "2021-06-02T02:45:55Z"
     },
     "nvd": [
       {
@@ -4171,9 +3291,9 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "libssl1.1",
+      "name": "libglib2.0-0",
       "pkg_type": "dpkg",
-      "version": "1.1.1d-0+deb10u6"
+      "version": "2.58.3-2+deb10u2"
     },
     "fix": {
       "advisories": [],
@@ -4182,208 +3302,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.0,
-            "exploitability_score": 1.9,
-            "impact_score": 6.9,
-            "vector": "AV:L/AC:H/Au:N/C:C/I:N/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-0928",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2010-0928"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2010-0928",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2010-0928"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libsystemd0",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 6.2,
-            "exploitability_score": 1.9,
-            "impact_score": 10.0,
-            "vector": "AV:L/AC:H/Au:N/C:C/I:C/A:C",
-            "version": "2.0"
-          },
-          {
-            "base_score": 6.7,
-            "exploitability_score": 0.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13776",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2020-13776"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-13776"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "perl",
-      "pkg_type": "dpkg",
-      "version": "5.28.1-6+deb10u1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2011-4116",
-        "severity": "High",
-        "vulnerability_id": "CVE-2011-4116"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2011-4116",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2011-4116"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "passwd",
-      "pkg_type": "dpkg",
-      "version": "1:4.5-1.1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 3.3,
-            "exploitability_score": 3.4,
-            "impact_score": 4.9,
-            "vector": "AV:L/AC:M/Au:N/C:N/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 4.7,
-            "exploitability_score": 1.0,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:H/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-4235",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2013-4235"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4235",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2013-4235"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc-bin",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
+      "detected_at": "2021-06-02T02:45:55Z"
     },
     "nvd": [
       {
@@ -4397,9 +3316,9 @@
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-4052",
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2012-0039",
         "severity": "Medium",
-        "vulnerability_id": "CVE-2010-4052"
+        "vulnerability_id": "CVE-2012-0039"
       }
     ],
     "vulnerability": {
@@ -4407,9 +3326,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4052",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2012-0039",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2010-4052"
+      "vulnerability_id": "CVE-2012-0039"
     }
   },
   {
@@ -4417,7 +3336,59 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "python3.7-minimal",
+      "name": "libldap-common",
+      "pkg_type": "dpkg",
+      "version": "2.4.47+dfsg-3+deb10u6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.0,
+            "exploitability_score": 4.9,
+            "impact_score": 4.9,
+            "vector": "AV:N/AC:H/Au:N/C:P/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 4.2,
+            "exploitability_score": 1.6,
+            "impact_score": 2.5,
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-15719",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2020-15719"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-15719",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2020-15719"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libpython3.7-minimal",
       "pkg_type": "dpkg",
       "version": "3.7.3-2+deb10u3"
     },
@@ -4428,7 +3399,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
+      "detected_at": "2021-06-02T02:45:55Z"
     },
     "nvd": [
       {
@@ -4469,6 +3440,51 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
+      "name": "libnss-systemd",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 3.3,
+            "exploitability_score": 3.4,
+            "impact_score": 4.9,
+            "vector": "AV:L/AC:M/Au:N/C:P/I:P/A:N",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-4392",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2013-4392"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2013-4392"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
       "name": "python2.7-minimal",
       "pkg_type": "dpkg",
       "version": "2.7.16-2+deb10u1"
@@ -4480,23 +3496,30 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
+      "detected_at": "2021-06-02T02:45:55Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
             "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
             "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-7040",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2013-7040"
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9674",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-9674"
       }
     ],
     "vulnerability": {
@@ -4504,9 +3527,165 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-7040",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2013-7040"
+      "vulnerability_id": "CVE-2019-9674"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libldap-common",
+      "pkg_type": "dpkg",
+      "version": "2.4.47+dfsg-3+deb10u6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 1.9,
+            "exploitability_score": 3.4,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:M/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 4.7,
+            "exploitability_score": 1.0,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-14159",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2017-14159"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-14159",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-14159"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libnss-systemd",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 2.4,
+            "exploitability_score": 0.9,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-20386",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2019-20386"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-20386"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "xdg-user-dirs",
+      "pkg_type": "dpkg",
+      "version": "0.17-2"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.6,
+            "exploitability_score": 3.9,
+            "impact_score": 6.4,
+            "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.8,
+            "exploitability_score": 1.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-15131",
+        "severity": "High",
+        "vulnerability_id": "CVE-2017-15131"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-15131",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-15131"
     }
   },
   {
@@ -4525,30 +3704,30 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
+      "detected_at": "2021-06-02T02:45:55Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 4.0,
-            "exploitability_score": 4.9,
-            "impact_score": 4.9,
-            "vector": "AV:N/AC:H/Au:N/C:N/I:P/A:P",
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
             "version": "2.0"
           },
           {
-            "base_score": 5.9,
-            "exploitability_score": 1.6,
-            "impact_score": 4.2,
-            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:H",
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
             "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-23336",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2021-23336"
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9674",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-9674"
       }
     ],
     "vulnerability": {
@@ -4556,9 +3735,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2021-23336",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2021-23336"
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-9674"
     }
   },
   {
@@ -4577,30 +3756,30 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
+      "detected_at": "2021-06-02T02:45:55Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 7.5,
-            "exploitability_score": 10.0,
+            "base_score": 6.8,
+            "exploitability_score": 8.6,
             "impact_score": 6.4,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
             "version": "2.0"
           },
           {
-            "base_score": 9.8,
-            "exploitability_score": 3.9,
+            "base_score": 8.8,
+            "exploitability_score": 2.8,
             "impact_score": 5.9,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.1"
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.0"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-27619",
-        "severity": "Critical",
-        "vulnerability_id": "CVE-2020-27619"
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-17522",
+        "severity": "High",
+        "vulnerability_id": "CVE-2017-17522"
       }
     ],
     "vulnerability": {
@@ -4608,9 +3787,361 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-27619",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-27619"
+      "vulnerability_id": "CVE-2017-17522"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libtasn1-6",
+      "pkg_type": "dpkg",
+      "version": "4.13-3"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 7.1,
+            "exploitability_score": 8.6,
+            "impact_score": 6.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:C",
+            "version": "2.0"
+          },
+          {
+            "base_score": 5.5,
+            "exploitability_score": 1.8,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-1000654",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2018-1000654"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2018-1000654",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2018-1000654"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libgssapi-krb5-2",
+      "pkg_type": "dpkg",
+      "version": "1.17-3+deb10u1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:L/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2004-0971",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2004-0971"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2004-0971",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2004-0971"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libgcrypt20",
+      "pkg_type": "dpkg",
+      "version": "1.8.4-5"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-6829",
+        "severity": "High",
+        "vulnerability_id": "CVE-2018-6829"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2018-6829",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2018-6829"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/sandbox/target/original-my-app-1.jar:guava",
+      "name": "guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-03-31T17:30:52Z",
+      "versions": [
+        "30.0-jre"
+      ],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 3.3,
+            "exploitability_score": 1.8,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2020-8908"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "passwd",
+      "pkg_type": "dpkg",
+      "version": "1:4.5-1.1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 3.3,
+            "exploitability_score": 3.4,
+            "impact_score": 4.9,
+            "vector": "AV:L/AC:M/Au:N/C:N/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 4.7,
+            "exploitability_score": 1.0,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:H/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-4235",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2013-4235"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4235",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2013-4235"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "python",
+      "pkg_type": "dpkg",
+      "version": "2.7.16-1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 7.2,
+            "exploitability_score": 3.9,
+            "impact_score": 10.0,
+            "vector": "AV:L/AC:L/Au:N/C:C/I:C/A:C",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2008-4108",
+        "severity": "High",
+        "vulnerability_id": "CVE-2008-4108"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2008-4108",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2008-4108"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libgssapi-krb5-2",
+      "pkg_type": "dpkg",
+      "version": "1.17-3+deb10u1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-5709",
+        "severity": "High",
+        "vulnerability_id": "CVE-2018-5709"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2018-5709",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2018-5709"
     }
   },
   {
@@ -4629,7 +4160,111 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:08Z"
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 7.5,
+            "exploitability_score": 10.0,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 9.8,
+            "exploitability_score": 3.9,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010022",
+        "severity": "Critical",
+        "vulnerability_id": "CVE-2019-1010022"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010022",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-1010022"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "login",
+      "pkg_type": "dpkg",
+      "version": "1:4.5-1.1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 3.3,
+            "exploitability_score": 3.4,
+            "impact_score": 4.9,
+            "vector": "AV:L/AC:M/Au:N/C:N/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 4.7,
+            "exploitability_score": 1.0,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:H/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-4235",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2013-4235"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4235",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2013-4235"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libldap-common",
+      "pkg_type": "dpkg",
+      "version": "2.4.47+dfsg-3+deb10u6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
     },
     "nvd": [
       {
@@ -4640,12 +4275,19 @@
             "impact_score": 2.9,
             "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
             "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.0"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-4051",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2010-4051"
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-17740",
+        "severity": "High",
+        "vulnerability_id": "CVE-2017-17740"
       }
     ],
     "vulnerability": {
@@ -4653,9 +4295,375 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4051",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17740",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2010-4051"
+      "vulnerability_id": "CVE-2017-17740"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libseccomp2",
+      "pkg_type": "dpkg",
+      "version": "2.3.3-4"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 7.5,
+            "exploitability_score": 10.0,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 9.8,
+            "exploitability_score": 3.9,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9893",
+        "severity": "Critical",
+        "vulnerability_id": "CVE-2019-9893"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9893",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-9893"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libglib2.0-0",
+      "pkg_type": "dpkg",
+      "version": "2.58.3-2+deb10u2"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.6,
+            "exploitability_score": 3.9,
+            "impact_score": 6.4,
+            "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.8,
+            "exploitability_score": 1.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-35457",
+        "severity": "High",
+        "vulnerability_id": "CVE-2020-35457"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-35457",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2020-35457"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "systemd",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 6.2,
+            "exploitability_score": 1.9,
+            "impact_score": 10.0,
+            "vector": "AV:L/AC:H/Au:N/C:C/I:C/A:C",
+            "version": "2.0"
+          },
+          {
+            "base_score": 6.7,
+            "exploitability_score": 0.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13776",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2020-13776"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2020-13776"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libpython3.7-minimal",
+      "pkg_type": "dpkg",
+      "version": "3.7.3-2+deb10u3"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 6.1,
+            "exploitability_score": 2.8,
+            "impact_score": 2.7,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-18348",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2019-18348"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-18348"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libc-bin",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9192",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-9192"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9192",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-9192"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libc6",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-20796",
+        "severity": "High",
+        "vulnerability_id": "CVE-2018-20796"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2018-20796",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2018-20796"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/sandbox/target/my-app-1.jar:guava",
+      "name": "guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-03-31T17:30:52Z",
+      "versions": [
+        "30.0-jre"
+      ],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:55Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 3.3,
+            "exploitability_score": 1.8,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2020-8908"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
     }
   }
 ]

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:80a31c3ce2e99c3691c27ac3b1753163214494e9b2ca07bfdccf29a5cca2bfbe.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:80a31c3ce2e99c3691c27ac3b1753163214494e9b2ca07bfdccf29a5cca2bfbe.json
@@ -3,107 +3,7 @@
     "artifact": {
       "cpe": null,
       "cpes": [],
-      "location": "/sandbox/node_modules/xmldom/package.json",
-      "name": "xmldom",
-      "pkg_type": "npm",
-      "version": "0.4.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-03-31T17:30:47Z",
-      "versions": [
-        "0.5.0"
-      ],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:06Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 4.3,
-            "exploitability_score": 2.8,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21366",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2021-21366"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "github:npm",
-      "link": "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv",
-      "severity": "Low",
-      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "cpe:a:ftpd:ftpd:0.2.1:*:*",
-      "cpes": [
-        "cpe:2.3:a:ftpd:ftpd:0.2.1:*:*:-:-:-:-:-"
-      ],
-      "location": "/usr/lib/ruby/gems/2.7.0/specifications/ftpd-0.2.1.gemspec",
-      "name": "ftpd",
-      "pkg_type": "gem",
-      "version": "0.2.1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-03-31T17:11:12Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 10.0,
-          "exploitability_score": 10.0,
-          "impact_score": 10.0,
-          "vector": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
-          "version": "2.0"
-        },
-        {
-          "base_score": 9.8,
-          "exploitability_score": 3.9,
-          "impact_score": 5.9,
-          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-          "version": "3.1"
-        }
-      ],
-      "description": null,
-      "feed": "nvdv2",
-      "feed_group": "nvdv2:cves",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
-      "severity": "Critical",
-      "vulnerability_id": "CVE-2013-2512"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "/sandbox/target/my-app-1.jar:guava",
+      "location": "/sandbox/target/original-my-app-1.jar:guava",
       "name": "guava",
       "pkg_type": "java",
       "version": "23.0"
@@ -117,7 +17,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:06Z"
+      "detected_at": "2021-06-02T02:45:53Z"
     },
     "nvd": [
       {
@@ -157,7 +57,61 @@
     "artifact": {
       "cpe": null,
       "cpes": [],
-      "location": "/sandbox/target/my-app-1.jar:guava",
+      "location": "/sandbox/node_modules/xmldom/package.json",
+      "name": "xmldom",
+      "pkg_type": "npm",
+      "version": "0.4.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-03-31T17:30:47Z",
+      "versions": [
+        "0.5.0"
+      ],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:53Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 4.3,
+            "exploitability_score": 2.8,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21366",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2021-21366"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "github:npm",
+      "link": "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv",
+      "severity": "Low",
+      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/sandbox/target/original-my-app-1.jar:guava",
       "name": "guava",
       "pkg_type": "java",
       "version": "23.0"
@@ -171,7 +125,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:06Z"
+      "detected_at": "2021-06-02T02:45:53Z"
     },
     "nvd": [
       {
@@ -211,7 +165,7 @@
     "artifact": {
       "cpe": null,
       "cpes": [],
-      "location": "/sandbox/target/original-my-app-1.jar:guava",
+      "location": "/sandbox/target/my-app-1.jar:guava",
       "name": "guava",
       "pkg_type": "java",
       "version": "23.0"
@@ -225,7 +179,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:06Z"
+      "detected_at": "2021-06-02T02:45:53Z"
     },
     "nvd": [
       {
@@ -265,7 +219,7 @@
     "artifact": {
       "cpe": null,
       "cpes": [],
-      "location": "/sandbox/target/original-my-app-1.jar:guava",
+      "location": "/sandbox/target/my-app-1.jar:guava",
       "name": "guava",
       "pkg_type": "java",
       "version": "23.0"
@@ -279,7 +233,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:06Z"
+      "detected_at": "2021-06-02T02:45:53Z"
     },
     "nvd": [
       {
@@ -333,7 +287,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:06Z"
+      "detected_at": "2021-06-02T02:45:53Z"
     },
     "nvd": [
       {
@@ -367,6 +321,60 @@
       "link": "https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
       "severity": "Low",
       "vulnerability_id": "GHSA-v6wp-4m6f-gcjg"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "cpe:a:ftpd:ftpd:0.2.1:*:*",
+      "cpes": [
+        "cpe:2.3:a:ftpd:ftpd:0.2.1:*:*:-:-:-:-:-"
+      ],
+      "location": "/usr/lib/ruby/gems/2.7.0/specifications/ftpd-0.2.1.gemspec",
+      "name": "ftpd",
+      "pkg_type": "gem",
+      "version": "0.2.1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-03-31T17:11:12Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 10.0,
+            "exploitability_score": 10.0,
+            "impact_score": 10.0,
+            "vector": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+            "version": "2.0"
+          },
+          {
+            "base_score": 9.8,
+            "exploitability_score": 3.9,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
+        "severity": "Critical",
+        "vulnerability_id": "CVE-2013-2512"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "nvdv2",
+      "feed_group": "nvdv2:cves",
+      "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
+      "severity": "Critical",
+      "vulnerability_id": "CVE-2013-2512"
     }
   }
 ]

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:fe3ca35038008b0eac0fa4e686bd072c9430000ab7d7853001bde5f5b8ccf60c.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:fe3ca35038008b0eac0fa4e686bd072c9430000ab7d7853001bde5f5b8ccf60c.json
@@ -4,9 +4,9 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "libgcrypt",
+      "name": "nss-tools",
       "pkg_type": "rpm",
-      "version": "1.5.3-14.el7"
+      "version": "3.53.1-3.el7_9"
     },
     "fix": {
       "advisories": [],
@@ -15,30 +15,30 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:10Z"
+      "detected_at": "2021-06-02T02:45:57Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 1.9,
-            "exploitability_score": 3.4,
+            "base_score": 1.2,
+            "exploitability_score": 1.9,
             "impact_score": 2.9,
-            "vector": "AV:L/AC:M/Au:N/C:P/I:N/A:N",
+            "vector": "AV:L/AC:H/Au:N/C:P/I:N/A:N",
             "version": "2.0"
           },
           {
-            "base_score": 4.2,
-            "exploitability_score": 0.5,
+            "base_score": 4.4,
+            "exploitability_score": 0.8,
             "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:P/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
+            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:N/A:N",
             "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-3591",
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-12399",
         "severity": "Medium",
-        "vulnerability_id": "CVE-2014-3591"
+        "vulnerability_id": "CVE-2020-12399"
       }
     ],
     "vulnerability": {
@@ -46,655 +46,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2014-3591",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2014-3591"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "glibc-common",
-      "pkg_type": "rpm",
-      "version": "2.17-323.el7_9"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:10Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.5,
-            "exploitability_score": 10.0,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-4043",
-        "severity": "High",
-        "vulnerability_id": "CVE-2014-4043"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2014-4043",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2014-4043"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "/sandbox/target/my-app-1.jar:guava",
-      "name": "guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2020-06-16T09:10:15Z",
-      "versions": [
-        "24.1.1-jre"
-      ],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:10Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2018-10237"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "github:java",
-      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
+      "link": "https://access.redhat.com/security/cve/CVE-2020-12399",
       "severity": "Medium",
-      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "/sandbox/target/original-my-app-1.jar:guava",
-      "name": "guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2020-06-16T09:10:15Z",
-      "versions": [
-        "24.1.1-jre"
-      ],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:10Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2018-10237"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "github:java",
-      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
-      "severity": "Medium",
-      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "/sandbox/node_modules/xmldom/package.json",
-      "name": "xmldom",
-      "pkg_type": "npm",
-      "version": "0.4.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-03-31T17:30:47Z",
-      "versions": [
-        "0.5.0"
-      ],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:10Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 4.3,
-            "exploitability_score": 2.8,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21366",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2021-21366"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "github:npm",
-      "link": "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv",
-      "severity": "Low",
-      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libgcrypt",
-      "pkg_type": "rpm",
-      "version": "1.5.3-14.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:10Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-5270",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2014-5270"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2014-5270",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2014-5270"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "gnupg2",
-      "pkg_type": "rpm",
-      "version": "2.0.22-5.el7_5"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:10Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-4617",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2014-4617"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2014-4617",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2014-4617"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "/sandbox/target/my-app-1.jar:guava",
-      "name": "guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-03-31T17:30:52Z",
-      "versions": [
-        "30.0-jre"
-      ],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:10Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 3.3,
-            "exploitability_score": 1.8,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2020-8908"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "github:java",
-      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
-      "severity": "Medium",
-      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:10Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-23841",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2021-23841"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2021-23841",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2021-23841"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "curl",
-      "pkg_type": "rpm",
-      "version": "7.29.0-59.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2020-11-11T09:10:27Z",
-      "versions": [
-        "0:7.29.0-59.el7_9.1"
-      ],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:10Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.6,
-            "exploitability_score": 3.9,
-            "impact_score": 6.4,
-            "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.1,
-            "exploitability_score": 1.8,
-            "impact_score": 5.2,
-            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8177",
-        "severity": "High",
-        "vulnerability_id": "CVE-2020-8177"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2020-8177",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2020-8177"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "/sandbox/target/original-my-app-1.jar:guava",
-      "name": "guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-03-31T17:30:52Z",
-      "versions": [
-        "30.0-jre"
-      ],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:10Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 3.3,
-            "exploitability_score": 1.8,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2020-8908"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "github:java",
-      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
-      "severity": "Medium",
-      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "glibc",
-      "pkg_type": "rpm",
-      "version": "2.17-323.el7_9"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:10Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.5,
-            "exploitability_score": 10.0,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-4043",
-        "severity": "High",
-        "vulnerability_id": "CVE-2014-4043"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2014-4043",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2014-4043"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libidn",
-      "pkg_type": "rpm",
-      "version": "1.28-4.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:10Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.5,
-            "exploitability_score": 10.0,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-2059",
-        "severity": "High",
-        "vulnerability_id": "CVE-2015-2059"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2015-2059",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2015-2059"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libcom_err",
-      "pkg_type": "rpm",
-      "version": "1.42.9-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:10Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.6,
-            "exploitability_score": 3.9,
-            "impact_score": 6.4,
-            "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-0247",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2015-0247"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2015-0247",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2015-0247"
+      "vulnerability_id": "CVE-2020-12399"
     }
   },
   {
@@ -715,7 +69,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:10Z"
+      "detected_at": "2021-06-02T02:45:57Z"
     },
     "nvd": [
       {
@@ -756,372 +110,6 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "nss",
-      "pkg_type": "rpm",
-      "version": "3.53.1-3.el7_9"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:10Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-25648",
-        "severity": "High",
-        "vulnerability_id": "CVE-2020-25648"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2020-25648",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2020-25648"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:10Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-23840",
-        "severity": "High",
-        "vulnerability_id": "CVE-2021-23840"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2021-23840",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2021-23840"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "/root/.npm/xmldom/0.4.0/package/package.json",
-      "name": "xmldom",
-      "pkg_type": "npm",
-      "version": "0.4.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-03-31T17:30:47Z",
-      "versions": [
-        "0.5.0"
-      ],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:10Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 4.3,
-            "exploitability_score": 2.8,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21366",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2021-21366"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "github:npm",
-      "link": "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv",
-      "severity": "Low",
-      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "nss-sysinit",
-      "pkg_type": "rpm",
-      "version": "3.53.1-3.el7_9"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:10Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 1.2,
-            "exploitability_score": 1.9,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:H/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 4.4,
-            "exploitability_score": 0.8,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:N/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-12399",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2020-12399"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2020-12399",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2020-12399"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "binutils",
-      "pkg_type": "rpm",
-      "version": "2.27-44.base.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:10Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 6.5,
-            "exploitability_score": 2.8,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-17450",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2019-17450"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2019-17450",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2019-17450"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "nss-tools",
-      "pkg_type": "rpm",
-      "version": "3.53.1-3.el7_9"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:10Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 1.2,
-            "exploitability_score": 1.9,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:H/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 4.4,
-            "exploitability_score": 0.8,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:N/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-12399",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2020-12399"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2020-12399",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2020-12399"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openldap",
-      "pkg_type": "rpm",
-      "version": "2.4.44-22.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:10Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-25692",
-        "severity": "High",
-        "vulnerability_id": "CVE-2020-25692"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2020-25692",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2020-25692"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
       "name": "python",
       "pkg_type": "rpm",
       "version": "2.7.5-89.el7"
@@ -1135,7 +123,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:10Z"
+      "detected_at": "2021-06-02T02:45:57Z"
     },
     "nvd": [
       {
@@ -1189,7 +177,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:10Z"
+      "detected_at": "2021-06-02T02:45:57Z"
     },
     "nvd": [
       {
@@ -1230,20 +218,268 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "openssl-libs",
+      "name": "binutils",
       "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
+      "version": "2.27-44.base.el7"
     },
     "fix": {
       "advisories": [],
-      "observed_at": "2020-12-19T09:16:55Z",
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:57Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 6.5,
+            "exploitability_score": 2.8,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-17450",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2019-17450"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "link": "https://access.redhat.com/security/cve/CVE-2019-17450",
+      "severity": "Low",
+      "vulnerability_id": "CVE-2019-17450"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libcom_err",
+      "pkg_type": "rpm",
+      "version": "1.42.9-19.el7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:57Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.6,
+            "exploitability_score": 3.9,
+            "impact_score": 6.4,
+            "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-0247",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2015-0247"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "link": "https://access.redhat.com/security/cve/CVE-2015-0247",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2015-0247"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libidn",
+      "pkg_type": "rpm",
+      "version": "1.28-4.el7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:57Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 7.5,
+            "exploitability_score": 10.0,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-2059",
+        "severity": "High",
+        "vulnerability_id": "CVE-2015-2059"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "link": "https://access.redhat.com/security/cve/CVE-2015-2059",
+      "severity": "Low",
+      "vulnerability_id": "CVE-2015-2059"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "nss-tools",
+      "pkg_type": "rpm",
+      "version": "3.53.1-3.el7_9"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:57Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-25648",
+        "severity": "High",
+        "vulnerability_id": "CVE-2020-25648"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "link": "https://access.redhat.com/security/cve/CVE-2020-25648",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2020-25648"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "cpe:a:ftpd:ftpd:0.2.1:*:*",
+      "cpes": [
+        "cpe:2.3:a:ftpd:ftpd:0.2.1:*:*:-:-:-:-:-"
+      ],
+      "location": "/usr/local/share/gems/specifications/ftpd-0.2.1.gemspec",
+      "name": "ftpd",
+      "pkg_type": "gem",
+      "version": "0.2.1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-03-31T17:11:12Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 10.0,
+            "exploitability_score": 10.0,
+            "impact_score": 10.0,
+            "vector": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+            "version": "2.0"
+          },
+          {
+            "base_score": 9.8,
+            "exploitability_score": 3.9,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
+        "severity": "Critical",
+        "vulnerability_id": "CVE-2013-2512"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "nvdv2",
+      "feed_group": "nvdv2:cves",
+      "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
+      "severity": "Critical",
+      "vulnerability_id": "CVE-2013-2512"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/sandbox/target/original-my-app-1.jar:guava",
+      "name": "guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2020-06-16T09:10:15Z",
       "versions": [
-        "1:1.0.2k-21.el7_9"
+        "24.1.1-jre"
       ],
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:10Z"
+      "detected_at": "2021-06-02T02:45:57Z"
     },
     "nvd": [
       {
@@ -1264,19 +500,19 @@
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-1971",
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
         "severity": "Medium",
-        "vulnerability_id": "CVE-2020-1971"
+        "vulnerability_id": "CVE-2018-10237"
       }
     ],
     "vulnerability": {
       "cvss": [],
       "description": null,
       "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2020-1971",
-      "severity": "High",
-      "vulnerability_id": "CVE-2020-1971"
+      "feed_group": "github:java",
+      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
     }
   },
   {
@@ -1284,9 +520,63 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "nss-tools",
+      "name": "curl",
       "pkg_type": "rpm",
-      "version": "3.53.1-3.el7_9"
+      "version": "7.29.0-59.el7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2020-11-11T09:10:27Z",
+      "versions": [
+        "0:7.29.0-59.el7_9.1"
+      ],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:57Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.6,
+            "exploitability_score": 3.9,
+            "impact_score": 6.4,
+            "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.1,
+            "exploitability_score": 1.8,
+            "impact_score": 5.2,
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8177",
+        "severity": "High",
+        "vulnerability_id": "CVE-2020-8177"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "link": "https://access.redhat.com/security/cve/CVE-2020-8177",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2020-8177"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "gnupg2",
+      "pkg_type": "rpm",
+      "version": "2.0.22-5.el7_5"
     },
     "fix": {
       "advisories": [],
@@ -1295,30 +585,30 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:10Z"
+      "detected_at": "2021-06-02T02:45:57Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
+            "base_score": 1.9,
+            "exploitability_score": 3.4,
             "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "vector": "AV:L/AC:M/Au:N/C:P/I:N/A:N",
             "version": "2.0"
           },
           {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
+            "base_score": 4.2,
+            "exploitability_score": 0.5,
             "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "vector": "CVSS:3.1/AV:P/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
             "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-25648",
-        "severity": "High",
-        "vulnerability_id": "CVE-2020-25648"
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-3591",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2014-3591"
       }
     ],
     "vulnerability": {
@@ -1326,9 +616,63 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2020-25648",
+      "link": "https://access.redhat.com/security/cve/CVE-2014-3591",
+      "severity": "Low",
+      "vulnerability_id": "CVE-2014-3591"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/sandbox/target/original-my-app-1.jar:guava",
+      "name": "guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-03-31T17:30:52Z",
+      "versions": [
+        "30.0-jre"
+      ],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:57Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 3.3,
+            "exploitability_score": 1.8,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2020-8908"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
       "severity": "Medium",
-      "vulnerability_id": "CVE-2020-25648"
+      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
     }
   },
   {
@@ -1347,113 +691,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:10Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-25648",
-        "severity": "High",
-        "vulnerability_id": "CVE-2020-25648"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2020-25648",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2020-25648"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "python-libs",
-      "pkg_type": "rpm",
-      "version": "2.7.5-89.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2020-11-11T09:10:28Z",
-      "versions": [
-        "0:2.7.5-90.el7"
-      ],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:10Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-20907",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-20907"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2019-20907",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2019-20907"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "nss",
-      "pkg_type": "rpm",
-      "version": "3.53.1-3.el7_9"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-05-30T05:16:10Z"
+      "detected_at": "2021-06-02T02:45:57Z"
     },
     "nvd": [
       {
@@ -1494,6 +732,114 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
+      "name": "python-libs",
+      "pkg_type": "rpm",
+      "version": "2.7.5-89.el7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2020-11-11T09:10:28Z",
+      "versions": [
+        "0:2.7.5-90.el7"
+      ],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:57Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-20907",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-20907"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "link": "https://access.redhat.com/security/cve/CVE-2019-20907",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2019-20907"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/sandbox/node_modules/xmldom/package.json",
+      "name": "xmldom",
+      "pkg_type": "npm",
+      "version": "0.4.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-03-31T17:30:47Z",
+      "versions": [
+        "0.5.0"
+      ],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:57Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 4.3,
+            "exploitability_score": 2.8,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21366",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2021-21366"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "github:npm",
+      "link": "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv",
+      "severity": "Low",
+      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
       "name": "gnupg2",
       "pkg_type": "rpm",
       "version": "2.0.22-5.el7_5"
@@ -1505,7 +851,52 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-05-30T05:16:10Z"
+      "detected_at": "2021-06-02T02:45:57Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-4617",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2014-4617"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "link": "https://access.redhat.com/security/cve/CVE-2014-4617",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2014-4617"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libgcrypt",
+      "pkg_type": "rpm",
+      "version": "1.5.3-14.el7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:57Z"
     },
     "nvd": [
       {
@@ -1543,14 +934,12 @@
   },
   {
     "artifact": {
-      "cpe": "cpe:a:ftpd:ftpd:0.2.1:*:*",
-      "cpes": [
-        "cpe:2.3:a:ftpd:ftpd:0.2.1:*:*:-:-:-:-:-"
-      ],
-      "location": "/usr/local/share/gems/specifications/ftpd-0.2.1.gemspec",
-      "name": "ftpd",
-      "pkg_type": "gem",
-      "version": "0.2.1"
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "openssl-libs",
+      "pkg_type": "rpm",
+      "version": "1.0.2k-19.el7"
     },
     "fix": {
       "advisories": [],
@@ -1559,32 +948,651 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-03-31T17:11:12Z"
+      "detected_at": "2021-06-02T02:45:57Z"
     },
-    "nvd": [],
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-23840",
+        "severity": "High",
+        "vulnerability_id": "CVE-2021-23840"
+      }
+    ],
     "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 10.0,
-          "exploitability_score": 10.0,
-          "impact_score": 10.0,
-          "vector": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
-          "version": "2.0"
-        },
-        {
-          "base_score": 9.8,
-          "exploitability_score": 3.9,
-          "impact_score": 5.9,
-          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-          "version": "3.1"
-        }
-      ],
+      "cvss": [],
       "description": null,
-      "feed": "nvdv2",
-      "feed_group": "nvdv2:cves",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
-      "severity": "Critical",
-      "vulnerability_id": "CVE-2013-2512"
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "link": "https://access.redhat.com/security/cve/CVE-2021-23840",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2021-23840"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "glibc-common",
+      "pkg_type": "rpm",
+      "version": "2.17-323.el7_9"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:57Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 7.5,
+            "exploitability_score": 10.0,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-4043",
+        "severity": "High",
+        "vulnerability_id": "CVE-2014-4043"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "link": "https://access.redhat.com/security/cve/CVE-2014-4043",
+      "severity": "Low",
+      "vulnerability_id": "CVE-2014-4043"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "nss",
+      "pkg_type": "rpm",
+      "version": "3.53.1-3.el7_9"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:57Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-25648",
+        "severity": "High",
+        "vulnerability_id": "CVE-2020-25648"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "link": "https://access.redhat.com/security/cve/CVE-2020-25648",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2020-25648"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "glibc",
+      "pkg_type": "rpm",
+      "version": "2.17-323.el7_9"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:57Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 7.5,
+            "exploitability_score": 10.0,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-4043",
+        "severity": "High",
+        "vulnerability_id": "CVE-2014-4043"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "link": "https://access.redhat.com/security/cve/CVE-2014-4043",
+      "severity": "Low",
+      "vulnerability_id": "CVE-2014-4043"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libgcrypt",
+      "pkg_type": "rpm",
+      "version": "1.5.3-14.el7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:57Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-5270",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2014-5270"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "link": "https://access.redhat.com/security/cve/CVE-2014-5270",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2014-5270"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "nss-sysinit",
+      "pkg_type": "rpm",
+      "version": "3.53.1-3.el7_9"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:57Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-25648",
+        "severity": "High",
+        "vulnerability_id": "CVE-2020-25648"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "link": "https://access.redhat.com/security/cve/CVE-2020-25648",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2020-25648"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "openssl-libs",
+      "pkg_type": "rpm",
+      "version": "1.0.2k-19.el7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2020-12-19T09:16:55Z",
+      "versions": [
+        "1:1.0.2k-21.el7_9"
+      ],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:57Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 5.9,
+            "exploitability_score": 2.2,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-1971",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2020-1971"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "link": "https://access.redhat.com/security/cve/CVE-2020-1971",
+      "severity": "High",
+      "vulnerability_id": "CVE-2020-1971"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/root/.npm/xmldom/0.4.0/package/package.json",
+      "name": "xmldom",
+      "pkg_type": "npm",
+      "version": "0.4.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-03-31T17:30:47Z",
+      "versions": [
+        "0.5.0"
+      ],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:57Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 4.3,
+            "exploitability_score": 2.8,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21366",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2021-21366"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "github:npm",
+      "link": "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv",
+      "severity": "Low",
+      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "openldap",
+      "pkg_type": "rpm",
+      "version": "2.4.44-22.el7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:57Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-25692",
+        "severity": "High",
+        "vulnerability_id": "CVE-2020-25692"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "link": "https://access.redhat.com/security/cve/CVE-2020-25692",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2020-25692"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/sandbox/target/my-app-1.jar:guava",
+      "name": "guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2020-06-16T09:10:15Z",
+      "versions": [
+        "24.1.1-jre"
+      ],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:57Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 5.9,
+            "exploitability_score": 2.2,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2018-10237"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "nss",
+      "pkg_type": "rpm",
+      "version": "3.53.1-3.el7_9"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:57Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 1.2,
+            "exploitability_score": 1.9,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:H/Au:N/C:P/I:N/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 4.4,
+            "exploitability_score": 0.8,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:N/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-12399",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2020-12399"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "link": "https://access.redhat.com/security/cve/CVE-2020-12399",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2020-12399"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "openssl-libs",
+      "pkg_type": "rpm",
+      "version": "1.0.2k-19.el7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:57Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 5.9,
+            "exploitability_score": 2.2,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-23841",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2021-23841"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "link": "https://access.redhat.com/security/cve/CVE-2021-23841",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2021-23841"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/sandbox/target/my-app-1.jar:guava",
+      "name": "guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-03-31T17:30:52Z",
+      "versions": [
+        "30.0-jre"
+      ],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-02T02:45:57Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 3.3,
+            "exploitability_score": 1.8,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2020-8908"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
     }
   }
 ]


### PR DESCRIPTION
This PR fixes issues introduced by policy engine model update in #1084 
- cvss score access in vulnerabilities gate
- missing nvd references for nvd vulnerabilities. This is redundant but necessary because of logic that operates on nvd references (such as vulnerabilities gate, external API etc)