### PR TITLE
Grype query vulnerability updates

### DIFF
--- a/anchore_engine/clients/grype_wrapper.py
+++ b/anchore_engine/clients/grype_wrapper.py
@@ -46,6 +46,10 @@ class GrypeVulnerability(Base, UtilMixin):
     def deserialized_related_vulnerabilities(self):
         return json.loads(self.related_vulnerabilities)
 
+    @property
+    def deserialized_fixed_in_versions(self):
+        return json.loads(self.fixed_in_versions)
+
 
 class GrypeVulnerabilityMetadata(Base, UtilMixin):
     __tablename__ = VULNERABILITY_METADATA_TABLE_NAME

--- a/anchore_engine/services/policy_engine/engine/vulns/mappers.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/mappers.py
@@ -542,6 +542,7 @@ class EngineGrypeDBMapper:
     def _transform_cvss(self, cvss, cvss_template):
         score_dict = copy.deepcopy(cvss_template)
         score_dict["version"] = cvss.get("Version")
+        score_dict["vector"] = cvss.get("Vector", None)
         score_dict["base_score"] = cvss.get("Metrics", {}).get("BaseScore", -1.0)
         score_dict["expolitability_score"] = cvss.get("Metrics", {}).get(
             "ExploitabilityScore", -1.0
@@ -594,7 +595,7 @@ class EngineGrypeDBMapper:
                 vuln_dict["namespace"] = grype_vulnerability.namespace
                 vuln_dict["description"] = grype_vulnerability_metadata.description
                 vuln_dict["severity"] = grype_vulnerability_metadata.severity
-                vuln_dict["link"] = grype_vulnerability_metadata.record_source
+                vuln_dict["link"] = grype_vulnerability_metadata.data_source
                 vuln_dict["references"] = grype_vulnerability_metadata.deserialized_urls
 
                 # Transform the cvss blocks

--- a/anchore_engine/services/policy_engine/engine/vulns/mappers.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/mappers.py
@@ -721,11 +721,18 @@ class EngineGrypeDBMapper:
 
                 # parse_nvd_data() using grype_vulnerability_metadata
 
+            # Transform the versions block
+            if grype_vulnerability.deserialized_fixed_in_versions:
+                version = ",".join(grype_vulnerability.deserialized_fixed_in_versions)
+            else:
+                version = "*"
+
+            # Populate affected_packages
             vuln_dict["affected_packages"].append(
                 {
                     "name": grype_vulnerability.package_name,
                     "type": grype_vulnerability.version_format,
-                    "version": grype_vulnerability.fixed_in_versions,
+                    "version": version,
                 }
             )
 

--- a/anchore_engine/services/policy_engine/engine/vulns/mappers.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/mappers.py
@@ -539,86 +539,15 @@ def to_engine_vulnerabilities(grype_response):
 
 
 class EngineGrypeDBMapper:
-    def _to_engine_vulnerability(self, grype_raw_result):
-        """
-        Receives a single vulnerability_metadata record from grype_db and maps into the data structure engine expects.
-        The vulnerability_metadata record may optionally (but in practice should always) have a nested record for the
-        related vulnerability record.
-        """
-        # Create the templated output object
-        output_vulnerability = {}
-        return_el_template = {
-            "id": None,
-            "namespace": None,
-            "severity": None,
-            "link": None,
-            "affected_packages": None,
-            "description": None,
-            "references": None,
-            "nvd_data": None,
-            "vendor_data": None,
-        }
-        output_vulnerability.update(return_el_template)
-
-        grype_vulnerability = grype_raw_result.GrypeVulnerability
-        grype_vulnerability_metadata = grype_raw_result.GrypeVulnerabilityMetadata
-
-        # Set mapped field values
-        if grype_vulnerability_metadata:
-            output_vulnerability["id"] = grype_vulnerability_metadata.id
-            output_vulnerability[
-                "description"
-            ] = grype_vulnerability_metadata.description
-            output_vulnerability["severity"] = grype_vulnerability_metadata.severity
-            output_vulnerability["link"] = grype_vulnerability_metadata.data_source
-            output_vulnerability[
-                "references"
-            ] = grype_vulnerability_metadata.deserialized_urls
-
-            # vendor_data = {}
-            # vendor_data["id"] = grype_vulnerability_metadata.id
-            #
-            # # Transform the cvss blocks
-            # cvss_v2 = []
-            # cvss_v3 = []
-            # cvss_combined = grype_vulnerability_metadata.deserialized_cvss
-            #
-            # for cvss in cvss_combined:
-            #     version = cvss["Version"]
-            #     if version.startswith("2"):
-            #         cvss_v2.append(cvss)
-            #     elif version.startswith("3"):
-            #         cvss_v3.append(cvss)
-            #     else:
-            #         log.warn(
-            #             "Omitting the following cvss with unknown version from vulnerability {}: {}",
-            #             output_vulnerability["id"],
-            #             cvss,
-            #         )
-            # vendor_data["cvss_v2"] = cvss_v2
-            # vendor_data["cvss_v3"] = cvss_v3
-            #
-            # if (
-            #     grype_vulnerability_metadata.record_source
-            #     and grype_vulnerability_metadata.record_source.startswith("nvdv2")
-            # ):
-            #     output_vulnerability["nvd_data"] = [vendor_data]
-            #     output_vulnerability["vendor_data"] = []
-            # else:
-            #     output_vulnerability["nvd_data"] = []
-            #     output_vulnerability["vendor_data"] = [vendor_data]
-
-        # Get fields from the nested vulnerability object, if it exists
-        if grype_vulnerability:
-            output_vulnerability["namespace"] = grype_vulnerability.namespace
-
-            affected_package = {}
-            affected_package["name"] = grype_vulnerability.package_name
-            affected_package["type"] = grype_vulnerability.version_format
-            affected_package["version"] = grype_vulnerability.version_constraint
-            output_vulnerability["affected_packages"] = [affected_package]
-
-        return output_vulnerability
+    def _transform_cvss(self, cvss, cvss_template):
+        score_dict = copy.deepcopy(cvss_template)
+        score_dict["version"] = cvss.get("Version")
+        score_dict["base_score"] = cvss.get("Metrics", {}).get("BaseScore", -1.0)
+        score_dict["expolitability_score"] = cvss.get("Metrics", {}).get(
+            "ExploitabilityScore", -1.0
+        )
+        score_dict["impact_score"] = cvss.get("Metrics", {}).get("ImpactScore", -1.0)
+        return score_dict
 
     def to_engine_vulnerabilities(self, grype_vulnerabilities):
         """
@@ -665,7 +594,7 @@ class EngineGrypeDBMapper:
                 vuln_dict["namespace"] = grype_vulnerability.namespace
                 vuln_dict["description"] = grype_vulnerability_metadata.description
                 vuln_dict["severity"] = grype_vulnerability_metadata.severity
-                vuln_dict["link"] = grype_vulnerability_metadata.data_source
+                vuln_dict["link"] = grype_vulnerability_metadata.record_source
                 vuln_dict["references"] = grype_vulnerability_metadata.deserialized_urls
 
                 # Transform the cvss blocks
@@ -674,17 +603,7 @@ class EngineGrypeDBMapper:
                 for cvss in cvss_combined:
                     version = cvss["Version"]
                     if version.startswith("2"):
-                        score_dict = copy.deepcopy(cvss_template)
-                        score_dict["version"] = (cvss.get("Version"),)
-                        score_dict["base_score"] = cvss.get("Metrics", {}).get(
-                            "BaseScore", -1.0
-                        )
-                        score_dict["exploitabilityScore"] = cvss.get("Metrics", {}).get(
-                            "ExploitabilityScore", -1.0
-                        )
-                        score_dict["impactScore"] = cvss.get("Metrics", {}).get(
-                            "ImpactScore", -1.0
-                        )
+                        score_dict = self._transform_cvss(cvss, cvss_template)
 
                         vuln_dict["vendor_data"].append(
                             {
@@ -693,17 +612,7 @@ class EngineGrypeDBMapper:
                             }
                         )
                     elif version.startswith("3"):
-                        score_dict = copy.deepcopy(cvss_template)
-                        score_dict["version"] = (cvss.get("Version"),)
-                        score_dict["base_score"] = cvss.get("Metrics", {}).get(
-                            "BaseScore", -1.0
-                        )
-                        score_dict["exploitabilityScore"] = cvss.get("Metrics", {}).get(
-                            "ExploitabilityScore", -1.0
-                        )
-                        score_dict["impactScore"] = cvss.get("Metrics", {}).get(
-                            "ImpactScore", -1.0
-                        )
+                        score_dict = self._transform_cvss(cvss, cvss_template)
 
                         vuln_dict["vendor_data"].append(
                             {

--- a/anchore_engine/services/policy_engine/engine/vulns/mappers.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/mappers.py
@@ -666,9 +666,7 @@ class EngineGrypeDBMapper:
                 vuln_dict["description"] = grype_vulnerability_metadata.description
                 vuln_dict["severity"] = grype_vulnerability_metadata.severity
                 vuln_dict["link"] = grype_vulnerability_metadata.data_source
-                output_vulnerability[
-                    "references"
-                ] = grype_vulnerability_metadata.deserialized_urls
+                vuln_dict["references"] = grype_vulnerability_metadata.deserialized_urls
 
                 # Transform the cvss blocks
                 cvss_combined = grype_vulnerability_metadata.deserialized_cvss
@@ -716,7 +714,7 @@ class EngineGrypeDBMapper:
                     else:
                         log.warn(
                             "Omitting the following cvss with unknown version from vulnerability {}: {}",
-                            output_vulnerability["id"],
+                            grype_vulnerability.id,
                             cvss,
                         )
                         continue

--- a/anchore_engine/services/policy_engine/engine/vulns/mappers.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/mappers.py
@@ -1,3 +1,4 @@
+import copy
 import datetime
 import uuid
 from collections import defaultdict
@@ -625,9 +626,109 @@ class EngineGrypeDBMapper:
         into the data structure engine expects.
         """
         transformed_vulnerabilities = []
+        intermediate_tuple_list = {}
+
+        return_el_template = {
+            "id": None,  # done
+            "namespace": None,  # done
+            "severity": None,  # done
+            "link": None,  # done
+            "affected_packages": [],  # done
+            "description": None,  # done
+            "references": None,  # leaving this be
+            "nvd_data": [],
+            "vendor_data": [],  # leaving this be
+        }
+        cvss_template = {
+            "version": None,
+            "vector": None,
+            "base_score": -1.0,
+            "expolitability_score": -1.0,
+            "impact_score": -1.0,
+        }
+
         for grype_raw_result in grype_vulnerabilities:
-            transformed_vulnerabilities.append(
-                self._to_engine_vulnerability(grype_raw_result)
+            grype_vulnerability = grype_raw_result.GrypeVulnerability
+            grype_vulnerability_metadata = grype_raw_result.GrypeVulnerabilityMetadata
+
+            vuln_dict = intermediate_tuple_list.get(
+                (grype_vulnerability.id, grype_vulnerability.namespace)
             )
 
-        return transformed_vulnerabilities
+            if not vuln_dict:
+                vuln_dict = copy.deepcopy(return_el_template)
+                intermediate_tuple_list[
+                    (grype_vulnerability.id, grype_vulnerability.namespace)
+                ] = vuln_dict
+
+                vuln_dict["id"] = grype_vulnerability_metadata.id
+                vuln_dict["namespace"] = grype_vulnerability.namespace
+                vuln_dict["description"] = grype_vulnerability_metadata.description
+                vuln_dict["severity"] = grype_vulnerability_metadata.severity
+                vuln_dict["link"] = grype_vulnerability_metadata.data_source
+                output_vulnerability[
+                    "references"
+                ] = grype_vulnerability_metadata.deserialized_urls
+
+                # Transform the cvss blocks
+                cvss_combined = grype_vulnerability_metadata.deserialized_cvss
+
+                for cvss in cvss_combined:
+                    version = cvss["Version"]
+                    if version.startswith("2"):
+                        score_dict = copy.deepcopy(cvss_template)
+                        score_dict["version"] = (cvss.get("Version"),)
+                        score_dict["base_score"] = cvss.get("Metrics", {}).get(
+                            "BaseScore", -1.0
+                        )
+                        score_dict["exploitabilityScore"] = cvss.get("Metrics", {}).get(
+                            "ExploitabilityScore", -1.0
+                        )
+                        score_dict["impactScore"] = cvss.get("Metrics", {}).get(
+                            "ImpactScore", -1.0
+                        )
+
+                        vuln_dict["vendor_data"].append(
+                            {
+                                "cvss_v2": score_dict,
+                                "id": grype_vulnerability_metadata.id,
+                            }
+                        )
+                    elif version.startswith("3"):
+                        score_dict = copy.deepcopy(cvss_template)
+                        score_dict["version"] = (cvss.get("Version"),)
+                        score_dict["base_score"] = cvss.get("Metrics", {}).get(
+                            "BaseScore", -1.0
+                        )
+                        score_dict["exploitabilityScore"] = cvss.get("Metrics", {}).get(
+                            "ExploitabilityScore", -1.0
+                        )
+                        score_dict["impactScore"] = cvss.get("Metrics", {}).get(
+                            "ImpactScore", -1.0
+                        )
+
+                        vuln_dict["vendor_data"].append(
+                            {
+                                "cvss_v3": score_dict,
+                                "id": grype_vulnerability_metadata.id,
+                            }
+                        )
+                    else:
+                        log.warn(
+                            "Omitting the following cvss with unknown version from vulnerability {}: {}",
+                            output_vulnerability["id"],
+                            cvss,
+                        )
+                        continue
+
+                # parse_nvd_data() using grype_vulnerability_metadata
+
+            vuln_dict["affected_packages"].append(
+                {
+                    "name": grype_vulnerability.package_name,
+                    "type": grype_vulnerability.version_format,
+                    "version": grype_vulnerability.fixed_in_versions,
+                }
+            )
+
+        return list(intermediate_tuple_list.values())


### PR DESCRIPTION
This PR contains updates @nightfurys and myself made to the /query/vulnerabilities grype mapping logic. It could use a little bit of refactoring still, but the response object from the grype provider backing for that endpoint is now more like that returned by the legacy provider.