### PR TITLE
query images_by_vulnerability with grype provider

### DIFF
--- a/anchore_engine/services/policy_engine/engine/policy/gates/vulnerabilities.py
+++ b/anchore_engine/services/policy_engine/engine/policy/gates/vulnerabilities.py
@@ -733,7 +733,7 @@ class VulnerabilityBlacklistTrigger(BaseTrigger):
         for vid in vids:
             found = False
 
-            matches = context.data.get("loaded_vulnerabilities_new")
+            matches = context.data.get("loaded_vulnerabilities")
             for match in matches:
                 if is_vendor_only:
                     if match.fix.wont_fix:

--- a/anchore_engine/services/policy_engine/engine/vulns/dedup.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/dedup.py
@@ -194,7 +194,15 @@ def transfer_vulnerability_timestamps(
         if source_match:
             destination_match = destination_map.get(identity_tuple)
             destination_match.match.detected_at = source_match.match.detected_at
-            # TODO something similar for fix observed at as well
+            # Transfer fix observed_at timestamp from source only if the fix versions are set and equal
+            if destination_match.fix.versions and source_match.fix.versions:
+                destination_match.fix.versions.sort()
+                source_match.fix.versions.sort()
+                if (
+                    destination_match.fix.versions == source_match.fix.versions
+                    and source_match.fix.observed_at
+                ):
+                    destination_match.fix.observed_at = source_match.fix.observed_at
 
     return list(destination_map.values())
 

--- a/tests/unit/anchore_engine/services/policy_engine/engine/vulnerabilities/test_providers.py
+++ b/tests/unit/anchore_engine/services/policy_engine/engine/vulnerabilities/test_providers.py
@@ -1,6 +1,8 @@
 from anchore_engine.common.models.policy_engine import (
     FixedArtifact,
     VulnerabilityMatch,
+    Vulnerability,
+    Artifact,
 )
 from anchore_engine.services.policy_engine.engine.vulns.providers import GrypeProvider
 import pytest
@@ -46,3 +48,232 @@ class TestGrypeProvider:
     )
     def test_exclude_wont_fix_true(self, test_input):
         assert len(GrypeProvider._exclude_wont_fix(test_input)) == 0
+
+    @pytest.mark.parametrize(
+        "test_input, expected_output",
+        [
+            pytest.param(
+                Vulnerability(vulnerability_id="CVE-xyz"),
+                [
+                    {
+                        "name": "foo",
+                        "version": "0.0",
+                        "type": "bar",
+                        "namespace": None,
+                        "severity": None,
+                    }
+                ],
+                id="match-1",
+            ),
+            pytest.param(
+                Vulnerability(
+                    vulnerability_id="CVE-xyz", severity="Critical", feed_group="meh"
+                ),
+                [
+                    {
+                        "name": "foo",
+                        "version": "0.0",
+                        "type": "bar",
+                        "namespace": "meh",
+                        "severity": "Critical",
+                    }
+                ],
+                id="match-2",
+            ),
+            pytest.param(
+                Vulnerability(
+                    vulnerability_id="CVE-pqr", severity="Critical", feed_group="meh"
+                ),
+                [],
+                id="no-match",
+            ),
+        ],
+    )
+    def test_filter_vulnerability_matches_no_optional_filters(
+        self, test_input, expected_output
+    ):
+        vuln_match = VulnerabilityMatch(
+            vulnerability=test_input,
+            artifact=Artifact(
+                name="foo",
+                version="0.0",
+                pkg_type="bar",
+                location="/usr/local/lib",
+            ),
+        )
+
+        results = GrypeProvider._filter_vulnerability_matches(
+            matches=[vuln_match],
+            vulnerability_id="CVE-xyz",
+            severity_filter=None,
+            namespace_filter=None,
+            affected_package_filter=None,
+            vendor_only=None,
+        )
+
+        assert results == expected_output
+
+    @pytest.mark.parametrize(
+        "test_input, test_filter, expected_output",
+        [
+            pytest.param(
+                True,
+                False,
+                [
+                    {
+                        "name": "foo",
+                        "version": None,
+                        "type": None,
+                        "namespace": None,
+                        "severity": None,
+                    }
+                ],
+                id="wontfix-true_vendoronly_false",
+            ),
+            pytest.param(
+                False,
+                False,
+                [
+                    {
+                        "name": "foo",
+                        "version": None,
+                        "type": None,
+                        "namespace": None,
+                        "severity": None,
+                    }
+                ],
+                id="wontfix-false_vendoronly_false",
+            ),
+            pytest.param(
+                False,
+                True,
+                [
+                    {
+                        "name": "foo",
+                        "version": None,
+                        "type": None,
+                        "namespace": None,
+                        "severity": None,
+                    }
+                ],
+                id="wontfix-false_vendoronly_true",
+            ),
+            pytest.param(
+                True,
+                True,
+                [],
+                id="wontfix-true_vendoronly_true",
+            ),
+        ],
+    )
+    def test_filter_vulnerability_matches_vendor_only(
+        self, test_input, test_filter, expected_output
+    ):
+        vuln_match = VulnerabilityMatch(
+            vulnerability=Vulnerability(vulnerability_id="CVE-xyz"),
+            artifact=Artifact(name="foo"),
+            fix=FixedArtifact(wont_fix=test_input),
+        )
+
+        results = GrypeProvider._filter_vulnerability_matches(
+            matches=[vuln_match],
+            vulnerability_id="CVE-xyz",
+            severity_filter=None,
+            namespace_filter=None,
+            affected_package_filter=None,
+            vendor_only=test_filter,
+        )
+
+        assert results == expected_output
+
+    @pytest.mark.parametrize(
+        "test_input, test_filter, expected_output",
+        [
+            pytest.param(
+                "High",
+                "Critical",
+                [],
+                id="no-match",
+            ),
+            pytest.param(
+                "High",
+                "High",
+                [
+                    {
+                        "name": "foo",
+                        "version": None,
+                        "type": None,
+                        "namespace": None,
+                        "severity": "High",
+                    }
+                ],
+                id="match",
+            ),
+        ],
+    )
+    def test_filter_vulnerability_matches_severity(
+        self, test_input, test_filter, expected_output
+    ):
+        vuln_match = VulnerabilityMatch(
+            vulnerability=Vulnerability(
+                vulnerability_id="CVE-xyz", severity=test_input
+            ),
+            artifact=Artifact(name="foo"),
+        )
+
+        results = GrypeProvider._filter_vulnerability_matches(
+            matches=[vuln_match],
+            vulnerability_id="CVE-xyz",
+            severity_filter=test_filter,
+            namespace_filter=None,
+            affected_package_filter=None,
+            vendor_only=None,
+        )
+
+        assert results == expected_output
+
+    @pytest.mark.parametrize(
+        "test_input, test_filter, expected_output",
+        [
+            pytest.param(
+                "foo",
+                "bar",
+                [],
+                id="no-match",
+            ),
+            pytest.param(
+                "meh",
+                "meh",
+                [
+                    {
+                        "name": "foo",
+                        "version": None,
+                        "type": None,
+                        "namespace": "meh",
+                        "severity": None,
+                    }
+                ],
+                id="match",
+            ),
+        ],
+    )
+    def test_filter_vulnerability_matches_namespace(
+        self, test_input, test_filter, expected_output
+    ):
+        vuln_match = VulnerabilityMatch(
+            vulnerability=Vulnerability(
+                vulnerability_id="CVE-xyz", feed_group=test_input
+            ),
+            artifact=Artifact(name="foo"),
+        )
+
+        results = GrypeProvider._filter_vulnerability_matches(
+            matches=[vuln_match],
+            vulnerability_id="CVE-xyz",
+            severity_filter=None,
+            namespace_filter=test_filter,
+            affected_package_filter=None,
+            vendor_only=None,
+        )
+
+        assert results == expected_output


### PR DESCRIPTION
- Implements the query using a jsonb query to look up all images that contain the vulnerability ID first. Loads the results into python space and applies the remaining query filters
- Fixes a typo/super-class function invocation
- Transfer fix observed-at timestamp from the source
- Lots of unit tests