### PR TITLE
Rescan images for vulnerabilities after a successful sync

### DIFF
--- a/anchore_engine/common/models/schemas.py
+++ b/anchore_engine/common/models/schemas.py
@@ -645,3 +645,39 @@ class LocalFeedDataRepoMetadata(JsonSerializable):
         self.download_configuration = download_configuration
         self.download_result = download_result
         self.data_write_dir = data_write_dir
+
+
+class ImageVulnerabilitiesQueueMessage(JsonSerializable):
+    class ImageVulnerabilitiesQueueMessageV1Schema(Schema):
+        account_id = fields.Str()
+        image_id = fields.Str()
+        image_digest = fields.Str()
+
+        @post_load
+        def make(self, data, **kwargs):
+            return ImageVulnerabilitiesQueueMessage(**data)
+
+    __schema__ = ImageVulnerabilitiesQueueMessageV1Schema()
+
+    def __init__(self, account_id=None, image_id=None, image_digest=None):
+        self.account_id = account_id
+        self.image_id = image_id
+        self.image_digest = image_digest
+
+
+class BatchImageVulnerabilitiesQueueMessage(JsonSerializable):
+    class BatchImageVulnerabilitiesQueueMessageV1Schema(Schema):
+        messages = fields.List(
+            fields.Nested(
+                ImageVulnerabilitiesQueueMessage.ImageVulnerabilitiesQueueMessageV1Schema
+            )
+        )
+
+        @post_load
+        def make(self, data, **kwargs):
+            return BatchImageVulnerabilitiesQueueMessage(**data)
+
+    __schema__ = BatchImageVulnerabilitiesQueueMessageV1Schema()
+
+    def __init__(self, messages=None):
+        self.messages = messages

--- a/anchore_engine/services/policy_engine/engine/tasks.py
+++ b/anchore_engine/services/policy_engine/engine/tasks.py
@@ -23,10 +23,6 @@ from anchore_engine.db import Image, end_session
 from anchore_engine.db import get_thread_scoped_session as get_session
 from anchore_engine.db import session_scope
 from anchore_engine.services.policy_engine.engine.exc import *
-from anchore_engine.services.policy_engine.engine.feeds.client import (
-    get_feeds_client,
-    get_grype_db_client,
-)
 from anchore_engine.services.policy_engine.engine.feeds.config import (
     compute_selected_configs_to_sync,
     get_section_for_vulnerabilities,
@@ -53,6 +49,7 @@ from anchore_engine.subsys.events import (
     FeedSyncTaskStarted,
 )
 from anchore_engine.utils import timer
+from anchore_engine.common.models.schemas import ImageVulnerabilitiesQueueMessage
 
 
 def construct_task_from_json(json_obj):
@@ -306,8 +303,8 @@ class FeedsUpdateTask(IAsyncTask):
                 )
 
             try:
-                self.rescan_images_created_between(
-                    from_time=start_time, to_time=end_time
+                get_vulnerabilities_provider().rescan_images_loaded_during_feed_sync(
+                    self.uuid, from_time=start_time, to_time=end_time
                 )
             except:
                 logger.exception(
@@ -318,87 +315,6 @@ class FeedsUpdateTask(IAsyncTask):
                 raise
             finally:
                 end_session()
-
-    def rescan_images_created_between(self, from_time, to_time):
-        """
-        If this was a vulnerability update (e.g. timestamps vuln feeds lies in that interval), then look for any images that were loaded in that interval and
-        re-scan the cves for those to ensure that no ordering of transactions caused cves to be missed for an image.
-
-        This is an alternative to a blocking approach by which image loading is blocked during feed syncs.
-
-        :param from_time:
-        :param to_time:
-        :return: count of updated images
-        """
-
-        if from_time is None or to_time is None:
-            raise ValueError("Cannot process None timestamp")
-
-        logger.info(
-            "Rescanning images loaded between {} and {} (operation_id={})".format(
-                from_time.isoformat(), to_time.isoformat(), self.uuid
-            )
-        )
-        count = 0
-
-        db = get_session()
-        try:
-            # it is critical that these tuples are in proper index order for the primary key of the Images object so that subsequent get() operation works
-            imgs = [
-                (x.id, x.user_id)
-                for x in db.query(Image).filter(
-                    Image.created_at >= from_time, Image.created_at <= to_time
-                )
-            ]
-            logger.info(
-                "Detected images: {} for rescan (operation_id={})".format(
-                    " ,".join([str(x) for x in imgs]) if imgs else "[]", self.uuid
-                )
-            )
-        finally:
-            db.rollback()
-
-        retry_max = 3
-        for img in imgs:
-            for i in range(retry_max):
-                try:
-                    # New transaction for each image to get incremental progress
-                    db = get_session()
-                    try:
-                        # If the type or ordering of 'img' tuple changes, this needs to be updated as it relies on symmetry of that tuple and the identity key of the Image entity
-                        image_obj = db.query(Image).get(img)
-                        if image_obj:
-                            logger.info(
-                                "Rescanning image {} post-vuln sync. (operation_id={})".format(
-                                    img, self.uuid
-                                )
-                            )
-                            get_vulnerabilities_provider().load_image(
-                                image_obj, db_session=db
-                            )
-                            count += 1
-                        else:
-                            logger.warn(
-                                "Failed to lookup image with tuple: {} (operation_id={})".format(
-                                    str(img), self.uuid
-                                )
-                            )
-
-                        db.commit()
-
-                    finally:
-                        db.rollback()
-
-                    break
-                except Exception as e:
-                    logger.exception(
-                        "Caught exception updating vulnerability scan results for image {}. Waiting and retrying (operation_id={})".format(
-                            img, self.uuid
-                        )
-                    )
-                    time.sleep(5)
-
-        return count
 
     @classmethod
     def from_json(cls, json_obj):
@@ -666,4 +582,52 @@ class GrypeDBSyncTask(IAsyncTask):
             except NoActiveDBSyncError:
                 logger.warn(
                     "Cannot initialize grype db locally since no record was found"
+                )
+
+
+class ImageVulnerabilitiesRefreshTask(IAsyncTask):
+    __task_name__ = "image_vulnerabilities_refresh_task"
+
+    def __init__(self, message: ImageVulnerabilitiesQueueMessage):
+        self.message = message
+
+    def execute(self):
+        with timer(
+            "image vulnerabilities refresh for %s/%s"
+            % (self.message.account_id, self.message.image_id),
+            log_level="info",
+        ):
+            logger.debug(
+                "Refreshing image vulnerabilities report for account_id=%s, image_id=%s, image_digest=%s",
+                self.message.account_id,
+                self.message.image_id,
+                self.message.image_digest,
+            )
+
+            with session_scope() as session:
+                img = (
+                    session.query(Image)
+                    .filter(
+                        Image.user_id == self.message.account_id,
+                        Image.id == self.message.image_id,
+                    )
+                    .one_or_none()
+                )
+
+                # lookup image first
+                if not img:
+                    logger.debug(
+                        "No record found for image account=%s, image_id=%s, skipping refresh",
+                        self.message.account_id,
+                        self.message.image_id,
+                    )
+                    return
+
+                # call the provider with vendor_only and force disabled
+                get_vulnerabilities_provider().get_image_vulnerabilities_json(
+                    image=img,
+                    vendor_only=False,
+                    db_session=session,
+                    force_refresh=False,
+                    use_store=True,
                 )

--- a/anchore_engine/services/simplequeue/__init__.py
+++ b/anchore_engine/services/simplequeue/__init__.py
@@ -26,7 +26,7 @@ queues_to_bootstrap = {
         "visibility_timeout": 3600,  # Default 1 hour timeout for messages outstanding
     },
     "archive_tasks": {"max_outstanding_messages": -1, "visibility_timeout": 20},
-    "refresh_tasks": default_queue_config,
+    "image_vulnerabilities": default_queue_config,
 }
 
 queues = {}


### PR DESCRIPTION
Implements the refresh mechanism after a successful grype sync
- updated the queuing logic to batch add images to avoid queue overheads
- policy-engine handler to retrieve refresh tasks from the queue and process
- move the old logic that refreshes images loaded during feed sync into the legacy provider and add a no-op for the grype provider