### PR TITLE
Bootstrap locks for grype wrapper and grype DB sync manager

### DIFF
--- a/anchore_engine/clients/grype_wrapper.py
+++ b/anchore_engine/clients/grype_wrapper.py
@@ -129,6 +129,7 @@ class GrypeWrapperSingleton(object):
     def __new__(cls):
         # If the singleton has not been initialized yet, do so with the instance variables below
         if cls._grype_wrapper_instance is None:
+            logger.debug("Initializing Grype wrapper instance.")
             # The singleton instance, only instantiated once outside of testing
             cls._grype_wrapper_instance = super(GrypeWrapperSingleton, cls).__new__(cls)
 

--- a/anchore_engine/services/policy_engine/engine/feeds/grypedb_sync.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/grypedb_sync.py
@@ -65,8 +65,6 @@ class GrypeDBSyncManager:
     Sync grype db to local instance of policy engine if it has been updated globally
     """
 
-    lock = threading.Lock()
-
     @classmethod
     def _get_active_grypedb(cls, session) -> GrypeDBFeedMetadata:
         """


### PR DESCRIPTION
<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**:
These changes are done to initialize shared locks before the twistd thread pool is started. That way we can ensure that the locks are in shared memory.

- Adds a post_bootstrap lifecycle handler that initializes the GrypeWrapperSingleton.
- Adds an import statement for grypedb_sync.py so that lock in grypedb_sync.GrypeDBSyncLock gets initialized.
  - Class variables are initialized on import, so this should be sufficient.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #:

**Special notes**:


