### PR TITLE
Use api model for grype groups and use provider for toggle feed enabled endpoint

### DIFF
--- a/anchore_engine/common/models/policy_engine.py
+++ b/anchore_engine/common/models/policy_engine.py
@@ -121,7 +121,7 @@ class FeedMetadata(JsonSerializable):
         enabled=None,
     ):
         self.name = name
-        self.created_aat = created_at
+        self.created_at = created_at
         self.updated_at = updated_at
         self.groups = groups
         self.last_full_sync = last_full_sync

--- a/anchore_engine/services/policy_engine/api/controllers/feeds.py
+++ b/anchore_engine/services/policy_engine/api/controllers/feeds.py
@@ -1,4 +1,3 @@
-import typing
 from dataclasses import asdict
 
 from flask import jsonify
@@ -26,7 +25,6 @@ from anchore_engine.services.policy_engine.engine.feeds.sync_utils import (
 )
 from anchore_engine.services.policy_engine.engine.tasks import FeedsUpdateTask
 from anchore_engine.services.policy_engine.engine.vulns.providers import (
-    VulnerabilitiesProvider,
     get_vulnerabilities_provider,
 )
 from anchore_engine.subsys import logger as log
@@ -51,12 +49,9 @@ def list_feeds(refresh_counts=False):
     return jsonify([feed.to_json() for feed in provider.get_feeds()])
 
 
-def _marshall_feed_response(
-    provider: VulnerabilitiesProvider, feed: DbFeedMetadata
-) -> FeedMetadata:
+def _marshall_feed_response(feed: DbFeedMetadata) -> FeedMetadata:
     """
-    Marshalls FeedMetadata record obtained from the db into the api model
-    Calls _marshall_group_response to build the groups for the specified vuln provider
+    Old method for marshaling a feed. Currently being replaced by workflows driven by providers
     """
     if not feed:
         return ValueError(feed)
@@ -69,9 +64,7 @@ def _marshall_feed_response(
     i.enabled = feed.enabled
     i.groups = []
 
-    groups = provider.get_feed_groups_detached(feed)
-
-    for group in groups:
+    for group in feed.groups:
         i.groups.append(_marshall_group_response(group))
 
     return i
@@ -79,7 +72,7 @@ def _marshall_feed_response(
 
 def _marshall_group_response(group: DbFeedGroupMetadata) -> FeedGroupMetadata:
     """
-    Marshalls the specified group from db record to api model
+    Old method for marshaling a feed's groups. Currently being replaced by workflows driven by providers
     """
     if not group:
         raise ValueError(group)

--- a/anchore_engine/services/policy_engine/api/controllers/feeds.py
+++ b/anchore_engine/services/policy_engine/api/controllers/feeds.py
@@ -47,7 +47,7 @@ def list_feeds(refresh_counts=False):
     if refresh_counts:
         provider.update_feed_group_counts()
 
-    return jsonify([feed.to_json() for feed in provider.get_feeds()])
+    return [feed.to_json() for feed in provider.get_feeds()]
 
 
 def _marshall_feed_response(feed: DbFeedMetadata) -> FeedMetadata:
@@ -133,17 +133,17 @@ def toggle_feed_enabled(feed, enabled):
 
     try:
         provider = get_vulnerabilities_provider()
-        feed = provider.toggle_feed_enabled(feed, enabled)
+        feed = provider.update_feed_enabled_status(feed, enabled)
 
         if not feed:
             raise ResourceNotFound(feed, detail={})
 
-        return jsonify(feed.to_json()), 200
+        return feed.to_json(), 200
 
     except InvalidFeed:
         raise BadRequest(
-            message="Feed not enabled on configured vulnerability provider",
-            detail={"feed": feed, "configured_provider": provider.__config__name__},
+            message="Feed not supported on configured vulnerability provider",
+            detail={"feed": feed, "configured_provider": provider.get_config_name()},
         )
     except Exception as e:
         log.error("Could not update feed enabled status")

--- a/anchore_engine/services/policy_engine/api/controllers/feeds.py
+++ b/anchore_engine/services/policy_engine/api/controllers/feeds.py
@@ -48,24 +48,7 @@ def list_feeds(refresh_counts=False):
     if refresh_counts:
         provider.update_feed_group_counts()
 
-    response = [x.to_json() for x in _marshall_feeds_response(provider)]
-
-    return jsonify(response)
-
-
-def _marshall_feeds_response(
-    provider: VulnerabilitiesProvider,
-) -> typing.List[FeedMetadata]:
-    """
-    Marshalls feeds and groups for specified provider into api models
-    """
-    response = []
-    meta = provider.get_feeds_detached()
-
-    for feed in meta:
-        response.append(_marshall_feed_response(provider, feed))
-
-    return response
+    return jsonify([feed.to_json() for feed in provider.get_feeds()])
 
 
 def _marshall_feed_response(

--- a/anchore_engine/services/policy_engine/engine/vulns/providers.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/providers.py
@@ -45,10 +45,10 @@ from anchore_engine.services.policy_engine.engine.feeds.config import (
     get_section_for_vulnerabilities,
 )
 from anchore_engine.services.policy_engine.engine.feeds.db import (
+    get_all_feeds,
     get_all_feeds_detached,
     get_feed_detached,
-    get_all_feeds,
-    set_feed_enabled
+    set_feed_enabled,
 )
 from anchore_engine.services.policy_engine.engine.feeds.feeds import (
     GrypeDBFeed,

--- a/anchore_engine/services/policy_engine/engine/vulns/providers.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/providers.py
@@ -235,7 +235,7 @@ class VulnerabilitiesProvider(ABC):
         """
         ...
 
-    def toggle_feed_enabled(
+    def update_feed_enabled_status(
         self, feed_name: str, enabled: bool
     ) -> Optional[APIFeedMetadata]:
         self.validate_feed(feed_name)

--- a/tests/integration/services/policy_engine/engine/vulns/test_providers.py
+++ b/tests/integration/services/policy_engine/engine/vulns/test_providers.py
@@ -19,7 +19,7 @@ class TestLegacyProvider:
 
     def test_get_feeds_detached(self, test_data_env, legacy_provider):
 
-        feeds = legacy_provider.get_feeds_detached()
+        feeds = legacy_provider._get_db_feeds()
 
         assert isinstance(feeds, list) is True
         assert len(feeds) == 1

--- a/tests/unit/anchore_engine/services/policy_engine/api/test_models.py
+++ b/tests/unit/anchore_engine/services/policy_engine/api/test_models.py
@@ -28,6 +28,7 @@ def test_feeds():
         "groups": None,
         "enabled": None,
         "last_full_sync": None,
+        "created_at": None,
     }
 
     f.groups = []
@@ -42,6 +43,7 @@ def test_feeds():
         "updated_at": datetime_to_rfc3339(d1),
         "enabled": None,
         "last_full_sync": None,
+        "created_at": None,
         "groups": [
             {
                 "name": "group1",


### PR DESCRIPTION
Abandons the use of the legacy FeedGroupMetadata class for persisting groups in grype. Also uses the provider to toggle the feed