### PR TITLE
Legacy provider nvd and vendor cvss score restructuring

### DIFF
--- a/anchore_engine/common/models/policy_engine.py
+++ b/anchore_engine/common/models/policy_engine.py
@@ -788,6 +788,51 @@ class VulnerabilityMatch(JsonSerializable):
             self.artifact.location,
         )
 
+    def get_cvss_scores_nvd(self):
+        """
+        Backwards compatible utility funciton for getting NVD assigned cvss scores attached to a vulnerability.
+        This is a convenience funciton that abstracts the logic of finding the relevant scores from the caller
+
+        TLDR;
+        Source for NVD CVSS score depends on the type of the vulnerability. There are two types vulnerabilities
+        - NVD vulnerabilities. Scores in the vulnerability object data model represent vendor assigned CVSS scores. In this case they are the same as NVD scores since the vendor is NVD
+        - Non-NVD vulnerabilities with NVD references. NVD CVSS scores are available via the NVD reference objects
+        """
+        scores = []
+
+        # check the vulnerability type using the feed group. legacy feed group for nvd is "nvdv2:cves", grype counterpart is "nvd"
+        if self.vulnerability.feed_group and "nvd" in self.vulnerability.feed_group:
+            scores = self.vulnerability.cvss
+        else:
+            if self.nvd:
+                [
+                    scores.extend(nvd_reference.cvss)
+                    for nvd_reference in self.nvd
+                    if nvd_reference.cvss
+                ]
+
+        return scores
+
+    def get_cvss_scores_vendor(self):
+        """
+        Backwards compatible utility funciton for getting vendor assigned cvss scores attached to a vulnerability.
+        This is a convenience funciton that abstracts the logic of finding the relevant scores from the caller
+
+        TLDR;
+        Source for vendor CVSS score depends on the type of the vulnerability. There are two types vulnerabilities
+        - NVD vulnerabilities. These don't have vendor scores. Scores in the vulnerability object data model represent vendor assigned CVSS scores but in this case they are accounted as NVD scores since the vendor is NVD.
+        - Non-NVD vulnerabilities with NVD references. CVSS scores are available via the vulnerability object
+        """
+        scores = []
+
+        # check the vulnerability type using the feed group. legacy feed group for nvd is "nvdv2:cves", grype counterpart is "nvd"
+        if self.vulnerability.feed_group and "nvd" in self.vulnerability.feed_group:
+            scores = []
+        else:
+            scores = self.vulnerability.cvss
+
+        return scores
+
 
 class VulnerabilitiesReportMetadata(JsonSerializable):
     class VulnerabilitiesReportMetadataV1Schema(Schema):

--- a/anchore_engine/services/policy_engine/engine/policy/gates/vulnerabilities.py
+++ b/anchore_engine/services/policy_engine/engine/policy/gates/vulnerabilities.py
@@ -283,7 +283,8 @@ class VulnerabilityMatchTrigger(BaseTrigger):
                 artifact_obj = vuln_match.artifact
                 fix_obj = vuln_match.fix
                 match_obj = vuln_match.match
-                nvd_objs = vuln_match.nvd
+                nvd_cvss_objects = vuln_match.get_cvss_scores_nvd()
+                vendor_cvss_objects = vuln_match.get_cvss_scores_vendor()
 
                 new_vuln_pkg_class = (
                     "non-os"
@@ -381,10 +382,9 @@ class VulnerabilityMatchTrigger(BaseTrigger):
 
                     # Gather cvss scores before operating with max
                     nvd_cvss_v3_scores = []
-                    for nvd_obj in nvd_objs:
-                        for cvss_obj in nvd_obj.cvss:
-                            if cvss_obj.version.startswith("3"):
-                                nvd_cvss_v3_scores.append(cvss_obj)
+                    for cvss_obj in nvd_cvss_objects:
+                        if cvss_obj.version.startswith("3"):
+                            nvd_cvss_v3_scores.append(cvss_obj)
 
                     # Compute max score for each type
                     if nvd_cvss_v3_scores:
@@ -497,7 +497,7 @@ class VulnerabilityMatchTrigger(BaseTrigger):
 
                     # Gather cvss scores before operating with max
                     vendor_cvss_v3_scores = []
-                    for score_obj in vulnerability_obj.cvss:
+                    for score_obj in vendor_cvss_objects:
                         if score_obj.version.startswith("3"):
                             vendor_cvss_v3_scores.append(score_obj)
 

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:406413437f26223183d133ccc7186f24c827729e1b21adc7330dd43fcdc030b3.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:406413437f26223183d133ccc7186f24c827729e1b21adc7330dd43fcdc030b3.json
@@ -4,9 +4,9 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "libapt-pkg5.0",
+      "name": "python3.7-minimal",
       "pkg_type": "dpkg",
-      "version": "1.8.2.2"
+      "version": "3.7.3-2+deb10u3"
     },
     "fix": {
       "advisories": [],
@@ -15,139 +15,40 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
             "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
             "version": "2.0"
           },
           {
-            "base_score": 3.7,
-            "exploitability_score": 2.2,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2011-3374",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2011-3374"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2011-3374",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2011-3374"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libsystemd0",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 3.3,
-            "exploitability_score": 3.4,
-            "impact_score": 4.9,
-            "vector": "AV:L/AC:M/Au:N/C:P/I:P/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-4392",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2013-4392"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2013-4392"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "/sandbox/target/original-my-app-1.jar:guava",
-      "name": "guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2020-06-16T09:10:15Z",
-      "versions": [
-        "24.1.1-jre"
-      ],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.9,
-            "exploitability_score": 2.2,
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
             "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
             "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2018-10237"
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9674",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-9674"
       }
     ],
     "vulnerability": {
       "cvss": [],
       "description": null,
       "feed": "vulnerabilities",
-      "feed_group": "github:java",
-      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
-      "severity": "Medium",
-      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-9674"
     }
   },
   {
@@ -155,9 +56,9 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "libsystemd0",
+      "name": "libgssapi-krb5-2",
       "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
+      "version": "1.17-3+deb10u1"
     },
     "fix": {
       "advisories": [],
@@ -166,30 +67,23 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 6.2,
-            "exploitability_score": 1.9,
-            "impact_score": 10.0,
-            "vector": "AV:L/AC:H/Au:N/C:C/I:C/A:C",
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:L/Au:N/C:N/I:P/A:N",
             "version": "2.0"
-          },
-          {
-            "base_score": 6.7,
-            "exploitability_score": 0.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H",
-            "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13776",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2020-13776"
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2004-0971",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2004-0971"
       }
     ],
     "vulnerability": {
@@ -197,9 +91,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2004-0971",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-13776"
+      "vulnerability_id": "CVE-2004-0971"
     }
   },
   {
@@ -218,7 +112,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
@@ -229,12 +123,19 @@
             "impact_score": 2.9,
             "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
             "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.0"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-4051",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2010-4051"
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-20796",
+        "severity": "High",
+        "vulnerability_id": "CVE-2018-20796"
       }
     ],
     "vulnerability": {
@@ -242,9 +143,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4051",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2018-20796",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2010-4051"
+      "vulnerability_id": "CVE-2018-20796"
     }
   },
   {
@@ -263,7 +164,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
@@ -297,9 +198,9 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "libpython2.7-minimal",
+      "name": "libldap-common",
       "pkg_type": "dpkg",
-      "version": "2.7.16-2+deb10u1"
+      "version": "2.4.47+dfsg-3+deb10u6"
     },
     "fix": {
       "advisories": [],
@@ -308,30 +209,30 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 4.0,
-            "exploitability_score": 4.9,
-            "impact_score": 4.9,
-            "vector": "AV:N/AC:H/Au:N/C:N/I:P/A:P",
+            "base_score": 1.9,
+            "exploitability_score": 3.4,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:M/Au:N/C:N/I:N/A:P",
             "version": "2.0"
           },
           {
-            "base_score": 5.9,
-            "exploitability_score": 1.6,
-            "impact_score": 4.2,
-            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:H",
-            "version": "3.1"
+            "base_score": 4.7,
+            "exploitability_score": 1.0,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.0"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-23336",
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-14159",
         "severity": "Medium",
-        "vulnerability_id": "CVE-2021-23336"
+        "vulnerability_id": "CVE-2017-14159"
       }
     ],
     "vulnerability": {
@@ -339,9 +240,61 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2021-23336",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2021-23336"
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-14159",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-14159"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libc-bin",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 5.3,
+            "exploitability_score": 3.9,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010024",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2019-1010024"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010024",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-1010024"
     }
   },
   {
@@ -360,233 +313,30 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 6.2,
-            "exploitability_score": 1.9,
-            "impact_score": 10.0,
-            "vector": "AV:L/AC:H/Au:N/C:C/I:C/A:C",
-            "version": "2.0"
-          },
-          {
-            "base_score": 6.7,
-            "exploitability_score": 0.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13776",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2020-13776"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-13776"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libudev1",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 3.3,
-            "exploitability_score": 3.4,
-            "impact_score": 4.9,
-            "vector": "AV:L/AC:M/Au:N/C:P/I:P/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-4392",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2013-4392"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2013-4392"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libpcre3",
-      "pkg_type": "dpkg",
-      "version": "2:8.39-12"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 6.8,
-            "exploitability_score": 8.6,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.8,
-            "exploitability_score": 1.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-7246",
-        "severity": "High",
-        "vulnerability_id": "CVE-2017-7246"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-7246",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-7246"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "/sandbox/node_modules/xmldom/package.json",
-      "name": "xmldom",
-      "pkg_type": "npm",
-      "version": "0.4.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-03-31T17:30:47Z",
-      "versions": [
-        "0.5.0"
-      ],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
             "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+            "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
             "version": "2.0"
           },
           {
-            "base_score": 4.3,
-            "exploitability_score": 2.8,
+            "base_score": 2.4,
+            "exploitability_score": 0.9,
             "impact_score": 1.4,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
+            "vector": "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
             "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21366",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2021-21366"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "github:npm",
-      "link": "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv",
-      "severity": "Low",
-      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libudev1",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 6.2,
-            "exploitability_score": 1.9,
-            "impact_score": 10.0,
-            "vector": "AV:L/AC:H/Au:N/C:C/I:C/A:C",
-            "version": "2.0"
-          },
-          {
-            "base_score": 6.7,
-            "exploitability_score": 0.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13776",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2020-13776"
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-20386",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2019-20386"
       }
     ],
     "vulnerability": {
@@ -594,9 +344,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-13776"
+      "vulnerability_id": "CVE-2019-20386"
     }
   },
   {
@@ -604,7 +354,7 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "libc6",
+      "name": "libc-bin",
       "pkg_type": "dpkg",
       "version": "2.28-10"
     },
@@ -615,7 +365,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
@@ -629,9 +379,9 @@
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-4052",
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-4051",
         "severity": "Medium",
-        "vulnerability_id": "CVE-2010-4052"
+        "vulnerability_id": "CVE-2010-4051"
       }
     ],
     "vulnerability": {
@@ -639,9 +389,61 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4052",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4051",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2010-4052"
+      "vulnerability_id": "CVE-2010-4051"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libc-bin",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-20796",
+        "severity": "High",
+        "vulnerability_id": "CVE-2018-20796"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2018-20796",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2018-20796"
     }
   },
   {
@@ -660,7 +462,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
@@ -701,52 +503,7 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "python2.7-minimal",
-      "pkg_type": "dpkg",
-      "version": "2.7.16-2+deb10u1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-7040",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2013-7040"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-7040",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2013-7040"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc-bin",
+      "name": "libc6",
       "pkg_type": "dpkg",
       "version": "2.28-10"
     },
@@ -757,647 +514,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.0,
-            "exploitability_score": 8.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:S/C:N/I:N/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-4756",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2010-4756"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4756",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2010-4756"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libpcre3",
-      "pkg_type": "dpkg",
-      "version": "2:8.39-12"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.5,
-            "exploitability_score": 1.8,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-16231",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2017-16231"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-16231",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-16231"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "login",
-      "pkg_type": "dpkg",
-      "version": "1:4.5-1.1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 6.9,
-            "exploitability_score": 3.4,
-            "impact_score": 10.0,
-            "vector": "AV:L/AC:M/Au:N/C:C/I:C/A:C",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.8,
-            "exploitability_score": 1.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-19882",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-19882"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-19882",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-19882"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "python2.7-minimal",
-      "pkg_type": "dpkg",
-      "version": "2.7.16-2+deb10u1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.0,
-            "exploitability_score": 4.9,
-            "impact_score": 4.9,
-            "vector": "AV:N/AC:H/Au:N/C:N/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.9,
-            "exploitability_score": 1.6,
-            "impact_score": 4.2,
-            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-23336",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2021-23336"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2021-23336",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2021-23336"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "tar",
-      "pkg_type": "dpkg",
-      "version": "1.30+dfsg-6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-20193",
-        "severity": "Unknown",
-        "vulnerability_id": "CVE-2021-20193"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2021-20193",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2021-20193"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libpython3.7-minimal",
-      "pkg_type": "dpkg",
-      "version": "3.7.3-2+deb10u3"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9674",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-9674"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-9674"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libpython2.7-minimal",
-      "pkg_type": "dpkg",
-      "version": "2.7.16-2+deb10u1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 6.1,
-            "exploitability_score": 2.8,
-            "impact_score": 2.7,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-18348",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2019-18348"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-18348"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libpython2.7-minimal",
-      "pkg_type": "dpkg",
-      "version": "2.7.16-2+deb10u1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 6.8,
-            "exploitability_score": 8.6,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 8.8,
-            "exploitability_score": 2.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-17522",
-        "severity": "High",
-        "vulnerability_id": "CVE-2017-17522"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-17522"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libpcre3",
-      "pkg_type": "dpkg",
-      "version": "2:8.39-12"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.8,
-            "exploitability_score": 10.0,
-            "impact_score": 6.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:C",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-11164",
-        "severity": "High",
-        "vulnerability_id": "CVE-2017-11164"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-11164",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-11164"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "login",
-      "pkg_type": "dpkg",
-      "version": "1:4.5-1.1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.9,
-            "exploitability_score": 3.9,
-            "impact_score": 6.9,
-            "vector": "AV:L/AC:L/Au:N/C:C/I:N/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2007-5686",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2007-5686"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2007-5686",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2007-5686"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "perl",
-      "pkg_type": "dpkg",
-      "version": "5.28.1-6+deb10u1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2011-4116",
-        "severity": "High",
-        "vulnerability_id": "CVE-2011-4116"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2011-4116",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2011-4116"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libudev1",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 2.4,
-            "exploitability_score": 0.9,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-20386",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2019-20386"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-20386"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "systemd",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 3.3,
-            "exploitability_score": 3.4,
-            "impact_score": 4.9,
-            "vector": "AV:L/AC:M/Au:N/C:P/I:P/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-4392",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2013-4392"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2013-4392"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc-bin",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
@@ -1431,103 +548,6 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "tar",
-      "pkg_type": "dpkg",
-      "version": "1.30+dfsg-6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9923",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-9923"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9923",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-9923"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl",
-      "pkg_type": "dpkg",
-      "version": "1.1.1d-0+deb10u6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.8,
-            "exploitability_score": 8.6,
-            "impact_score": 4.9,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2007-6755",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2007-6755"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2007-6755",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2007-6755"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
       "name": "libc6",
       "pkg_type": "dpkg",
       "version": "2.28-10"
@@ -1539,612 +559,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9192",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-9192"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9192",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-9192"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libssl1.1",
-      "pkg_type": "dpkg",
-      "version": "1.1.1d-0+deb10u6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.8,
-            "exploitability_score": 8.6,
-            "impact_score": 4.9,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2007-6755",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2007-6755"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2007-6755",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2007-6755"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libpython2.7-minimal",
-      "pkg_type": "dpkg",
-      "version": "2.7.16-2+deb10u1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-7040",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2013-7040"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-7040",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2013-7040"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc-bin",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 6.8,
-            "exploitability_score": 8.6,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 8.8,
-            "exploitability_score": 2.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010023",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-1010023"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010023",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-1010023"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc6",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 6.8,
-            "exploitability_score": 8.6,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 8.8,
-            "exploitability_score": 2.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010023",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-1010023"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010023",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-1010023"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "python3.7-minimal",
-      "pkg_type": "dpkg",
-      "version": "3.7.3-2+deb10u3"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.5,
-            "exploitability_score": 10.0,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 9.8,
-            "exploitability_score": 3.9,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-27619",
-        "severity": "Critical",
-        "vulnerability_id": "CVE-2020-27619"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-27619",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-27619"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc6",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.3,
-            "exploitability_score": 3.9,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010025",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2019-1010025"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010025",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-1010025"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "passwd",
-      "pkg_type": "dpkg",
-      "version": "1:4.5-1.1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.9,
-            "exploitability_score": 3.9,
-            "impact_score": 6.9,
-            "vector": "AV:L/AC:L/Au:N/C:C/I:N/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2007-5686",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2007-5686"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2007-5686",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2007-5686"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "/sandbox/target/my-app-1.jar:guava",
-      "name": "guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2020-06-16T09:10:15Z",
-      "versions": [
-        "24.1.1-jre"
-      ],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2018-10237"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "github:java",
-      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
-      "severity": "Medium",
-      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "python3.7-minimal",
-      "pkg_type": "dpkg",
-      "version": "3.7.3-2+deb10u3"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9674",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-9674"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-9674"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "passwd",
-      "pkg_type": "dpkg",
-      "version": "1:4.5-1.1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 6.9,
-            "exploitability_score": 3.4,
-            "impact_score": 10.0,
-            "vector": "AV:L/AC:M/Au:N/C:C/I:C/A:C",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.8,
-            "exploitability_score": 1.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-19882",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-19882"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-19882",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-19882"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "systemd",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 2.4,
-            "exploitability_score": 0.9,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-20386",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2019-20386"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-20386"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc6",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
@@ -2185,207 +600,6 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "libssl1.1",
-      "pkg_type": "dpkg",
-      "version": "1.1.1d-0+deb10u6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.0,
-            "exploitability_score": 1.9,
-            "impact_score": 6.9,
-            "vector": "AV:L/AC:H/Au:N/C:C/I:N/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-0928",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2010-0928"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2010-0928",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2010-0928"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "coreutils",
-      "pkg_type": "dpkg",
-      "version": "8.30-3"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 1.9,
-            "exploitability_score": 3.4,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:M/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 4.7,
-            "exploitability_score": 1.0,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:H/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-18018",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2017-18018"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-18018",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-18018"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libpython3.7-minimal",
-      "pkg_type": "dpkg",
-      "version": "3.7.3-2+deb10u3"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.5,
-            "exploitability_score": 10.0,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 9.8,
-            "exploitability_score": 3.9,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-27619",
-        "severity": "Critical",
-        "vulnerability_id": "CVE-2020-27619"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-27619",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-27619"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "apt",
-      "pkg_type": "dpkg",
-      "version": "1.8.2.2"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 3.7,
-            "exploitability_score": 2.2,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2011-3374",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2011-3374"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2011-3374",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2011-3374"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
       "name": "libsystemd0",
       "pkg_type": "dpkg",
       "version": "241-7~deb10u7"
@@ -2397,30 +611,30 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
+            "base_score": 6.2,
+            "exploitability_score": 1.9,
+            "impact_score": 10.0,
+            "vector": "AV:L/AC:H/Au:N/C:C/I:C/A:C",
             "version": "2.0"
           },
           {
-            "base_score": 2.4,
-            "exploitability_score": 0.9,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+            "base_score": 6.7,
+            "exploitability_score": 0.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H",
             "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-20386",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2019-20386"
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13776",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2020-13776"
       }
     ],
     "vulnerability": {
@@ -2428,9 +642,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-20386"
+      "vulnerability_id": "CVE-2020-13776"
     }
   },
   {
@@ -2449,59 +663,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.3,
-            "exploitability_score": 3.9,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010024",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2019-1010024"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010024",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-1010024"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc-bin",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
@@ -2512,125 +674,12 @@
             "impact_score": 2.9,
             "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
             "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-20796",
-        "severity": "High",
-        "vulnerability_id": "CVE-2018-20796"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2018-20796",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2018-20796"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "/usr/local/lib/python3.7/dist-packages/aiohttp",
-      "name": "aiohttp",
-      "pkg_type": "python",
-      "version": "3.7.3"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-03-31T17:30:49Z",
-      "versions": [
-        "3.7.4"
-      ],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.8,
-            "exploitability_score": 8.6,
-            "impact_score": 4.9,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 6.1,
-            "exploitability_score": 2.8,
-            "impact_score": 2.7,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21330",
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-4051",
         "severity": "Medium",
-        "vulnerability_id": "CVE-2021-21330"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "github:python",
-      "link": "https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
-      "severity": "Low",
-      "vulnerability_id": "GHSA-v6wp-4m6f-gcjg"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "python3.7-minimal",
-      "pkg_type": "dpkg",
-      "version": "3.7.3-2+deb10u3"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 6.1,
-            "exploitability_score": 2.8,
-            "impact_score": 2.7,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-18348",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2019-18348"
+        "vulnerability_id": "CVE-2010-4051"
       }
     ],
     "vulnerability": {
@@ -2638,61 +687,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4051",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-18348"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "bash",
-      "pkg_type": "dpkg",
-      "version": "5.0-4"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.2,
-            "exploitability_score": 3.9,
-            "impact_score": 10.0,
-            "vector": "AV:L/AC:L/Au:N/C:C/I:C/A:C",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.8,
-            "exploitability_score": 1.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-18276",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-18276"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18276",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-18276"
+      "vulnerability_id": "CVE-2010-4051"
     }
   },
   {
@@ -2711,7 +708,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
@@ -2752,6 +749,58 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
+      "name": "libpython3.7-minimal",
+      "pkg_type": "dpkg",
+      "version": "3.7.3-2+deb10u3"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9674",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-9674"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-9674"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
       "name": "tar",
       "pkg_type": "dpkg",
       "version": "1.30+dfsg-6"
@@ -2763,23 +812,30 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 10.0,
+            "base_score": 5.0,
             "exploitability_score": 10.0,
-            "impact_score": 10.0,
-            "vector": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
             "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.0"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2005-2541",
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9923",
         "severity": "High",
-        "vulnerability_id": "CVE-2005-2541"
+        "vulnerability_id": "CVE-2019-9923"
       }
     ],
     "vulnerability": {
@@ -2787,9 +843,212 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2005-2541",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9923",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2005-2541"
+      "vulnerability_id": "CVE-2019-9923"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/sandbox/target/my-app-1.jar:guava",
+      "name": "guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-03-31T17:30:52Z",
+      "versions": [
+        "30.0-jre"
+      ],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 3.3,
+            "exploitability_score": 1.8,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2020-8908"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libssl1.1",
+      "pkg_type": "dpkg",
+      "version": "1.1.1d-0+deb10u6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.0,
+            "exploitability_score": 1.9,
+            "impact_score": 6.9,
+            "vector": "AV:L/AC:H/Au:N/C:C/I:N/A:N",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-0928",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2010-0928"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-0928",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2010-0928"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "login",
+      "pkg_type": "dpkg",
+      "version": "1:4.5-1.1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 6.9,
+            "exploitability_score": 3.4,
+            "impact_score": 10.0,
+            "vector": "AV:L/AC:M/Au:N/C:C/I:C/A:C",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.8,
+            "exploitability_score": 1.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-19882",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-19882"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-19882",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-19882"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "apt",
+      "pkg_type": "dpkg",
+      "version": "1.8.2.2"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 3.7,
+            "exploitability_score": 2.2,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2011-3374",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2011-3374"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2011-3374",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2011-3374"
     }
   },
   {
@@ -2808,7 +1067,718 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 6.8,
+            "exploitability_score": 8.6,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 8.8,
+            "exploitability_score": 2.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-17522",
+        "severity": "High",
+        "vulnerability_id": "CVE-2017-17522"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-17522"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libpcre3",
+      "pkg_type": "dpkg",
+      "version": "2:8.39-12"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 7.8,
+            "exploitability_score": 10.0,
+            "impact_score": 6.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:C",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-11164",
+        "severity": "High",
+        "vulnerability_id": "CVE-2017-11164"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-11164",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-11164"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libnss-systemd",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 6.2,
+            "exploitability_score": 1.9,
+            "impact_score": 10.0,
+            "vector": "AV:L/AC:H/Au:N/C:C/I:C/A:C",
+            "version": "2.0"
+          },
+          {
+            "base_score": 6.7,
+            "exploitability_score": 0.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13776",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2020-13776"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2020-13776"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libc-bin",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 7.5,
+            "exploitability_score": 10.0,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 9.8,
+            "exploitability_score": 3.9,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010022",
+        "severity": "Critical",
+        "vulnerability_id": "CVE-2019-1010022"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010022",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-1010022"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libgssapi-krb5-2",
+      "pkg_type": "dpkg",
+      "version": "1.17-3+deb10u1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-5709",
+        "severity": "High",
+        "vulnerability_id": "CVE-2018-5709"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2018-5709",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2018-5709"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "python2.7-minimal",
+      "pkg_type": "dpkg",
+      "version": "2.7.16-2+deb10u1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 6.1,
+            "exploitability_score": 2.8,
+            "impact_score": 2.7,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-18348",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2019-18348"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-18348"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libnss-systemd",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 3.3,
+            "exploitability_score": 3.4,
+            "impact_score": 4.9,
+            "vector": "AV:L/AC:M/Au:N/C:P/I:P/A:N",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-4392",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2013-4392"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2013-4392"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libudev1",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 3.3,
+            "exploitability_score": 3.4,
+            "impact_score": 4.9,
+            "vector": "AV:L/AC:M/Au:N/C:P/I:P/A:N",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-4392",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2013-4392"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2013-4392"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/sandbox/target/my-app-1.jar:guava",
+      "name": "guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2020-06-16T09:10:15Z",
+      "versions": [
+        "24.1.1-jre"
+      ],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 5.9,
+            "exploitability_score": 2.2,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2018-10237"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libgcrypt20",
+      "pkg_type": "dpkg",
+      "version": "1.8.4-5"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-6829",
+        "severity": "High",
+        "vulnerability_id": "CVE-2018-6829"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2018-6829",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2018-6829"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/sandbox/node_modules/xmldom/package.json",
+      "name": "xmldom",
+      "pkg_type": "npm",
+      "version": "0.4.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-03-31T17:30:47Z",
+      "versions": [
+        "0.5.0"
+      ],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 4.3,
+            "exploitability_score": 2.8,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21366",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2021-21366"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "github:npm",
+      "link": "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv",
+      "severity": "Low",
+      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libc6",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 5.3,
+            "exploitability_score": 3.9,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010025",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2019-1010025"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010025",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-1010025"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libldap-common",
+      "pkg_type": "dpkg",
+      "version": "2.4.47+dfsg-3+deb10u6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-3276",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2015-3276"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2015-3276",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2015-3276"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libc6",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 5.3,
+            "exploitability_score": 3.9,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010024",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2019-1010024"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010024",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-1010024"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libpython3.7-minimal",
+      "pkg_type": "dpkg",
+      "version": "3.7.3-2+deb10u3"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
@@ -2860,7 +1830,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
@@ -2869,21 +1839,14 @@
             "base_score": 5.0,
             "exploitability_score": 10.0,
             "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
             "version": "2.0"
-          },
-          {
-            "base_score": 5.3,
-            "exploitability_score": 3.9,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
-            "version": "3.0"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010024",
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-4052",
         "severity": "Medium",
-        "vulnerability_id": "CVE-2019-1010024"
+        "vulnerability_id": "CVE-2010-4052"
       }
     ],
     "vulnerability": {
@@ -2891,205 +1854,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010024",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4052",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-1010024"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libldap-common",
-      "pkg_type": "dpkg",
-      "version": "2.4.47+dfsg-3+deb10u6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-3276",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2015-3276"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2015-3276",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2015-3276"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "perl-base",
-      "pkg_type": "dpkg",
-      "version": "5.28.1-6+deb10u1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2011-4116",
-        "severity": "High",
-        "vulnerability_id": "CVE-2011-4116"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2011-4116",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2011-4116"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": "cpe:a:ftpd:ftpd:0.2.1:*:*",
-      "cpes": [
-        "cpe:2.3:a:ftpd:ftpd:0.2.1:*:*:-:-:-:-:-"
-      ],
-      "location": "/var/lib/gems/2.5.0/specifications/ftpd-0.2.1.gemspec",
-      "name": "ftpd",
-      "pkg_type": "gem",
-      "version": "0.2.1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-03-31T17:11:12Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 10.0,
-            "exploitability_score": 10.0,
-            "impact_score": 10.0,
-            "vector": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
-            "version": "2.0"
-          },
-          {
-            "base_score": 9.8,
-            "exploitability_score": 3.9,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
-        "severity": "Critical",
-        "vulnerability_id": "CVE-2013-2512"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "nvdv2",
-      "feed_group": "nvdv2:cves",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
-      "severity": "Critical",
-      "vulnerability_id": "CVE-2013-2512"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl",
-      "pkg_type": "dpkg",
-      "version": "1.1.1d-0+deb10u6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.0,
-            "exploitability_score": 1.9,
-            "impact_score": 6.9,
-            "vector": "AV:L/AC:H/Au:N/C:C/I:N/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-0928",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2010-0928"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2010-0928",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2010-0928"
+      "vulnerability_id": "CVE-2010-4052"
     }
   },
   {
@@ -3108,7 +1875,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
@@ -3149,6 +1916,58 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
+      "name": "libpython2.7-minimal",
+      "pkg_type": "dpkg",
+      "version": "2.7.16-2+deb10u1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9674",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-9674"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-9674"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
       "name": "libc-bin",
       "pkg_type": "dpkg",
       "version": "2.28-10"
@@ -3160,7 +1979,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
@@ -3171,12 +1990,19 @@
             "impact_score": 2.9,
             "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
             "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.0"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-4051",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2010-4051"
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9192",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-9192"
       }
     ],
     "vulnerability": {
@@ -3184,9 +2010,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4051",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9192",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2010-4051"
+      "vulnerability_id": "CVE-2019-9192"
     }
   },
   {
@@ -3194,9 +2020,9 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "libc6",
+      "name": "python3.7-minimal",
       "pkg_type": "dpkg",
-      "version": "2.28-10"
+      "version": "3.7.3-2+deb10u3"
     },
     "fix": {
       "advisories": [],
@@ -3205,23 +2031,30 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 4.0,
-            "exploitability_score": 8.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:S/C:N/I:N/A:P",
+            "base_score": 6.8,
+            "exploitability_score": 8.6,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
             "version": "2.0"
+          },
+          {
+            "base_score": 8.8,
+            "exploitability_score": 2.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.0"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-4756",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2010-4756"
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-17522",
+        "severity": "High",
+        "vulnerability_id": "CVE-2017-17522"
       }
     ],
     "vulnerability": {
@@ -3229,9 +2062,92 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4756",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2010-4756"
+      "vulnerability_id": "CVE-2017-17522"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "tar",
+      "pkg_type": "dpkg",
+      "version": "1.30+dfsg-6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-20193",
+        "severity": "Unknown",
+        "vulnerability_id": "CVE-2021-20193"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2021-20193",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2021-20193"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "cpe:a:ftpd:ftpd:0.2.1:*:*",
+      "cpes": [
+        "cpe:2.3:a:ftpd:ftpd:0.2.1:*:*:-:-:-:-:-"
+      ],
+      "location": "/var/lib/gems/2.5.0/specifications/ftpd-0.2.1.gemspec",
+      "name": "ftpd",
+      "pkg_type": "gem",
+      "version": "0.2.1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-03-31T17:11:12Z"
+    },
+    "nvd": [],
+    "vulnerability": {
+      "cvss": [
+        {
+          "base_score": 10.0,
+          "exploitability_score": 10.0,
+          "impact_score": 10.0,
+          "vector": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+          "version": "2.0"
+        },
+        {
+          "base_score": 9.8,
+          "exploitability_score": 3.9,
+          "impact_score": 5.9,
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "version": "3.1"
+        }
+      ],
+      "description": null,
+      "feed": "nvdv2",
+      "feed_group": "nvdv2:cves",
+      "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
+      "severity": "Critical",
+      "vulnerability_id": "CVE-2013-2512"
     }
   },
   {
@@ -3250,7 +2166,253 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9674",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-9674"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-9674"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "python3.7-minimal",
+      "pkg_type": "dpkg",
+      "version": "3.7.3-2+deb10u3"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 7.5,
+            "exploitability_score": 10.0,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 9.8,
+            "exploitability_score": 3.9,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-27619",
+        "severity": "Critical",
+        "vulnerability_id": "CVE-2020-27619"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-27619",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2020-27619"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libsystemd0",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 3.3,
+            "exploitability_score": 3.4,
+            "impact_score": 4.9,
+            "vector": "AV:L/AC:M/Au:N/C:P/I:P/A:N",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-4392",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2013-4392"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2013-4392"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libpcre3",
+      "pkg_type": "dpkg",
+      "version": "2:8.39-12"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 5.5,
+            "exploitability_score": 1.8,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-16231",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2017-16231"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-16231",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-16231"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "systemd",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 3.3,
+            "exploitability_score": 3.4,
+            "impact_score": 4.9,
+            "vector": "AV:L/AC:M/Au:N/C:P/I:P/A:N",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-4392",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2013-4392"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2013-4392"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libpython2.7-minimal",
+      "pkg_type": "dpkg",
+      "version": "2.7.16-2+deb10u1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
@@ -3259,7 +2421,54 @@
             "base_score": 4.3,
             "exploitability_score": 8.6,
             "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-7040",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2013-7040"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-7040",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2013-7040"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/usr/local/lib/python3.7/dist-packages/aiohttp",
+      "name": "aiohttp",
+      "pkg_type": "python",
+      "version": "3.7.3"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-03-31T17:30:49Z",
+      "versions": [
+        "3.7.4"
+      ],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.8,
+            "exploitability_score": 8.6,
+            "impact_score": 4.9,
+            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:N",
             "version": "2.0"
           },
           {
@@ -3271,19 +2480,19 @@
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-18348",
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21330",
         "severity": "Medium",
-        "vulnerability_id": "CVE-2019-18348"
+        "vulnerability_id": "CVE-2021-21330"
       }
     ],
     "vulnerability": {
       "cvss": [],
       "description": null,
       "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-18348"
+      "feed_group": "github:python",
+      "link": "https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
+      "severity": "Low",
+      "vulnerability_id": "GHSA-v6wp-4m6f-gcjg"
     }
   },
   {
@@ -3291,9 +2500,9 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "libglib2.0-0",
+      "name": "xdg-user-dirs",
       "pkg_type": "dpkg",
-      "version": "2.58.3-2+deb10u2"
+      "version": "0.17-2"
     },
     "fix": {
       "advisories": [],
@@ -3302,23 +2511,30 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "base_score": 4.6,
+            "exploitability_score": 3.9,
+            "impact_score": 6.4,
+            "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
             "version": "2.0"
+          },
+          {
+            "base_score": 7.8,
+            "exploitability_score": 1.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.0"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2012-0039",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2012-0039"
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-15131",
+        "severity": "High",
+        "vulnerability_id": "CVE-2017-15131"
       }
     ],
     "vulnerability": {
@@ -3326,9 +2542,158 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2012-0039",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-15131",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2012-0039"
+      "vulnerability_id": "CVE-2017-15131"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "bash",
+      "pkg_type": "dpkg",
+      "version": "5.0-4"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 7.2,
+            "exploitability_score": 3.9,
+            "impact_score": 10.0,
+            "vector": "AV:L/AC:L/Au:N/C:C/I:C/A:C",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.8,
+            "exploitability_score": 1.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-18276",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-18276"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18276",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-18276"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libtasn1-6",
+      "pkg_type": "dpkg",
+      "version": "4.13-3"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 7.1,
+            "exploitability_score": 8.6,
+            "impact_score": 6.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:C",
+            "version": "2.0"
+          },
+          {
+            "base_score": 5.5,
+            "exploitability_score": 1.8,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-1000654",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2018-1000654"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2018-1000654",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2018-1000654"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "passwd",
+      "pkg_type": "dpkg",
+      "version": "1:4.5-1.1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.9,
+            "exploitability_score": 3.9,
+            "impact_score": 6.9,
+            "vector": "AV:L/AC:L/Au:N/C:C/I:N/A:N",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2007-5686",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2007-5686"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2007-5686",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2007-5686"
     }
   },
   {
@@ -3347,7 +2712,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
@@ -3399,127 +2764,30 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 6.8,
+            "base_score": 4.3,
             "exploitability_score": 8.6,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 8.8,
-            "exploitability_score": 2.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-17522",
-        "severity": "High",
-        "vulnerability_id": "CVE-2017-17522"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-17522"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libnss-systemd",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 3.3,
-            "exploitability_score": 3.4,
-            "impact_score": 4.9,
-            "vector": "AV:L/AC:M/Au:N/C:P/I:P/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-4392",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2013-4392"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2013-4392"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "python2.7-minimal",
-      "pkg_type": "dpkg",
-      "version": "2.7.16-2+deb10u1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
             "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
             "version": "2.0"
           },
           {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "base_score": 6.1,
+            "exploitability_score": 2.8,
+            "impact_score": 2.7,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
             "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9674",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-9674"
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-18348",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2019-18348"
       }
     ],
     "vulnerability": {
@@ -3527,9 +2795,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-9674"
+      "vulnerability_id": "CVE-2019-18348"
     }
   },
   {
@@ -3537,9 +2805,9 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "libldap-common",
+      "name": "libpython3.7-minimal",
       "pkg_type": "dpkg",
-      "version": "2.4.47+dfsg-3+deb10u6"
+      "version": "3.7.3-2+deb10u3"
     },
     "fix": {
       "advisories": [],
@@ -3548,30 +2816,30 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 1.9,
-            "exploitability_score": 3.4,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:M/Au:N/C:N/I:N/A:P",
+            "base_score": 7.5,
+            "exploitability_score": 10.0,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
             "version": "2.0"
           },
           {
-            "base_score": 4.7,
-            "exploitability_score": 1.0,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
+            "base_score": 9.8,
+            "exploitability_score": 3.9,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-14159",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2017-14159"
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-27619",
+        "severity": "Critical",
+        "vulnerability_id": "CVE-2020-27619"
       }
     ],
     "vulnerability": {
@@ -3579,9 +2847,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-14159",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-27619",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-14159"
+      "vulnerability_id": "CVE-2020-27619"
     }
   },
   {
@@ -3589,7 +2857,52 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "libnss-systemd",
+      "name": "tar",
+      "pkg_type": "dpkg",
+      "version": "1.30+dfsg-6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 10.0,
+            "exploitability_score": 10.0,
+            "impact_score": 10.0,
+            "vector": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2005-2541",
+        "severity": "High",
+        "vulnerability_id": "CVE-2005-2541"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2005-2541",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2005-2541"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "systemd",
       "pkg_type": "dpkg",
       "version": "241-7~deb10u7"
     },
@@ -3600,7 +2913,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
@@ -3641,9 +2954,9 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "xdg-user-dirs",
+      "name": "libc6",
       "pkg_type": "dpkg",
-      "version": "0.17-2"
+      "version": "2.28-10"
     },
     "fix": {
       "advisories": [],
@@ -3652,30 +2965,30 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 4.6,
-            "exploitability_score": 3.9,
-            "impact_score": 6.4,
-            "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
             "version": "2.0"
           },
           {
-            "base_score": 7.8,
-            "exploitability_score": 1.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
             "version": "3.0"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-15131",
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9192",
         "severity": "High",
-        "vulnerability_id": "CVE-2017-15131"
+        "vulnerability_id": "CVE-2019-9192"
       }
     ],
     "vulnerability": {
@@ -3683,9 +2996,210 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-15131",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9192",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-15131"
+      "vulnerability_id": "CVE-2019-9192"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "passwd",
+      "pkg_type": "dpkg",
+      "version": "1:4.5-1.1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 6.9,
+            "exploitability_score": 3.4,
+            "impact_score": 10.0,
+            "vector": "AV:L/AC:M/Au:N/C:C/I:C/A:C",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.8,
+            "exploitability_score": 1.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-19882",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-19882"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-19882",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-19882"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libssl1.1",
+      "pkg_type": "dpkg",
+      "version": "1.1.1d-0+deb10u6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.8,
+            "exploitability_score": 8.6,
+            "impact_score": 4.9,
+            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:N",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2007-6755",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2007-6755"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2007-6755",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2007-6755"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libudev1",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 6.2,
+            "exploitability_score": 1.9,
+            "impact_score": 10.0,
+            "vector": "AV:L/AC:H/Au:N/C:C/I:C/A:C",
+            "version": "2.0"
+          },
+          {
+            "base_score": 6.7,
+            "exploitability_score": 0.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13776",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2020-13776"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2020-13776"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libudev1",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 2.4,
+            "exploitability_score": 0.9,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-20386",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2019-20386"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-20386"
     }
   },
   {
@@ -3704,30 +3218,30 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
             "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
             "version": "2.0"
           },
           {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "base_score": 6.1,
+            "exploitability_score": 2.8,
+            "impact_score": 2.7,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
             "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9674",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-9674"
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-18348",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2019-18348"
       }
     ],
     "vulnerability": {
@@ -3735,9 +3249,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-9674"
+      "vulnerability_id": "CVE-2019-18348"
     }
   },
   {
@@ -3756,7 +3270,508 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 6.1,
+            "exploitability_score": 2.8,
+            "impact_score": 2.7,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-18348",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2019-18348"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-18348"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libsystemd0",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 2.4,
+            "exploitability_score": 0.9,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-20386",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2019-20386"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-20386"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libglib2.0-0",
+      "pkg_type": "dpkg",
+      "version": "2.58.3-2+deb10u2"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2012-0039",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2012-0039"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2012-0039",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2012-0039"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "python2.7-minimal",
+      "pkg_type": "dpkg",
+      "version": "2.7.16-2+deb10u1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-7040",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2013-7040"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-7040",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2013-7040"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libseccomp2",
+      "pkg_type": "dpkg",
+      "version": "2.3.3-4"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 7.5,
+            "exploitability_score": 10.0,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 9.8,
+            "exploitability_score": 3.9,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9893",
+        "severity": "Critical",
+        "vulnerability_id": "CVE-2019-9893"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9893",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-9893"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/sandbox/target/original-my-app-1.jar:guava",
+      "name": "guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2020-06-16T09:10:15Z",
+      "versions": [
+        "24.1.1-jre"
+      ],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 5.9,
+            "exploitability_score": 2.2,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2018-10237"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libc6",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 6.8,
+            "exploitability_score": 8.6,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 8.8,
+            "exploitability_score": 2.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010023",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-1010023"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010023",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-1010023"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libglib2.0-0",
+      "pkg_type": "dpkg",
+      "version": "2.58.3-2+deb10u2"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.6,
+            "exploitability_score": 3.9,
+            "impact_score": 6.4,
+            "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.8,
+            "exploitability_score": 1.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-35457",
+        "severity": "High",
+        "vulnerability_id": "CVE-2020-35457"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-35457",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2020-35457"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libc-bin",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.0,
+            "exploitability_score": 8.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:S/C:N/I:N/A:P",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-4756",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2010-4756"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4756",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2010-4756"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "perl",
+      "pkg_type": "dpkg",
+      "version": "5.28.1-6+deb10u1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2011-4116",
+        "severity": "High",
+        "vulnerability_id": "CVE-2011-4116"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2011-4116",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2011-4116"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libpython2.7-minimal",
+      "pkg_type": "dpkg",
+      "version": "2.7.16-2+deb10u1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
@@ -3797,9 +3812,9 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "libtasn1-6",
+      "name": "libc6",
       "pkg_type": "dpkg",
-      "version": "4.13-3"
+      "version": "2.28-10"
     },
     "fix": {
       "advisories": [],
@@ -3808,75 +3823,23 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 7.1,
-            "exploitability_score": 8.6,
-            "impact_score": 6.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:C",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.5,
-            "exploitability_score": 1.8,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-1000654",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2018-1000654"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2018-1000654",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2018-1000654"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libgssapi-krb5-2",
-      "pkg_type": "dpkg",
-      "version": "1.17-3+deb10u1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
+            "base_score": 4.0,
+            "exploitability_score": 8.0,
             "impact_score": 2.9,
-            "vector": "AV:L/AC:L/Au:N/C:N/I:P/A:N",
+            "vector": "AV:N/AC:L/Au:S/C:N/I:N/A:P",
             "version": "2.0"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2004-0971",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2004-0971"
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-4756",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2010-4756"
       }
     ],
     "vulnerability": {
@@ -3884,9 +3847,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2004-0971",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4756",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2004-0971"
+      "vulnerability_id": "CVE-2010-4756"
     }
   },
   {
@@ -3894,9 +3857,9 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "libgcrypt20",
+      "name": "libldap-common",
       "pkg_type": "dpkg",
-      "version": "1.8.4-5"
+      "version": "2.4.47+dfsg-3+deb10u6"
     },
     "fix": {
       "advisories": [],
@@ -3905,7 +3868,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
@@ -3914,21 +3877,21 @@
             "base_score": 5.0,
             "exploitability_score": 10.0,
             "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
             "version": "2.0"
           },
           {
             "base_score": 7.5,
             "exploitability_score": 3.9,
             "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
             "version": "3.0"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-6829",
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-17740",
         "severity": "High",
-        "vulnerability_id": "CVE-2018-6829"
+        "vulnerability_id": "CVE-2017-17740"
       }
     ],
     "vulnerability": {
@@ -3936,9 +3899,411 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2018-6829",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17740",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2018-6829"
+      "vulnerability_id": "CVE-2017-17740"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "python2.7-minimal",
+      "pkg_type": "dpkg",
+      "version": "2.7.16-2+deb10u1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.0,
+            "exploitability_score": 4.9,
+            "impact_score": 4.9,
+            "vector": "AV:N/AC:H/Au:N/C:N/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 5.9,
+            "exploitability_score": 1.6,
+            "impact_score": 4.2,
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-23336",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2021-23336"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2021-23336",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2021-23336"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libapt-pkg5.0",
+      "pkg_type": "dpkg",
+      "version": "1.8.2.2"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 3.7,
+            "exploitability_score": 2.2,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2011-3374",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2011-3374"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2011-3374",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2011-3374"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "coreutils",
+      "pkg_type": "dpkg",
+      "version": "8.30-3"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 1.9,
+            "exploitability_score": 3.4,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:M/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 4.7,
+            "exploitability_score": 1.0,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:H/A:N",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-18018",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2017-18018"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-18018",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-18018"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "openssl",
+      "pkg_type": "dpkg",
+      "version": "1.1.1d-0+deb10u6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.0,
+            "exploitability_score": 1.9,
+            "impact_score": 6.9,
+            "vector": "AV:L/AC:H/Au:N/C:C/I:N/A:N",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-0928",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2010-0928"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-0928",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2010-0928"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "systemd",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 6.2,
+            "exploitability_score": 1.9,
+            "impact_score": 10.0,
+            "vector": "AV:L/AC:H/Au:N/C:C/I:C/A:C",
+            "version": "2.0"
+          },
+          {
+            "base_score": 6.7,
+            "exploitability_score": 0.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13776",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2020-13776"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2020-13776"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libpcre3",
+      "pkg_type": "dpkg",
+      "version": "2:8.39-12"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 6.8,
+            "exploitability_score": 8.6,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.8,
+            "exploitability_score": 1.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-7246",
+        "severity": "High",
+        "vulnerability_id": "CVE-2017-7246"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-7246",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-7246"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "perl-base",
+      "pkg_type": "dpkg",
+      "version": "5.28.1-6+deb10u1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2011-4116",
+        "severity": "High",
+        "vulnerability_id": "CVE-2011-4116"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2011-4116",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2011-4116"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "python",
+      "pkg_type": "dpkg",
+      "version": "2.7.16-1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:49Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 7.2,
+            "exploitability_score": 3.9,
+            "impact_score": 10.0,
+            "vector": "AV:L/AC:L/Au:N/C:C/I:C/A:C",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2008-4108",
+        "severity": "High",
+        "vulnerability_id": "CVE-2008-4108"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2008-4108",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2008-4108"
     }
   },
   {
@@ -3959,7 +4324,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
@@ -4011,7 +4376,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
@@ -4052,9 +4417,9 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "python",
+      "name": "openssl",
       "pkg_type": "dpkg",
-      "version": "2.7.16-1"
+      "version": "1.1.1d-0+deb10u6"
     },
     "fix": {
       "advisories": [],
@@ -4063,23 +4428,23 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 7.2,
-            "exploitability_score": 3.9,
-            "impact_score": 10.0,
-            "vector": "AV:L/AC:L/Au:N/C:C/I:C/A:C",
+            "base_score": 5.8,
+            "exploitability_score": 8.6,
+            "impact_score": 4.9,
+            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:N",
             "version": "2.0"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2008-4108",
-        "severity": "High",
-        "vulnerability_id": "CVE-2008-4108"
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2007-6755",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2007-6755"
       }
     ],
     "vulnerability": {
@@ -4087,113 +4452,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2008-4108",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2007-6755",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2008-4108"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libgssapi-krb5-2",
-      "pkg_type": "dpkg",
-      "version": "1.17-3+deb10u1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-5709",
-        "severity": "High",
-        "vulnerability_id": "CVE-2018-5709"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2018-5709",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2018-5709"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc-bin",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.5,
-            "exploitability_score": 10.0,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 9.8,
-            "exploitability_score": 3.9,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010022",
-        "severity": "Critical",
-        "vulnerability_id": "CVE-2019-1010022"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010022",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-1010022"
+      "vulnerability_id": "CVE-2007-6755"
     }
   },
   {
@@ -4212,7 +4473,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
@@ -4253,9 +4514,9 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "libldap-common",
+      "name": "login",
       "pkg_type": "dpkg",
-      "version": "2.4.47+dfsg-3+deb10u6"
+      "version": "1:4.5-1.1"
     },
     "fix": {
       "advisories": [],
@@ -4264,186 +4525,23 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
+            "base_score": 4.9,
             "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-17740",
-        "severity": "High",
-        "vulnerability_id": "CVE-2017-17740"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17740",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-17740"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libseccomp2",
-      "pkg_type": "dpkg",
-      "version": "2.3.3-4"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.5,
-            "exploitability_score": 10.0,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+            "impact_score": 6.9,
+            "vector": "AV:L/AC:L/Au:N/C:C/I:N/A:N",
             "version": "2.0"
-          },
-          {
-            "base_score": 9.8,
-            "exploitability_score": 3.9,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.0"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9893",
-        "severity": "Critical",
-        "vulnerability_id": "CVE-2019-9893"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9893",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-9893"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libglib2.0-0",
-      "pkg_type": "dpkg",
-      "version": "2.58.3-2+deb10u2"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.6,
-            "exploitability_score": 3.9,
-            "impact_score": 6.4,
-            "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.8,
-            "exploitability_score": 1.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-35457",
-        "severity": "High",
-        "vulnerability_id": "CVE-2020-35457"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-35457",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-35457"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "systemd",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 6.2,
-            "exploitability_score": 1.9,
-            "impact_score": 10.0,
-            "vector": "AV:L/AC:H/Au:N/C:C/I:C/A:C",
-            "version": "2.0"
-          },
-          {
-            "base_score": 6.7,
-            "exploitability_score": 0.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13776",
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2007-5686",
         "severity": "Medium",
-        "vulnerability_id": "CVE-2020-13776"
+        "vulnerability_id": "CVE-2007-5686"
       }
     ],
     "vulnerability": {
@@ -4451,9 +4549,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2007-5686",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-13776"
+      "vulnerability_id": "CVE-2007-5686"
     }
   },
   {
@@ -4461,9 +4559,9 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "libpython3.7-minimal",
+      "name": "libpython2.7-minimal",
       "pkg_type": "dpkg",
-      "version": "3.7.3-2+deb10u3"
+      "version": "2.7.16-2+deb10u1"
     },
     "fix": {
       "advisories": [],
@@ -4472,30 +4570,30 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+            "base_score": 4.0,
+            "exploitability_score": 4.9,
+            "impact_score": 4.9,
+            "vector": "AV:N/AC:H/Au:N/C:N/I:P/A:P",
             "version": "2.0"
           },
           {
-            "base_score": 6.1,
-            "exploitability_score": 2.8,
-            "impact_score": 2.7,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+            "base_score": 5.9,
+            "exploitability_score": 1.6,
+            "impact_score": 4.2,
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:H",
             "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-18348",
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-23336",
         "severity": "Medium",
-        "vulnerability_id": "CVE-2019-18348"
+        "vulnerability_id": "CVE-2021-23336"
       }
     ],
     "vulnerability": {
@@ -4503,9 +4601,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-18348"
+      "link": "https://security-tracker.debian.org/tracker/CVE-2021-23336",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2021-23336"
     }
   },
   {
@@ -4524,30 +4622,30 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
+      "detected_at": "2021-06-07T20:20:49Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "base_score": 6.8,
+            "exploitability_score": 8.6,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
             "version": "2.0"
           },
           {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "base_score": 8.8,
+            "exploitability_score": 2.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
             "version": "3.0"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9192",
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010023",
         "severity": "High",
-        "vulnerability_id": "CVE-2019-9192"
+        "vulnerability_id": "CVE-2019-1010023"
       }
     ],
     "vulnerability": {
@@ -4555,115 +4653,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9192",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010023",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-9192"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc6",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-20796",
-        "severity": "High",
-        "vulnerability_id": "CVE-2018-20796"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2018-20796",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2018-20796"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "/sandbox/target/my-app-1.jar:guava",
-      "name": "guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-03-31T17:30:52Z",
-      "versions": [
-        "30.0-jre"
-      ],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:55Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 3.3,
-            "exploitability_score": 1.8,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2020-8908"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "github:java",
-      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
-      "severity": "Medium",
-      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
+      "vulnerability_id": "CVE-2019-1010023"
     }
   }
 ]

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:80a31c3ce2e99c3691c27ac3b1753163214494e9b2ca07bfdccf29a5cca2bfbe.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:80a31c3ce2e99c3691c27ac3b1753163214494e9b2ca07bfdccf29a5cca2bfbe.json
@@ -3,7 +3,7 @@
     "artifact": {
       "cpe": null,
       "cpes": [],
-      "location": "/sandbox/target/original-my-app-1.jar:guava",
+      "location": "/sandbox/target/my-app-1.jar:guava",
       "name": "guava",
       "pkg_type": "java",
       "version": "23.0"
@@ -17,7 +17,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:53Z"
+      "detected_at": "2021-06-07T20:20:47Z"
     },
     "nvd": [
       {
@@ -71,7 +71,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:53Z"
+      "detected_at": "2021-06-07T20:20:47Z"
     },
     "nvd": [
       {
@@ -111,168 +111,6 @@
     "artifact": {
       "cpe": null,
       "cpes": [],
-      "location": "/sandbox/target/original-my-app-1.jar:guava",
-      "name": "guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-03-31T17:30:52Z",
-      "versions": [
-        "30.0-jre"
-      ],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:53Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 3.3,
-            "exploitability_score": 1.8,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2020-8908"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "github:java",
-      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
-      "severity": "Medium",
-      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "/sandbox/target/my-app-1.jar:guava",
-      "name": "guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2020-06-16T09:10:15Z",
-      "versions": [
-        "24.1.1-jre"
-      ],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:53Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2018-10237"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "github:java",
-      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
-      "severity": "Medium",
-      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "/sandbox/target/my-app-1.jar:guava",
-      "name": "guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-03-31T17:30:52Z",
-      "versions": [
-        "30.0-jre"
-      ],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:53Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 3.3,
-            "exploitability_score": 1.8,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2020-8908"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "github:java",
-      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
-      "severity": "Medium",
-      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
       "location": "/usr/lib/python3.8/site-packages/aiohttp",
       "name": "aiohttp",
       "pkg_type": "python",
@@ -287,7 +125,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:53Z"
+      "detected_at": "2021-06-07T20:20:47Z"
     },
     "nvd": [
       {
@@ -325,6 +163,114 @@
   },
   {
     "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/sandbox/target/original-my-app-1.jar:guava",
+      "name": "guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-03-31T17:30:52Z",
+      "versions": [
+        "30.0-jre"
+      ],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:47Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 3.3,
+            "exploitability_score": 1.8,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2020-8908"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/sandbox/target/my-app-1.jar:guava",
+      "name": "guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-03-31T17:30:52Z",
+      "versions": [
+        "30.0-jre"
+      ],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:47Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 3.3,
+            "exploitability_score": 1.8,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2020-8908"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
+    }
+  },
+  {
+    "artifact": {
       "cpe": "cpe:a:ftpd:ftpd:0.2.1:*:*",
       "cpes": [
         "cpe:2.3:a:ftpd:ftpd:0.2.1:*:*:-:-:-:-:-"
@@ -343,38 +289,84 @@
     "match": {
       "detected_at": "2021-03-31T17:11:12Z"
     },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 10.0,
-            "exploitability_score": 10.0,
-            "impact_score": 10.0,
-            "vector": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
-            "version": "2.0"
-          },
-          {
-            "base_score": 9.8,
-            "exploitability_score": 3.9,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
-        "severity": "Critical",
-        "vulnerability_id": "CVE-2013-2512"
-      }
-    ],
+    "nvd": [],
     "vulnerability": {
-      "cvss": [],
+      "cvss": [
+        {
+          "base_score": 10.0,
+          "exploitability_score": 10.0,
+          "impact_score": 10.0,
+          "vector": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+          "version": "2.0"
+        },
+        {
+          "base_score": 9.8,
+          "exploitability_score": 3.9,
+          "impact_score": 5.9,
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "version": "3.1"
+        }
+      ],
       "description": null,
       "feed": "nvdv2",
       "feed_group": "nvdv2:cves",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
       "severity": "Critical",
       "vulnerability_id": "CVE-2013-2512"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/sandbox/target/original-my-app-1.jar:guava",
+      "name": "guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2020-06-16T09:10:15Z",
+      "versions": [
+        "24.1.1-jre"
+      ],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:47Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 5.9,
+            "exploitability_score": 2.2,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2018-10237"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
     }
   }
 ]

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:fe3ca35038008b0eac0fa4e686bd072c9430000ab7d7853001bde5f5b8ccf60c.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/sha256:fe3ca35038008b0eac0fa4e686bd072c9430000ab7d7853001bde5f5b8ccf60c.json
@@ -15,363 +15,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:57Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 1.2,
-            "exploitability_score": 1.9,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:H/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 4.4,
-            "exploitability_score": 0.8,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:N/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-12399",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2020-12399"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2020-12399",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2020-12399"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "/usr/local/lib64/python3.6/site-packages/aiohttp",
-      "name": "aiohttp",
-      "pkg_type": "python",
-      "version": "3.7.3"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-03-31T17:30:49Z",
-      "versions": [
-        "3.7.4"
-      ],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:57Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.8,
-            "exploitability_score": 8.6,
-            "impact_score": 4.9,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 6.1,
-            "exploitability_score": 2.8,
-            "impact_score": 2.7,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21330",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2021-21330"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "github:python",
-      "link": "https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
-      "severity": "Low",
-      "vulnerability_id": "GHSA-v6wp-4m6f-gcjg"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "python",
-      "pkg_type": "rpm",
-      "version": "2.7.5-89.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2020-11-11T09:10:28Z",
-      "versions": [
-        "0:2.7.5-90.el7"
-      ],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:57Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-20907",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-20907"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2019-20907",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2019-20907"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libcurl",
-      "pkg_type": "rpm",
-      "version": "7.29.0-59.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2020-11-11T09:10:27Z",
-      "versions": [
-        "0:7.29.0-59.el7_9.1"
-      ],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:57Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.6,
-            "exploitability_score": 3.9,
-            "impact_score": 6.4,
-            "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.1,
-            "exploitability_score": 1.8,
-            "impact_score": 5.2,
-            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8177",
-        "severity": "High",
-        "vulnerability_id": "CVE-2020-8177"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2020-8177",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2020-8177"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "binutils",
-      "pkg_type": "rpm",
-      "version": "2.27-44.base.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:57Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 6.5,
-            "exploitability_score": 2.8,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-17450",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2019-17450"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2019-17450",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2019-17450"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libcom_err",
-      "pkg_type": "rpm",
-      "version": "1.42.9-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:57Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.6,
-            "exploitability_score": 3.9,
-            "impact_score": 6.4,
-            "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-0247",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2015-0247"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2015-0247",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2015-0247"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libidn",
-      "pkg_type": "rpm",
-      "version": "1.28-4.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:57Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.5,
-            "exploitability_score": 10.0,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-2059",
-        "severity": "High",
-        "vulnerability_id": "CVE-2015-2059"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2015-2059",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2015-2059"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "nss-tools",
-      "pkg_type": "rpm",
-      "version": "3.53.1-3.el7_9"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:57Z"
+      "detected_at": "2021-06-07T20:20:50Z"
     },
     "nvd": [
       {
@@ -409,14 +53,12 @@
   },
   {
     "artifact": {
-      "cpe": "cpe:a:ftpd:ftpd:0.2.1:*:*",
-      "cpes": [
-        "cpe:2.3:a:ftpd:ftpd:0.2.1:*:*:-:-:-:-:-"
-      ],
-      "location": "/usr/local/share/gems/specifications/ftpd-0.2.1.gemspec",
-      "name": "ftpd",
-      "pkg_type": "gem",
-      "version": "0.2.1"
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libidn",
+      "pkg_type": "rpm",
+      "version": "1.28-4.el7"
     },
     "fix": {
       "advisories": [],
@@ -425,47 +67,40 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-03-31T17:11:12Z"
+      "detected_at": "2021-06-07T20:20:50Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 10.0,
+            "base_score": 7.5,
             "exploitability_score": 10.0,
-            "impact_score": 10.0,
-            "vector": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
             "version": "2.0"
-          },
-          {
-            "base_score": 9.8,
-            "exploitability_score": 3.9,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
-        "severity": "Critical",
-        "vulnerability_id": "CVE-2013-2512"
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-2059",
+        "severity": "High",
+        "vulnerability_id": "CVE-2015-2059"
       }
     ],
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "nvdv2",
-      "feed_group": "nvdv2:cves",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
-      "severity": "Critical",
-      "vulnerability_id": "CVE-2013-2512"
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "link": "https://access.redhat.com/security/cve/CVE-2015-2059",
+      "severity": "Low",
+      "vulnerability_id": "CVE-2015-2059"
     }
   },
   {
     "artifact": {
       "cpe": null,
       "cpes": [],
-      "location": "/sandbox/target/original-my-app-1.jar:guava",
+      "location": "/sandbox/target/my-app-1.jar:guava",
       "name": "guava",
       "pkg_type": "java",
       "version": "23.0"
@@ -479,7 +114,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:57Z"
+      "detected_at": "2021-06-07T20:20:50Z"
     },
     "nvd": [
       {
@@ -533,7 +168,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:57Z"
+      "detected_at": "2021-06-07T20:20:50Z"
     },
     "nvd": [
       {
@@ -574,9 +209,9 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "gnupg2",
+      "name": "nss-sysinit",
       "pkg_type": "rpm",
-      "version": "2.0.22-5.el7_5"
+      "version": "3.53.1-3.el7_9"
     },
     "fix": {
       "advisories": [],
@@ -585,7 +220,159 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:57Z"
+      "detected_at": "2021-06-07T20:20:50Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-25648",
+        "severity": "High",
+        "vulnerability_id": "CVE-2020-25648"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "link": "https://access.redhat.com/security/cve/CVE-2020-25648",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2020-25648"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "python",
+      "pkg_type": "rpm",
+      "version": "2.7.5-89.el7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2020-11-11T09:10:28Z",
+      "versions": [
+        "0:2.7.5-90.el7"
+      ],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:50Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-20907",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-20907"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "link": "https://access.redhat.com/security/cve/CVE-2019-20907",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2019-20907"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": "cpe:a:ftpd:ftpd:0.2.1:*:*",
+      "cpes": [
+        "cpe:2.3:a:ftpd:ftpd:0.2.1:*:*:-:-:-:-:-"
+      ],
+      "location": "/usr/local/share/gems/specifications/ftpd-0.2.1.gemspec",
+      "name": "ftpd",
+      "pkg_type": "gem",
+      "version": "0.2.1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-03-31T17:11:12Z"
+    },
+    "nvd": [],
+    "vulnerability": {
+      "cvss": [
+        {
+          "base_score": 10.0,
+          "exploitability_score": 10.0,
+          "impact_score": 10.0,
+          "vector": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+          "version": "2.0"
+        },
+        {
+          "base_score": 9.8,
+          "exploitability_score": 3.9,
+          "impact_score": 5.9,
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "version": "3.1"
+        }
+      ],
+      "description": null,
+      "feed": "nvdv2",
+      "feed_group": "nvdv2:cves",
+      "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
+      "severity": "Critical",
+      "vulnerability_id": "CVE-2013-2512"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libgcrypt",
+      "pkg_type": "rpm",
+      "version": "1.5.3-14.el7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:50Z"
     },
     "nvd": [
       {
@@ -625,54 +412,108 @@
     "artifact": {
       "cpe": null,
       "cpes": [],
-      "location": "/sandbox/target/original-my-app-1.jar:guava",
-      "name": "guava",
-      "pkg_type": "java",
-      "version": "23.0"
+      "location": "/sandbox/node_modules/xmldom/package.json",
+      "name": "xmldom",
+      "pkg_type": "npm",
+      "version": "0.4.0"
     },
     "fix": {
       "advisories": [],
-      "observed_at": "2021-03-31T17:30:52Z",
+      "observed_at": "2021-03-31T17:30:47Z",
       "versions": [
-        "30.0-jre"
+        "0.5.0"
       ],
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:57Z"
+      "detected_at": "2021-06-07T20:20:50Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
             "impact_score": 2.9,
-            "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
+            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
             "version": "2.0"
           },
           {
-            "base_score": 3.3,
-            "exploitability_score": 1.8,
+            "base_score": 4.3,
+            "exploitability_score": 2.8,
             "impact_score": 1.4,
-            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
             "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2020-8908"
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21366",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2021-21366"
       }
     ],
     "vulnerability": {
       "cvss": [],
       "description": null,
       "feed": "vulnerabilities",
-      "feed_group": "github:java",
-      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
-      "severity": "Medium",
-      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
+      "feed_group": "github:npm",
+      "link": "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv",
+      "severity": "Low",
+      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/usr/local/lib64/python3.6/site-packages/aiohttp",
+      "name": "aiohttp",
+      "pkg_type": "python",
+      "version": "3.7.3"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-03-31T17:30:49Z",
+      "versions": [
+        "3.7.4"
+      ],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:50Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.8,
+            "exploitability_score": 8.6,
+            "impact_score": 4.9,
+            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 6.1,
+            "exploitability_score": 2.8,
+            "impact_score": 2.7,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21330",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2021-21330"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "github:python",
+      "link": "https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
+      "severity": "Low",
+      "vulnerability_id": "GHSA-v6wp-4m6f-gcjg"
     }
   },
   {
@@ -691,7 +532,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:57Z"
+      "detected_at": "2021-06-07T20:20:50Z"
     },
     "nvd": [
       {
@@ -732,20 +573,18 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "python-libs",
+      "name": "openldap",
       "pkg_type": "rpm",
-      "version": "2.7.5-89.el7"
+      "version": "2.4.44-22.el7"
     },
     "fix": {
       "advisories": [],
-      "observed_at": "2020-11-11T09:10:28Z",
-      "versions": [
-        "0:2.7.5-90.el7"
-      ],
+      "observed_at": null,
+      "versions": [],
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:57Z"
+      "detected_at": "2021-06-07T20:20:50Z"
     },
     "nvd": [
       {
@@ -766,9 +605,9 @@
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-20907",
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-25692",
         "severity": "High",
-        "vulnerability_id": "CVE-2019-20907"
+        "vulnerability_id": "CVE-2020-25692"
       }
     ],
     "vulnerability": {
@@ -776,30 +615,75 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2019-20907",
+      "link": "https://access.redhat.com/security/cve/CVE-2020-25692",
       "severity": "Medium",
-      "vulnerability_id": "CVE-2019-20907"
+      "vulnerability_id": "CVE-2020-25692"
     }
   },
   {
     "artifact": {
       "cpe": null,
       "cpes": [],
-      "location": "/sandbox/node_modules/xmldom/package.json",
-      "name": "xmldom",
-      "pkg_type": "npm",
-      "version": "0.4.0"
+      "location": "pkgdb",
+      "name": "glibc-common",
+      "pkg_type": "rpm",
+      "version": "2.17-323.el7_9"
     },
     "fix": {
       "advisories": [],
-      "observed_at": "2021-03-31T17:30:47Z",
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:50Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 7.5,
+            "exploitability_score": 10.0,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-4043",
+        "severity": "High",
+        "vulnerability_id": "CVE-2014-4043"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "link": "https://access.redhat.com/security/cve/CVE-2014-4043",
+      "severity": "Low",
+      "vulnerability_id": "CVE-2014-4043"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "openssl-libs",
+      "pkg_type": "rpm",
+      "version": "1.0.2k-19.el7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2020-12-19T09:16:55Z",
       "versions": [
-        "0.5.0"
+        "1:1.0.2k-21.el7_9"
       ],
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:57Z"
+      "detected_at": "2021-06-07T20:20:50Z"
     },
     "nvd": [
       {
@@ -808,31 +692,83 @@
             "base_score": 4.3,
             "exploitability_score": 8.6,
             "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
             "version": "2.0"
           },
           {
-            "base_score": 4.3,
-            "exploitability_score": 2.8,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
+            "base_score": 5.9,
+            "exploitability_score": 2.2,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
             "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21366",
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-1971",
         "severity": "Medium",
-        "vulnerability_id": "CVE-2021-21366"
+        "vulnerability_id": "CVE-2020-1971"
       }
     ],
     "vulnerability": {
       "cvss": [],
       "description": null,
       "feed": "vulnerabilities",
-      "feed_group": "github:npm",
-      "link": "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv",
-      "severity": "Low",
-      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv"
+      "feed_group": "rhel:7",
+      "link": "https://access.redhat.com/security/cve/CVE-2020-1971",
+      "severity": "High",
+      "vulnerability_id": "CVE-2020-1971"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "nss",
+      "pkg_type": "rpm",
+      "version": "3.53.1-3.el7_9"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:50Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 1.2,
+            "exploitability_score": 1.9,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:H/Au:N/C:P/I:N/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 4.4,
+            "exploitability_score": 0.8,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:N/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-12399",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2020-12399"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "link": "https://access.redhat.com/security/cve/CVE-2020-12399",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2020-12399"
     }
   },
   {
@@ -851,52 +787,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:57Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-4617",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2014-4617"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2014-4617",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2014-4617"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libgcrypt",
-      "pkg_type": "rpm",
-      "version": "1.5.3-14.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:57Z"
+      "detected_at": "2021-06-07T20:20:50Z"
     },
     "nvd": [
       {
@@ -948,7 +839,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:57Z"
+      "detected_at": "2021-06-07T20:20:50Z"
     },
     "nvd": [
       {
@@ -989,51 +880,6 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "glibc-common",
-      "pkg_type": "rpm",
-      "version": "2.17-323.el7_9"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:57Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.5,
-            "exploitability_score": 10.0,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-4043",
-        "severity": "High",
-        "vulnerability_id": "CVE-2014-4043"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2014-4043",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2014-4043"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
       "name": "nss",
       "pkg_type": "rpm",
       "version": "3.53.1-3.el7_9"
@@ -1045,7 +891,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:57Z"
+      "detected_at": "2021-06-07T20:20:50Z"
     },
     "nvd": [
       {
@@ -1086,51 +932,6 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "glibc",
-      "pkg_type": "rpm",
-      "version": "2.17-323.el7_9"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:57Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.5,
-            "exploitability_score": 10.0,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-4043",
-        "severity": "High",
-        "vulnerability_id": "CVE-2014-4043"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2014-4043",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2014-4043"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
       "name": "libgcrypt",
       "pkg_type": "rpm",
       "version": "1.5.3-14.el7"
@@ -1142,7 +943,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:57Z"
+      "detected_at": "2021-06-07T20:20:50Z"
     },
     "nvd": [
       {
@@ -1176,7 +977,169 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "nss-sysinit",
+      "name": "libcurl",
+      "pkg_type": "rpm",
+      "version": "7.29.0-59.el7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2020-11-11T09:10:27Z",
+      "versions": [
+        "0:7.29.0-59.el7_9.1"
+      ],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:50Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.6,
+            "exploitability_score": 3.9,
+            "impact_score": 6.4,
+            "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.1,
+            "exploitability_score": 1.8,
+            "impact_score": 5.2,
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8177",
+        "severity": "High",
+        "vulnerability_id": "CVE-2020-8177"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "link": "https://access.redhat.com/security/cve/CVE-2020-8177",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2020-8177"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/sandbox/target/my-app-1.jar:guava",
+      "name": "guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-03-31T17:30:52Z",
+      "versions": [
+        "30.0-jre"
+      ],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:50Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 3.3,
+            "exploitability_score": 1.8,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2020-8908"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/sandbox/target/original-my-app-1.jar:guava",
+      "name": "guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-03-31T17:30:52Z",
+      "versions": [
+        "30.0-jre"
+      ],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:50Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 3.3,
+            "exploitability_score": 1.8,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2020-8908"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "nss-tools",
       "pkg_type": "rpm",
       "version": "3.53.1-3.el7_9"
     },
@@ -1187,84 +1150,30 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:57Z"
+      "detected_at": "2021-06-07T20:20:50Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
+            "base_score": 1.2,
+            "exploitability_score": 1.9,
             "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "vector": "AV:L/AC:H/Au:N/C:P/I:N/A:N",
             "version": "2.0"
           },
           {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
+            "base_score": 4.4,
+            "exploitability_score": 0.8,
             "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:N/A:N",
             "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-25648",
-        "severity": "High",
-        "vulnerability_id": "CVE-2020-25648"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2020-25648",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2020-25648"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2020-12-19T09:16:55Z",
-      "versions": [
-        "1:1.0.2k-21.el7_9"
-      ],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:57Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-1971",
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-12399",
         "severity": "Medium",
-        "vulnerability_id": "CVE-2020-1971"
+        "vulnerability_id": "CVE-2020-12399"
       }
     ],
     "vulnerability": {
@@ -1272,9 +1181,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2020-1971",
-      "severity": "High",
-      "vulnerability_id": "CVE-2020-1971"
+      "link": "https://access.redhat.com/security/cve/CVE-2020-12399",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2020-12399"
     }
   },
   {
@@ -1295,7 +1204,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:57Z"
+      "detected_at": "2021-06-07T20:20:50Z"
     },
     "nvd": [
       {
@@ -1336,9 +1245,9 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "openldap",
+      "name": "gnupg2",
       "pkg_type": "rpm",
-      "version": "2.4.44-22.el7"
+      "version": "2.0.22-5.el7_5"
     },
     "fix": {
       "advisories": [],
@@ -1347,7 +1256,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:57Z"
+      "detected_at": "2021-06-07T20:20:50Z"
     },
     "nvd": [
       {
@@ -1358,19 +1267,12 @@
             "impact_score": 2.9,
             "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
             "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-25692",
-        "severity": "High",
-        "vulnerability_id": "CVE-2020-25692"
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-4617",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2014-4617"
       }
     ],
     "vulnerability": {
@@ -1378,115 +1280,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2020-25692",
+      "link": "https://access.redhat.com/security/cve/CVE-2014-4617",
       "severity": "Medium",
-      "vulnerability_id": "CVE-2020-25692"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "/sandbox/target/my-app-1.jar:guava",
-      "name": "guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2020-06-16T09:10:15Z",
-      "versions": [
-        "24.1.1-jre"
-      ],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:57Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2018-10237"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "github:java",
-      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
-      "severity": "Medium",
-      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "nss",
-      "pkg_type": "rpm",
-      "version": "3.53.1-3.el7_9"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "wont_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-02T02:45:57Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 1.2,
-            "exploitability_score": 1.9,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:H/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 4.4,
-            "exploitability_score": 0.8,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:N/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-12399",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2020-12399"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2020-12399",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2020-12399"
+      "vulnerability_id": "CVE-2014-4617"
     }
   },
   {
@@ -1505,7 +1301,7 @@
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:57Z"
+      "detected_at": "2021-06-07T20:20:50Z"
     },
     "nvd": [
       {
@@ -1545,44 +1341,240 @@
     "artifact": {
       "cpe": null,
       "cpes": [],
-      "location": "/sandbox/target/my-app-1.jar:guava",
+      "location": "pkgdb",
+      "name": "libcom_err",
+      "pkg_type": "rpm",
+      "version": "1.42.9-19.el7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:50Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.6,
+            "exploitability_score": 3.9,
+            "impact_score": 6.4,
+            "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-0247",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2015-0247"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "link": "https://access.redhat.com/security/cve/CVE-2015-0247",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2015-0247"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "binutils",
+      "pkg_type": "rpm",
+      "version": "2.27-44.base.el7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:50Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 6.5,
+            "exploitability_score": 2.8,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-17450",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2019-17450"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "link": "https://access.redhat.com/security/cve/CVE-2019-17450",
+      "severity": "Low",
+      "vulnerability_id": "CVE-2019-17450"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "glibc",
+      "pkg_type": "rpm",
+      "version": "2.17-323.el7_9"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:50Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 7.5,
+            "exploitability_score": 10.0,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-4043",
+        "severity": "High",
+        "vulnerability_id": "CVE-2014-4043"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "link": "https://access.redhat.com/security/cve/CVE-2014-4043",
+      "severity": "Low",
+      "vulnerability_id": "CVE-2014-4043"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "python-libs",
+      "pkg_type": "rpm",
+      "version": "2.7.5-89.el7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2020-11-11T09:10:28Z",
+      "versions": [
+        "0:2.7.5-90.el7"
+      ],
+      "wont_fix": false
+    },
+    "match": {
+      "detected_at": "2021-06-07T20:20:50Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-20907",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-20907"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "rhel:7",
+      "link": "https://access.redhat.com/security/cve/CVE-2019-20907",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2019-20907"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/sandbox/target/original-my-app-1.jar:guava",
       "name": "guava",
       "pkg_type": "java",
       "version": "23.0"
     },
     "fix": {
       "advisories": [],
-      "observed_at": "2021-03-31T17:30:52Z",
+      "observed_at": "2020-06-16T09:10:15Z",
       "versions": [
-        "30.0-jre"
+        "24.1.1-jre"
       ],
       "wont_fix": false
     },
     "match": {
-      "detected_at": "2021-06-02T02:45:57Z"
+      "detected_at": "2021-06-07T20:20:50Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
             "impact_score": 2.9,
-            "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
+            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
             "version": "2.0"
           },
           {
-            "base_score": 3.3,
-            "exploitability_score": 1.8,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
+            "base_score": 5.9,
+            "exploitability_score": 2.2,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
             "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2020-8908"
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2018-10237"
       }
     ],
     "vulnerability": {
@@ -1590,9 +1582,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "github:java",
-      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
+      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
       "severity": "Medium",
-      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
+      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
     }
   }
 ]


### PR DESCRIPTION
CVSS scores were weirdly structured to accommodate NVD and vendor scores. This PR addresses that issue by creating utility functions to access scores so the caller doesn't have to know where to look for relevant score objects depending on the vulnerability