### PR TITLE
Updates to grype rwlock context managers.

### DIFF
--- a/anchore_engine/clients/grype_wrapper.py
+++ b/anchore_engine/clients/grype_wrapper.py
@@ -224,7 +224,7 @@ class GrypeWrapperSingleton(object):
         read_lock = self._grype_db_lock.gen_rlock()
 
         try:
-            if read_lock.acquire(blocking=True, timeout=self.LOCK_READ_ACCESS_TIMEOUT):
+            if read_lock.acquire(timeout=self.LOCK_READ_ACCESS_TIMEOUT):
                 logger.debug("Acquired read access for the grype_db lock")
                 yield
             else:
@@ -246,7 +246,7 @@ class GrypeWrapperSingleton(object):
         write_lock = self._grype_db_lock.gen_wlock()
 
         try:
-            if write_lock.acquire(blocking=True, timeout=self.LOCK_READ_ACCESS_TIMEOUT):
+            if write_lock.acquire(timeout=self.LOCK_READ_ACCESS_TIMEOUT):
                 logger.debug("Unable to acquire write access for the grype_db lock")
                 yield
             else:

--- a/anchore_engine/clients/grype_wrapper.py
+++ b/anchore_engine/clients/grype_wrapper.py
@@ -220,7 +220,9 @@ class GrypeWrapperSingleton(object):
         read_lock = self._grype_db_lock.gen_rlock()
 
         try:
-            acquired = read_lock.acquire(blocking=True, timeout=self.LOCK_READ_ACCESS_TIMEOUT)
+            acquired = read_lock.acquire(
+                blocking=True, timeout=self.LOCK_READ_ACCESS_TIMEOUT
+            )
             if acquired:
                 logger.debug("Acquired read access for the grype_db lock")
                 yield acquired
@@ -241,7 +243,9 @@ class GrypeWrapperSingleton(object):
         write_lock = self._grype_db_lock.gen_wlock()
 
         try:
-            acquired = write_lock.acquire(blocking=True, timeout=self.LOCK_READ_ACCESS_TIMEOUT)
+            acquired = write_lock.acquire(
+                blocking=True, timeout=self.LOCK_READ_ACCESS_TIMEOUT
+            )
             if acquired:
                 logger.debug("Unable to acquire write access for the grype_db lock")
                 yield acquired

--- a/anchore_engine/clients/grype_wrapper.py
+++ b/anchore_engine/clients/grype_wrapper.py
@@ -220,15 +220,14 @@ class GrypeWrapperSingleton(object):
         read_lock = self._grype_db_lock.gen_rlock()
 
         try:
-            if read_lock.acquire(blocking=False, timeout=self.LOCK_READ_ACCESS_TIMEOUT):
+            acquired = read_lock.acquire(blocking=True, timeout=self.LOCK_READ_ACCESS_TIMEOUT)
+            if acquired:
                 logger.debug("Acquired read access for the grype_db lock")
-                yield
+                yield acquired
             else:
                 raise Exception("Unable to acquire read access for the grype_db lock")
-        except Exception as exception:
-            raise exception
         finally:
-            if read_lock.locked():
+            if acquired:
                 logger.debug("Releasing read access for the grype_db lock")
                 read_lock.release()
 
@@ -242,17 +241,14 @@ class GrypeWrapperSingleton(object):
         write_lock = self._grype_db_lock.gen_wlock()
 
         try:
-            if write_lock.acquire(
-                blocking=False, timeout=self.LOCK_WRITE_ACCESS_TIMEOUT
-            ):
+            acquired = write_lock.acquire(blocking=True, timeout=self.LOCK_READ_ACCESS_TIMEOUT)
+            if acquired:
                 logger.debug("Unable to acquire write access for the grype_db lock")
-                yield
+                yield acquired
             else:
                 raise Exception("Unable to acquire write access for the grype_db lock")
-        except Exception as exception:
-            raise exception
         finally:
-            if write_lock.locked():
+            if acquired:
                 logger.debug("Releasing write access for the grype_db lock")
                 write_lock.release()
 

--- a/anchore_engine/clients/grype_wrapper.py
+++ b/anchore_engine/clients/grype_wrapper.py
@@ -97,8 +97,8 @@ class GrypeWrapperSingleton(object):
     _grype_wrapper_instance = None
 
     # These values should be treated as constants, and will not be changed by the functions below
-    LOCK_READ_ACCESS_TIMEOUT = 60
-    LOCK_WRITE_ACCESS_TIMEOUT = 60
+    LOCK_READ_ACCESS_TIMEOUT = 60000
+    LOCK_WRITE_ACCESS_TIMEOUT = 60000
     SQL_LITE_URL_TEMPLATE = "sqlite:///{}"
     GRYPE_SUB_COMMAND = "grype -vv -o json"
     GRYPE_VERSION_COMMAND = "grype version -o json"
@@ -243,7 +243,7 @@ class GrypeWrapperSingleton(object):
 
         try:
             if write_lock.acquire(
-                blocking=True, timeout=self.LOCK_WRITE_ACCESS_TIMEOUT
+                blocking=False, timeout=self.LOCK_WRITE_ACCESS_TIMEOUT
             ):
                 logger.debug("Unable to acquire write access for the grype_db lock")
                 yield

--- a/tests/unit/anchore_engine/clients/test_grype_wrapper.py
+++ b/tests/unit/anchore_engine/clients/test_grype_wrapper.py
@@ -1,17 +1,20 @@
+import json
+import os
+import shutil
+import time
+from queue import Empty, Queue
+from threading import Thread
+
+import pytest
+import sqlalchemy
 from sqlalchemy.orm import sessionmaker
 
 import anchore_engine.configuration.localconfig
-import json
-import os
-import pytest
-import shutil
-import sqlalchemy
-
 from anchore_engine.clients.grype_wrapper import (
-    GrypeWrapperSingleton,
+    VULNERABILITIES,
     GrypeDBEngineMetadata,
     GrypeDBMetadata,
-    VULNERABILITIES,
+    GrypeWrapperSingleton,
 )
 
 TEST_DATA_RELATIVE_PATH = "../../data/grype_db/"
@@ -1250,3 +1253,196 @@ def test_query_record_source_counts(
     assert filtered_result.feed == VULNERABILITIES
     assert filtered_result.count == expected_count
     assert filtered_result.last_synced == LAST_SYNCED_TIMESTAMP
+
+
+class TestLocking:
+    @staticmethod
+    def read_nothing(grype_wrapper, name, input_queue, output_queue):
+        print("Waiting to acquire read lock for {}".format(name))
+        with grype_wrapper.read_lock_access() as acquired:
+            output_queue.put(name)
+            print("Read lock acquired for {} - {}".format(name, acquired))
+            if input_queue.get(block=True):
+                print("Releasing read lock for {}".format(name))
+                return
+
+    @staticmethod
+    def write_nothing(grype_wrapper, name, input_queue, output_queue):
+        print("Waiting to acquire write lock for {}".format(name))
+        with grype_wrapper.write_lock_access() as acquired:
+            output_queue.put(name)
+            print("Write lock acquired for {} - {}".format(name, acquired))
+            if input_queue.get(block=True):
+                print("Releasing write lock for {}".format(name))
+                return
+
+    @staticmethod
+    def value_in_queue(queue, value, timeout=None):
+        try:
+            result = queue.get(block=True, timeout=timeout)
+            if result == value:
+                return True
+        except Empty:
+            pass
+        return False
+
+    def test_simultaneous_read(self):
+        """
+        Tests that two threads reading at the same time is possible.
+        """
+        grype_wrapper = TestGrypeWrapperSingleton.get_instance()
+        instruction_queue = Queue()
+        output_queue = Queue()
+
+        reader_1_name = "a"
+        reader_2_name = "b"
+
+        a = Thread(
+            target=self.read_nothing,
+            args=(grype_wrapper, reader_1_name, instruction_queue, output_queue),
+        )
+        b = Thread(
+            target=self.read_nothing,
+            args=(grype_wrapper, reader_2_name, instruction_queue, output_queue),
+        )
+        a.start()
+        b.start()
+        acquired_tasks = []
+        for x in range(2):
+            acquired_tasks.append(output_queue.get(block=True, timeout=3))
+        assert reader_1_name in acquired_tasks
+        assert reader_2_name in acquired_tasks
+        instruction_queue.put(True)
+        instruction_queue.put(True)
+        a.join()
+        b.join()
+
+    def test_simultaneous_write(self):
+        """
+        Tests that two threads writing at the same time is not possible.
+        """
+        grype_wrapper = TestGrypeWrapperSingleton.get_instance()
+
+        writer_1_instruction_queue = Queue()
+        writer_2_instruction_queue = Queue()
+        output_queue = Queue()
+        writer_1_name = "a"
+        writer_2_name = "b"
+
+        writer_1 = Thread(
+            target=self.write_nothing,
+            args=(
+                grype_wrapper,
+                writer_1_name,
+                writer_1_instruction_queue,
+                output_queue,
+            ),
+        )
+        writer_2 = Thread(
+            target=self.write_nothing,
+            args=(
+                grype_wrapper,
+                writer_2_name,
+                writer_2_instruction_queue,
+                output_queue,
+            ),
+        )
+
+        writer_1.start()
+        time.sleep(1)
+        writer_2.start()
+
+        acquired_writer_1 = self.value_in_queue(output_queue, writer_1_name, 3)
+        assert acquired_writer_1
+
+        acquired_writer_2 = self.value_in_queue(output_queue, writer_2_name, 3)
+        assert not acquired_writer_2
+
+        writer_1_instruction_queue.put(True)
+        writer_1.join()
+
+        acquired_writer_2 = self.value_in_queue(output_queue, writer_2_name, 3)
+        assert acquired_writer_2
+
+        writer_2_instruction_queue.put(True)
+        writer_2.join()
+
+    def test_simultaneous_write_while_reading(self):
+        """
+        Tests that one thread cannot write while another thread is already reading.
+        """
+        grype_wrapper = TestGrypeWrapperSingleton.get_instance()
+
+        reader_instruction_queue = Queue()
+        writer_instruction_queue = Queue()
+        output_queue = Queue()
+        writer_name = "a"
+        reader_name = "b"
+
+        reader = Thread(
+            target=self.read_nothing,
+            args=(grype_wrapper, reader_name, reader_instruction_queue, output_queue),
+        )
+        writer = Thread(
+            target=self.write_nothing,
+            args=(grype_wrapper, writer_name, writer_instruction_queue, output_queue),
+        )
+
+        reader.start()
+        time.sleep(1)
+        writer.start()
+
+        acquired_read = self.value_in_queue(output_queue, reader_name, 3)
+        assert acquired_read
+
+        acquired_write = self.value_in_queue(output_queue, writer_name, 3)
+        assert not acquired_write
+
+        reader_instruction_queue.put(True)
+        reader.join()
+
+        acquired_write = self.value_in_queue(output_queue, writer_name, 3)
+        assert acquired_write
+
+        writer_instruction_queue.put(True)
+        writer.join()
+
+    def test_simultaneous_read_while_writing(self):
+        """
+        Tests that one thread cannot read while another thread is already writing.
+        """
+        grype_wrapper = TestGrypeWrapperSingleton.get_instance()
+
+        reader_instruction_queue = Queue()
+        writer_instruction_queue = Queue()
+        output_queue = Queue()
+        writer_name = "a"
+        reader_name = "b"
+
+        reader = Thread(
+            target=self.read_nothing,
+            args=(grype_wrapper, reader_name, reader_instruction_queue, output_queue),
+        )
+        writer = Thread(
+            target=self.write_nothing,
+            args=(grype_wrapper, writer_name, writer_instruction_queue, output_queue),
+        )
+
+        writer.start()
+        time.sleep(1)
+        reader.start()
+
+        acquired_write = self.value_in_queue(output_queue, writer_name, 3)
+        assert acquired_write
+
+        acquired_read = self.value_in_queue(output_queue, reader_name, 3)
+        assert not acquired_read
+
+        writer_instruction_queue.put(True)
+        writer.join()
+
+        acquired_read = self.value_in_queue(output_queue, reader_name, 3)
+        assert acquired_read
+
+        reader_instruction_queue.put(True)
+        reader.join()


### PR DESCRIPTION
Testing some changes to the way the rwlock in the grype wrapper is accessed in the read and write context managers.

I have not tested this yet due to time constraints. Sharing here for group debugging purposes, as we were just looking at this on a call.