### PR TITLE
Adds cpe-based matching for alpine apks to support upstream vulns

### DIFF
--- a/anchore_engine/db/entities/policy_engine.py
+++ b/anchore_engine/db/entities/policy_engine.py
@@ -4,6 +4,7 @@ import json
 import re
 import zlib
 from collections import namedtuple
+import typing
 from typing import List
 
 from sqlalchemy import (
@@ -1123,6 +1124,28 @@ class VulnDBMetadata(Base):
                 return "CVE-" + cve_id_col[0]
 
         return self.name
+
+    @property
+    def referenced_cves(self) -> typing.List[str]:
+        """
+        Returns all referenced CVE IDs from the record, may be zero, one, or many.
+
+        :return: List[Str]
+        """
+        ids = set()
+
+        # References is a list of objects each with a potential "source" key
+        for reference in [
+            ref for ref in self.references if ref.get("source") == "CVE ID"
+        ]:
+            url = reference.get("url")
+            if url:
+                # findall should return a single id list ['2020-11989']
+                cve_id_col = re.findall(r"\=(\d+\-\d+)", url)
+                if cve_id_col:
+                    ids.add("CVE-" + cve_id_col[0])
+
+        return list(ids)
 
     def _get_max_cvss_v3_metric_nvd(self):
         cvss_v3 = None
@@ -2413,8 +2436,17 @@ class ImageCpe(Base):
     )
 
     def __repr__(self):
-        return "<{} user_id={}, img_id={}, name={}>".format(
-            self.__class__, self.image_user_id, self.image_id, self.name
+        return (
+            "<{} user_id={}, img_id={}, name={}, version={}, type={}, path={}>".format(
+                self.__class__,
+                self.image_user_id,
+                self.image_id,
+                self.name,
+                self.name,
+                self.version,
+                self.pkg_type,
+                self.pkg_path,
+            )
         )
 
     def fixed_in(self):
@@ -2742,6 +2774,9 @@ class Image(Base):
             return self.distro_name + ":" + self.distro_version
         else:
             return None
+
+    def distro_namespace_obj(self):
+        return DistroNamespace.for_obj(self)
 
     def get_packages_by_type(self, pkg_type):
         db = get_thread_scoped_session()

--- a/anchore_engine/services/policy_engine/api/controllers/synchronous_operations.py
+++ b/anchore_engine/services/policy_engine/api/controllers/synchronous_operations.py
@@ -805,34 +805,6 @@ def get_image_vulnerabilities(user_id, image_id, force_refresh=False, vendor_onl
     Return the vulnerability listing for the specified image and load from catalog if not found and specifically asked
     to do so.
 
-
-    Example json output:
-    {
-       "multi" : {
-          "url_column_index" : 7,
-          "result" : {
-             "rows" : [],
-             "rowcount" : 0,
-             "colcount" : 8,
-             "header" : [
-                "CVE_ID",
-                "Severity",
-                "*Total_Affected",
-                "Vulnerable_Package",
-                "Fix_Available",
-                "Fix_Images",
-                "Rebuild_Images",
-                "URL"
-             ]
-          },
-          "querycommand" : "/usr/lib/python2.7/site-packages/anchore/anchore-modules/multi-queries/cve-scan.py /ebs_data/anchore/querytmp/queryimages.7026386 /ebs_data/anchore/data /ebs_data/anchore/querytmp/query.59057288 all",
-          "queryparams" : "all",
-          "warns" : [
-             "0005b136f0fb (prom/prometheus:master) cannot perform CVE scan: no CVE data is currently available for the detected base distro type (busybox:unknown_version,busybox:v1.26.2)"
-          ]
-       }
-    }
-
     :param user_id: user id of image to evaluate
     :param image_id: image id to evaluate
     :param force_refresh: if true, flush and recompute vulnerabilities rather than returning current values

--- a/anchore_engine/services/policy_engine/engine/vulns/cpe_matchers.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/cpe_matchers.py
@@ -1,0 +1,333 @@
+from typing import List, Tuple
+
+from sqlalchemy.orm import Session
+from collections import namedtuple
+
+from anchore_engine.db import (
+    NvdV2Metadata,
+    CpeV2Vulnerability,
+    Image,
+    get_thread_scoped_session,
+    ImageCpe,
+    VulnDBCpe,
+    Vulnerability,
+    DistroNamespace,
+    ImagePackage,
+)
+from anchore_engine.services.policy_engine.engine.vulns.cpes import (
+    FuzzyCandidateCpeGenerator,
+    dedup_cpe_vulnerabilities,
+)
+from anchore_engine.services.policy_engine.engine.vulns.db import (
+    CpeDBQueryManager,
+    db_result_tuples_to_list,
+)
+from anchore_engine.subsys import logger
+from anchore_engine.utils import timer
+
+# Match class to bind the image and vuln sides and ease comparisons and hashing
+CpeMatch = namedtuple("CpeMatch", ["image_cpe", "vuln_cpe"])
+
+
+def cve_ids_for_vuln_record(vuln: Vulnerability) -> List[str]:
+    """
+    Get CVE Id for vuln from alpine record
+
+    :param vuln:
+    :return: list of CVE ids associated with the vulnerability record
+    """
+
+    if vuln.id.startswith("CVE-"):
+        ids = [vuln.id]
+    else:
+        ids = []
+
+    # Some records have references in the metadata structure as (Amazon ALAS, for an example):
+    # {"CVE": ["CVE-1", "CVE-2",...]}
+    try:
+        refs = vuln.additional_metadata["CVE"]
+    except (KeyError, AttributeError, TypeError):
+        refs = []
+
+    ids.extend(refs)
+    if len(ids) > 1:
+        # Ensure no duplicates
+        return list(set(ids))
+    else:
+        return ids
+
+
+def filter_secdb_entries(
+    image_distro: DistroNamespace, matches: List[str], db_manager: CpeDBQueryManager
+) -> List[str]:
+    """
+    Execute the filtering functionality itself on the sets
+
+    :param image_distro:
+    :param matches: match list to filter
+    :return: filtered match list
+    """
+
+    secdb_matched_cves = db_manager.matched_records_for_namespace(image_distro, matches)
+
+    logger.spew("Secdb matched cves %s", secdb_matched_cves)
+    unmatched = set(matches).difference(secdb_matched_cves)
+    return list(unmatched)
+
+
+def cpes_for_image_packages(
+    packages: List[ImagePackage],
+) -> List[Tuple[ImagePackage, ImageCpe]]:
+    """
+    Generate cpes for the packages
+
+    :param packages:
+    :return:
+    """
+    # If pre-Syft integration, there are no CPEs for distro packages
+    cpe_generator = FuzzyCandidateCpeGenerator()
+
+    # Capture the mapping of cpes to each distro package
+    os_pkg_cpe_mappings: List[Tuple[ImagePackage, ImageCpe]] = []
+
+    for pkg in packages:
+        os_pkg_cpe_mappings.extend(
+            [(pkg, cpe) for cpe in cpe_generator.for_distro_package(pkg)]
+        )
+    return os_pkg_cpe_mappings
+
+
+def cpe_product_version_keygen(cpe) -> Tuple[str]:
+    """
+    Key generator that uses only product and version, expects either an ImageCpe or a CpeVuln class
+
+    :param cpe:
+    :return:
+    """
+    # Name is an alias for product
+    try:
+        return (cpe.product, cpe.version)
+    except AttributeError:
+        return (cpe.name, cpe.version)
+
+
+def cpe_vendor_product_version_keygen(cpe) -> Tuple[str]:
+    """
+    Key generator that uses vendor, product, and version expects either an ImageCpe or a CpeVuln class
+
+    :param cpe:
+    :return:
+    """
+
+    # Name is an alias for product
+    try:
+        return (cpe.vendor, cpe.product, cpe.version)
+    except AttributeError:
+        return (cpe.vendor, cpe.name, cpe.version)
+
+
+def map_matches_to_image(
+    matched_vuln_cpes: List,
+    image_cpes: List[ImageCpe],
+    keygen_fn=cpe_product_version_keygen,
+) -> List[CpeMatch]:
+    """
+    Maps the vuln matches back to the image cpe by vendor, product, version tuple
+
+    :param matched_vuln_cpes:
+    :param image_cpes:
+    :return:
+    """
+    # Join the found cpes against the input cpes, this done after the queries to make queries faster
+    image_cpe_map = {keygen_fn(cpe): cpe for cpe in image_cpes}
+
+    return [
+        CpeMatch(
+            image_cpe=image_cpe_map[keygen_fn(vuln)],
+            vuln_cpe=vuln,
+        )
+        for vuln in matched_vuln_cpes
+    ]
+
+
+class UnsupportedCpeTypeError(Exception):
+    ...
+
+
+class NonOSCpeMatcher:
+    """
+    A CPE matcher for images. Requires that image CPE records are loaded into the database. Works only
+    on non-os package types (due to constraints on how things are loaded  in the db).
+
+    """
+
+    def __init__(
+        self,
+        nvd_cls: type = NvdV2Metadata,
+        cpe_cls: type = CpeV2Vulnerability,
+    ):
+        self.nvd_cls = nvd_cls
+        self.cpe_cls = cpe_cls
+        self.db_manager = CpeDBQueryManager(get_thread_scoped_session())
+
+    def image_cpe_vulnerabilities(self, image: Image) -> List[Tuple]:
+        """
+        Returns the cpe-based matches for the image's non-os packages as a list of (ImageCpe, <vuln cpe>) tuples
+        where the vuln cpe may be different types depending on config
+
+        :param image: image to scan
+        :return: list of (ImageCpe, <vuln cpe>) tuples
+        """
+
+        return dedup_cpe_vulnerabilities(self._scan_image_cpes(image))
+
+    def _scan_image_cpes(
+        self,
+        image: Image,
+    ) -> List[Tuple]:
+        """
+        Similar to the vulnerabilities function, but using the cpe matches instead, basically the NVD raw data source
+
+        :return: list of (image_cpe, cpe_vulnerability) tuples
+        """
+
+        with timer("non-os cpe matcher", log_level="debug"):
+            return self.db_manager.query_image_application_vulnerabilities(
+                self.cpe_cls, image
+            )
+
+
+class DistroEnabledCpeMatcher(NonOSCpeMatcher):
+    """
+    Scans distro packages for CPE-based matches
+    """
+
+    # If true, will not include matches in Cpe-Sources for with the matched CVE is also present in the distro-specific source
+    exclude_distro_records = True
+
+    def _scan_image_cpes(
+        self,
+        image: Image,
+    ) -> List[CpeMatch]:
+        """
+        Return a list of (image_cpe, cpe_vuln) tuples for the image where the image_cpe may be for os or non-os package types (e.g apks as well as npms)
+
+        :param image:
+        :return:
+        """
+
+        # Get matches for non-os packages
+        non_os_matches = [
+            CpeMatch(image_cpe=img_cpe, vuln_cpe=vuln_cpe)
+            for img_cpe, vuln_cpe in super()._scan_image_cpes(image)
+        ]
+        os_matches = self._scan_distro_packages_by_cpe(image)
+        all_matches = non_os_matches + os_matches
+
+        # Dedup between os and non-os? There could be name conflicts
+        deduped_matches = dedup_cpe_vulnerabilities(all_matches)
+        mapped = [
+            CpeMatch(image_cpe=img, vuln_cpe=vuln) for img, vuln in deduped_matches
+        ]
+        return mapped
+
+    def _scan_distro_packages_by_cpe(self, image: Image) -> List[CpeMatch]:
+
+        # Match the distro packages
+        with timer("os cpe matcher", log_level="debug"):
+            db = get_thread_scoped_session()
+            db.refresh(image)
+            os_matches = self._match_distro_packages_by_cpe(image)
+
+        return os_matches
+
+    def _query_cpe_matches(self, image_cpes: List[ImageCpe]) -> List[CpeMatch]:
+        """
+        Get the CVE ids for the input list of matches
+
+        :param db:
+        :param packages:
+        :return:
+        """
+        nvd_cpes = self.db_manager.query_nvd_cpe_matches(image_cpes, self.cpe_cls)
+        vulndb_cpes = self.db_manager.query_vulndb_cpes(image_cpes)
+        logger.debug(
+            "Found %s nvd matches and %s vulndb matches",
+            len(nvd_cpes),
+            len(vulndb_cpes),
+        )
+
+        # Join the found cpes against the input cpes, this done after the queries to make queries faster
+        nvd_findings = map_matches_to_image(nvd_cpes, image_cpes)
+        vulndb_findings = map_matches_to_image(vulndb_cpes, image_cpes)
+
+        return nvd_findings + vulndb_findings
+
+    @staticmethod
+    def get_cve_ids(matches: List[CpeMatch]) -> List[str]:
+        cve_ids = []
+
+        for match in matches:
+            if isinstance(match.vuln_cpe, VulnDBCpe):
+                cve_ids.extend(match.vuln_cpe.parent.referenced_cves)
+            else:
+                cve_ids.append(match.vuln_cpe.parent.name)
+
+        return list(set(cve_ids))  # Dedup the list
+
+    def _get_cpes_for_os_packages(
+        self, packages: List[ImagePackage]
+    ) -> List[Tuple[ImagePackage, ImageCpe]]:
+        return cpes_for_image_packages(packages)
+
+    def _match_distro_packages_by_cpe(self, image: Image) -> List[CpeMatch]:
+        """
+        Returns list of tuples of (imagecpe, vulncpe) that are matches
+
+        :param image:
+        :return: list of tuples
+        """
+        logger.spew(
+            "scanning os packages for cpe matches id=%s digest=%s",
+            image.id,
+            image.digest,
+        )
+
+        os_pkg_cpe_mappings = self._get_cpes_for_os_packages(image.packages)
+
+        logger.spew("distro cpes: %s", os_pkg_cpe_mappings)
+
+        os_cpes = [cpe for pkg, cpe in os_pkg_cpe_mappings]
+        # Get the matches
+        matches = self._query_cpe_matches(os_cpes)
+
+        logger.spew(
+            "pre-filter cpe distro findings: %s",
+            [(match.image_cpe, match.vuln_cpe.vulnerability_id) for match in matches],
+        )
+
+        # Filter the matches if configured to do so
+        if matches and self.exclude_distro_records:
+            # Remove any matches that are for a CVE ID that is represented in the vendor vuln db, regardless of match status.
+            matched_cve_ids = self.get_cve_ids(matches)
+            filtered_matched_cve_ids = set(
+                filter_secdb_entries(
+                    image.distro_namespace_obj(), matched_cve_ids, self.db_manager
+                )
+            )
+
+            matches = [
+                match
+                for match in matches
+                if match.vuln_cpe.vulnerability_id in filtered_matched_cve_ids
+            ]
+
+        logger.debug(
+            "post-filter cpe distro findings: %s",
+            [
+                (match.image_cpe.name, match.vuln_cpe.vulnerability_id)
+                for match in matches
+            ],
+        )
+
+        return matches

--- a/anchore_engine/services/policy_engine/engine/vulns/cpes.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/cpes.py
@@ -1,0 +1,181 @@
+import re
+import typing
+from typing import List, Tuple
+
+from anchore_engine.db.entities.policy_engine import ImageCpe, ImagePackage
+from anchore_engine.common import os_package_types
+
+
+def compare_fields(lhs, rhs):
+    """
+    Comparison function for cpe fields for ordering
+    - * is considered least specific and any non-* value is considered greater
+    - if both sides are non-*, comparison defaults to python lexicographic comparison for consistency
+    """
+
+    if lhs == "*":
+        if rhs == "*":
+            return 0
+        else:
+            return 1
+    else:
+        if rhs == "*":
+            return -1
+        else:
+            # case where both are not *, i.e. some value. pick a way to compare them, using lexicographic comparison for now
+            if rhs == lhs:
+                return 0
+            elif rhs > lhs:
+                return 1
+            else:
+                return -1
+
+
+def compare_cpes(lhs: ImageCpe, rhs: ImageCpe):
+    """
+    Compares the cpes based on business logic and returns -1, 0 or 1 if the lhs is lower than, equal to or greater than the rhs respectively
+
+    Business logic here is to compare vendor, name, version, update and meta fields in that order
+    """
+    vendor_cmp = compare_fields(lhs.vendor, rhs.vendor)
+    if vendor_cmp != 0:
+        return vendor_cmp
+
+    name_cmp = compare_fields(lhs.name, rhs.name)
+    if name_cmp != 0:
+        return name_cmp
+
+    version_cmp = compare_fields(lhs.version, rhs.version)
+    if version_cmp != 0:
+        return version_cmp
+
+    update_cmp = compare_fields(lhs.update, rhs.update)
+    if update_cmp != 0:
+        return update_cmp
+
+    meta_cmp = compare_fields(lhs.meta, rhs.meta)
+    if meta_cmp != 0:
+        return meta_cmp
+
+    # all avenues of comparison have been depleted, the two cpes are same for all practical purposes
+    return 0
+
+
+class FuzzyCandidateCpeGenerator:
+    """
+    A generator for CPEs from package metadata that generates candidates predictively
+    """
+
+    embedded_semver_regex = re.compile(r".*([0-9]+\.[0-9]+\.[0-9]+).*")
+
+    def for_distro_package(self, package: ImagePackage) -> typing.List[ImageCpe]:
+        """
+        Create the cpes for a single distro package
+
+        :param package:
+        :return: list of ImageCpes for the package
+        """
+        cpes = []
+
+        # Do a "-" --> "_" substitution addition so may have multiple cpe candidates for a single package
+        names = {package.name, re.sub("-", "_", package.name)}
+        if not package.pkg_path and package.pkg_type in os_package_types:
+            pkg_path = "pkgdb"
+        else:
+            pkg_path = package.pkg_path
+
+        for name in names:
+            # for vendor in vendors:
+            c = ImageCpe()
+            c.name = name
+            c.version = package.version
+            c.pkg_type = package.pkg_type
+            c.cpetype = "a"
+            c.vendor = "*"  # vendor match anything
+            c.meta = "-"
+            c.update = "-"
+            c.pkg_path = pkg_path
+            cpes.append(c)
+
+        return cpes
+
+    def _fuzzy_products(self, package: ImagePackage) -> typing.List[str]:
+        """
+        General handler for fuzzy CPE generation
+        :param package:
+        :return:
+        """
+
+        products = {package.name}
+        # TODO: add the generic product generation code (including nomatch exclusions here)
+        return list(products)
+
+    def _fuzzy_versions(self, package: ImagePackage) -> typing.List[str]:
+        versions = {package.version}
+        patt = re.match(self.embedded_semver_regex, package.version)
+        if patt:
+            candidate_version = patt.group(1)
+            versions.add(candidate_version)
+
+        return list(versions)
+
+
+class BasicVersionCpeMatcher:
+    """
+    Simple matcher that only examines the product and version fields for exact matches
+    """
+
+    def matches(self, cpe_a, cpe_b) -> bool:
+        return cpe_a.product == cpe_b.product and cpe_a.version == cpe_b.version
+
+
+class VendorEnabledMatcher:
+    """
+    Extended support for vendor matching, but
+    """
+
+    def matches(self, cpe_a, cpe_b) -> bool:
+        return (
+            cpe_a.vendor == cpe_b.vendor
+            and cpe_a.product == cpe_b.product
+            and cpe_a.version == cpe_b.version
+        )
+
+
+def dedup_cpe_vulnerabilities(image_vuln_tuples: List[Tuple]) -> List[Tuple]:
+    """
+    Due to multiple cpes per package in the analysis data, the list of matched vulnerabilities may contain duplicates.
+    This function filters the list and yields one record aka image vulnerability cpe tuple per vulnerability affecting a package
+    """
+    if not image_vuln_tuples:
+        return list()
+
+    # build a hash with vulnerability as the key mapped to a unique set of packages
+    dedup_hash = dict()
+
+    for image_cpe, vuln_cpe in image_vuln_tuples:
+
+        # construct key that ties vulnerability and package - a unique indicator for the vulnerability affecting a package
+        vuln_pkg_key = (
+            vuln_cpe.vulnerability_id,
+            vuln_cpe.namespace_name,
+            image_cpe.pkg_path,
+        )
+
+        # check if the vulnerability was already recorded for the package
+        if vuln_pkg_key in dedup_hash:
+            # compare the existing cpe to the new cpe
+            current_cpe = dedup_hash[vuln_pkg_key][0]
+            if compare_cpes(current_cpe, image_cpe) > 0:
+                # if the new cpe trumps the existing one, overwrite
+                dedup_hash[vuln_pkg_key] = (image_cpe, vuln_cpe)
+            else:
+                # otherwise leave the existing cpe be
+                pass
+        else:
+            # vulnerability was never recorded for the package, nothing to compare it against
+            dedup_hash[vuln_pkg_key] = (image_cpe, vuln_cpe)
+
+    final_results = list(dedup_hash.values())
+
+    return final_results

--- a/anchore_engine/services/policy_engine/engine/vulns/db.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/db.py
@@ -1,0 +1,259 @@
+import typing
+from typing import List, Tuple
+
+import sqlalchemy.orm
+from sqlalchemy import func, and_, or_
+from sqlalchemy.orm import Session, joinedload
+
+from anchore_engine.db import (
+    ImageCpe,
+    VulnDBCpe,
+    Image,
+    Vulnerability,
+    CpeV2Vulnerability,
+    DistroNamespace,
+)
+from anchore_engine.subsys import logger
+
+
+def db_result_tuples_to_list(
+    result_tulpe_rows: List[Tuple[str]], extract_tuple_index=0
+):
+    """
+    Expects tuple input from a tuple-style query response (each row is a tuple of result columns)
+
+    :param cve_tulpes:
+    :return:
+    """
+    return (
+        [row[extract_tuple_index] for row in result_tulpe_rows]
+        if result_tulpe_rows
+        else []
+    )
+
+
+class CpeDBQueryManager:
+    def __init__(self, db_session: Session):
+        self.db_session = db_session
+
+    def joined_query_image_application_nvd_vulns(
+        self, cpe_cls: typing.Type, image_id: str, account: str
+    ) -> List[Tuple]:
+        """
+        Match image non-os packages against NVD cpes using a DB query to join for cpes of non-os packages that
+        are entered in the db at image-load time.
+
+        :param db: db session
+        :param account: account name
+        :param image_id: the image id
+        :param cpe_cls: the class of CPE to match against in the db entities
+        :return: list of ImageCpe, cpe_cls tuples
+        """
+        cpe_vulnerabilities = (
+            self.db_session.query(ImageCpe, cpe_cls)
+            .filter(
+                ImageCpe.image_id == image_id,
+                ImageCpe.image_user_id == account,
+                func.lower(ImageCpe.name) == cpe_cls.name,
+                ImageCpe.version == cpe_cls.version,
+            )
+            .options(joinedload(cpe_cls.parent, innerjoin=True))
+            .all()
+        )
+        return cpe_vulnerabilities
+
+    def joined_query_image_application_vulndb_vulns(
+        self, image_id: str, user_id: str
+    ) -> List[Tuple[ImageCpe, VulnDBCpe]]:
+        """
+        Return matches of image non-os packages against VulnDB data if present using a joined query in the DB for
+        image cpes loaded into the db already
+
+        :param user_id:
+        :param image_id:
+        :param db:
+        :param image:
+        :return:
+        """
+        matches = (
+            self.db_session.query(ImageCpe, VulnDBCpe)
+            .filter(
+                ImageCpe.image_id == image_id,
+                ImageCpe.image_user_id == user_id,
+                func.lower(ImageCpe.name) == VulnDBCpe.name,
+                ImageCpe.version == VulnDBCpe.version,
+                VulnDBCpe.is_affected.is_(True),
+            )
+            .options(joinedload(VulnDBCpe.parent, innerjoin=True))
+            .all()
+        )
+        return matches
+
+    def query_image_application_vulnerabilities(
+        self,
+        cpe_cls: typing.Type,
+        image: Image,
+    ) -> List[Tuple]:
+        """
+        Find image cpes for non-distro packages (application packages) by doing a CPE match on the CPE-based feeds
+
+        :return: list of (image_cpe, cpe_vulnerability) tuples
+        """
+        cpe_vulns = self.joined_query_image_application_nvd_vulns(
+            cpe_cls, image.id, image.user_id
+        )
+        vulndb_vulns = self.joined_query_image_application_vulndb_vulns(
+            image.id, image.user_id
+        )
+
+        # vulndb is similar to nvd cpes, add them here
+        cpe_vulns.extend(vulndb_vulns)
+        return cpe_vulns
+
+    def matched_records_for_namespace(
+        self, namespace: DistroNamespace, filter_ids: List[str]
+    ) -> List[str]:
+        return db_result_tuples_to_list(
+            self._query_records_for_namespace(namespace, filter_ids)
+        )
+
+    def _query_records_for_namespace(
+        self, namespace: DistroNamespace, filter_ids: List[str]
+    ) -> List[Tuple[str]]:
+        """
+        Utility function to lookup all vulns for the namespace
+
+        :param namespace_name: string namespace (e.g. "alpine:3.8")
+        :param match_set: the list of cve ids to query against
+        :return: iterable for Vulnerability records
+        """
+
+        # Chunk on length of match_set
+        chunk_size = 100
+        idx = 0
+        vuln_ids = []
+        match_count = len(filter_ids)
+
+        logger.spew("Checking for sec db matches for %s", filter_ids)
+
+        # Do a chunked query to ensure a long list of match_set doesn't break due to query length
+        while idx < match_count:
+            chunk = filter_ids[idx : idx + chunk_size]
+            idx += chunk_size
+            logger.spew(
+                "Query chunk %s with namespace %s",
+                chunk,
+                namespace.like_namespace_names,
+            )
+
+            qry = self.db_session.query(Vulnerability.id).filter(
+                Vulnerability.namespace_name.in_(namespace.like_namespace_names),
+                Vulnerability.id.in_(chunk),
+            )
+
+            result = _db_query_wrapper(qry, get_all=True)
+            logger.spew("Raw result = %s", str(result))
+            vuln_ids.extend(result)
+
+        logger.spew("Found cve id matches for %s", vuln_ids)
+        return vuln_ids
+
+    def query_nvd_cpe_matches(
+        self, packages: List[ImageCpe], cpe_cls=CpeV2Vulnerability
+    ) -> List:
+        """
+        DB Query helper to get NVD matches for the given product and version
+
+        :param packages:
+        :param cpe_cls: The cpe class to query
+        :return:
+        """
+
+        chunk_size = 50  # Max number of and/or clauses per query
+        count = 0
+        results = []
+
+        clauses = []
+        # # OR the AND clauses together
+        for image_cpe in packages:
+            clauses.append(
+                and_(
+                    image_cpe.name == cpe_cls.product,
+                    image_cpe.version == cpe_cls.version,
+                )
+            )
+            count += 1
+
+            if count >= chunk_size:
+                # Run the query
+                qry = self.db_session.query(cpe_cls).filter(or_(*clauses))
+                results.extend(_db_query_wrapper(qry, get_all=True))
+                count = 0
+                clauses = []
+
+        if count > 0:
+            # Run the query to catch the last set
+            qry = self.db_session.query(cpe_cls).filter(or_(*clauses))
+            results.extend(_db_query_wrapper(qry, get_all=True))
+
+        return results
+
+    def query_vulndb_cpes(self, packages: List[ImageCpe]) -> List[VulnDBCpe]:
+        """
+        DB query helper to get VulnDB matches for hte given product and version
+        :param db:
+        :param packages:
+        :return:
+        """
+
+        chunk_size = 50  # Max number of and/or clauses per query
+        count = 0
+        results = []
+
+        # OR the AND clauses together
+        clauses = []
+        for cpe in packages:
+            clauses.append(
+                and_(
+                    VulnDBCpe.name == cpe.name,
+                    VulnDBCpe.version == cpe.version,
+                )
+            )
+            count += 1
+
+            if count >= chunk_size:
+                # Run the query
+                qry = (
+                    self.db_session.query(VulnDBCpe)
+                    .filter(VulnDBCpe.is_affected.is_(True))
+                    .filter(or_(*clauses))
+                )
+                results.extend(_db_query_wrapper(qry, get_all=True))
+                clauses = []
+                count = 0
+
+        if count > 0:
+            # Run the query to catch the last set
+            qry = (
+                self.db_session.query(VulnDBCpe)
+                .filter(VulnDBCpe.is_affected.is_(True))
+                .filter(or_(*clauses))
+            )
+            results.extend(_db_query_wrapper(qry, get_all=True))
+
+        return results
+
+
+def _db_query_wrapper(query: sqlalchemy.orm.Query, get_all=True):
+    """
+    Logging wrapper on the query call to simplify debugging
+    :param query:
+    :param get_all:
+    :return:
+    """
+    logger.spew("executing query: %s", str(query))
+    # If get_all, then caller will iterate over results
+    if get_all:
+        return query.all()
+
+    return query

--- a/anchore_engine/services/policy_engine/engine/vulns/providers.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/providers.py
@@ -319,7 +319,7 @@ class LegacyProvider(VulnerabilitiesProvider):
 
         user_id = image.user_id
         image_id = image.id
-
+        warns = []
         results = []
 
         if force_refresh:
@@ -354,7 +354,7 @@ class LegacyProvider(VulnerabilitiesProvider):
             vulns = []
             ns = DistroNamespace.for_obj(image)
             if not have_vulnerabilities_for(ns):
-                warns = [
+                warns += [
                     "No vulnerability data available for image distro: {}".format(
                         ns.namespace_name
                     )

--- a/anchore_engine/services/policy_engine/engine/vulns/scanners.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/scanners.py
@@ -5,15 +5,24 @@ A scanner may use persistence context or an external tool to match image content
 import datetime
 import json
 import os
-import uuid
+import typing
+from typing import List
+
+from sqlalchemy.orm.session import Session
 
 from anchore_engine.clients.grype_wrapper import GrypeWrapperSingleton
-from anchore_engine.configuration import localconfig
-from anchore_engine.db.entities.policy_engine import ImageCpe, Image
 from anchore_engine.common.models.policy_engine import (
     ImageVulnerabilitiesReport,
     VulnerabilitiesReportMetadata,
     VulnerabilityScanProblem,
+)
+from anchore_engine.configuration import localconfig
+from anchore_engine.db.entities.policy_engine import (
+    Image,
+    ImagePackageVulnerability,
+    ImageCpe,
+    NvdV2Metadata,
+    CpeV2Vulnerability,
 )
 from anchore_engine.services.policy_engine.engine import vulnerabilities
 from anchore_engine.services.policy_engine.engine.feeds.grypedb_sync import (
@@ -22,7 +31,7 @@ from anchore_engine.services.policy_engine.engine.feeds.grypedb_sync import (
 )
 from anchore_engine.subsys import logger
 from anchore_engine.utils import timer
-from typing import List
+from .cpe_matchers import NonOSCpeMatcher, DistroEnabledCpeMatcher
 from .dedup import get_image_vulnerabilities_deduper
 from .mappers import to_grype_sbom, to_engine_vulnerabilities
 
@@ -31,124 +40,58 @@ SAVE_SBOM_TO_FILE = (
     os.getenv("ANCHORE_POLICY_ENGINE_SAVE_SBOM_TO_FILE", "true").lower() == "true"
 )
 
+# Distros that only add a CVE record to their secdb entries when a fix is available
+nvd_distro_matching_enabled = (
+    os.getenv("ANCHORE_ENABLE_DISTRO_NVD_MATCHES", "true").lower() == "true"
+)
+
+FIX_ONLY_DISTROS = ["alpine"]
+
+
+def is_fix_only_distro(distro_name: str) -> bool:
+    """
+    Does the given distro's security feed/db support vulnerability records before a fix is available?
+
+    :param distro_name:
+    :return: bool
+    """
+    return distro_name in FIX_ONLY_DISTROS
+
 
 class LegacyScanner:
     """
     Scanner wrapping the legacy vulnerabilities subsystem.
     """
 
-    def flush_and_recompute_vulnerabilities(self, image_obj, db_session):
+    def flush_and_recompute_vulnerabilities(
+        self, image_obj: Image, db_session: Session
+    ) -> typing.List[ImagePackageVulnerability]:
         """
         Wrapper for rescan_image function.
         """
-        vulnerabilities.rescan_image(image_obj, db_session)
+        return vulnerabilities.rescan_image(image_obj, db_session)
 
-    def compute_vulnerabilities(self, image_obj):
-        """
-        Wrapper for vulnerabilities_for_image function
-        """
+    def get_vulnerabilities(
+        self, image: Image
+    ) -> typing.List[ImagePackageVulnerability]:
+        distro_matches = image.vulnerabilities()
+        return distro_matches
 
-        vulnerabilities.vulnerabilities_for_image(image_obj)
-
-    def get_vulnerabilities(self, image):
-        return image.vulnerabilities()
-
-    def get_cpe_vulnerabilities(self, image, nvd_cls: type, cpe_cls: type):
-        with timer("Image vulnerability cpe lookups", log_level="debug"):
-            return self.dedup_cpe_vulnerabilities(
-                image.cpe_vulnerabilities(_nvd_cls=nvd_cls, _cpe_cls=cpe_cls)
-            )
-
-    def compare_fields(self, lhs, rhs):
-        """
-        Comparison function for cpe fields
-        - * is considered least specific and any non-* value is considered greater
-        - if both sides are non-*, comparison defaults to python lexicographic comparison for consistency
-        """
-
-        if lhs == "*":
-            if rhs == "*":
-                return 0
-            else:
-                return 1
+    def get_cpe_vulnerabilities(
+        self,
+        image: Image,
+        nvd_cls: type = NvdV2Metadata,
+        cpe_cls: type = CpeV2Vulnerability,
+    ):
+        if nvd_distro_matching_enabled and is_fix_only_distro(image.distro_name):
+            matcher = DistroEnabledCpeMatcher(nvd_cls, cpe_cls)
         else:
-            if rhs == "*":
-                return -1
-            else:
-                # case where both are not *, i.e. some value. pick a way to compare them, using lexicographic comparison for now
-                if rhs == lhs:
-                    return 0
-                elif rhs > lhs:
-                    return 1
-                else:
-                    return -1
+            matcher = NonOSCpeMatcher(nvd_cls, cpe_cls)
 
-    def compare_cpes(self, lhs: ImageCpe, rhs: ImageCpe):
-        """
-        Compares the cpes based on business logic and returns -1, 0 or 1 if the lhs is lower than, equal to or greater than the rhs respectively
+        with timer("Image vulnerability cpe lookups", log_level="debug"):
+            matches = matcher.image_cpe_vulnerabilities(image)
 
-        Business logic here is to compare vendor, name, version, update and meta fields in that order
-        """
-        vendor_cmp = self.compare_fields(lhs.vendor, rhs.vendor)
-        if vendor_cmp != 0:
-            return vendor_cmp
-
-        name_cmp = self.compare_fields(lhs.name, rhs.name)
-        if name_cmp != 0:
-            return name_cmp
-
-        version_cmp = self.compare_fields(lhs.version, rhs.version)
-        if version_cmp != 0:
-            return version_cmp
-
-        update_cmp = self.compare_fields(lhs.update, rhs.update)
-        if update_cmp != 0:
-            return update_cmp
-
-        meta_cmp = self.compare_fields(lhs.meta, rhs.meta)
-        if meta_cmp != 0:
-            return meta_cmp
-
-        # all avenues of comparison have been depleted, the two cpes are same for all practical purposes
-        return 0
-
-    def dedup_cpe_vulnerabilities(self, image_vuln_tuples):
-        """
-        Due to multiple cpes per package in the analysis data, the list of matched vulnerabilities may contain duplicates.
-        This function filters the list and yields one record aka image vulnerability cpe tuple per vulnerability affecting a package
-        """
-        if not image_vuln_tuples:
-            return list()
-
-        # build a hash with vulnerability as the key mapped to a unique set of packages
-        dedup_hash = dict()
-
-        for image_cpe, vuln_cpe in image_vuln_tuples:
-
-            # construct key that ties vulnerability and package - a unique indicator for the vulnerability affecting a package
-            vuln_pkg_key = (
-                vuln_cpe.vulnerability_id,
-                vuln_cpe.namespace_name,
-                image_cpe.pkg_path,
-            )
-
-            # check if the vulnerability was already recorded for the package
-            if vuln_pkg_key in dedup_hash:
-                # compare the existing cpe to the new cpe
-                current_cpe = dedup_hash[vuln_pkg_key][0]
-                if self.compare_cpes(current_cpe, image_cpe) > 0:
-                    # if the new cpe trumps the existing one, overwrite
-                    dedup_hash[vuln_pkg_key] = (image_cpe, vuln_cpe)
-                else:
-                    # otherwise leave the existing cpe be
-                    pass
-            else:
-                # vulnerability was never recorded for the package, nothing to compare it against
-                dedup_hash[vuln_pkg_key] = (image_cpe, vuln_cpe)
-
-        final_results = list(dedup_hash.values())
-
-        return final_results
+        return matches
 
 
 class GrypeScanner:

--- a/anchore_engine/subsys/logger.py
+++ b/anchore_engine/subsys/logger.py
@@ -179,8 +179,9 @@ def safe_formatter(message, args):
     return message
 
 
-def spew(msg_string):
-    return _msg(msg_string, msg_log_level="SPEW")
+def spew(msg_string, *args):
+    formatted_msg_string = safe_formatter(msg_string, args)
+    return _msg(formatted_msg_string, msg_log_level="SPEW")
 
 
 @bootstrap_logger_intercept(logging.DEBUG)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -104,3 +104,41 @@ def echo_anchore_db():
         return anchore_db(connection_str=None, do_echo=True)
 
     return invoke
+
+
+@pytest.fixture
+def mem_db(do_echo=False):
+    from anchore_engine.db.entities.common import (
+        get_engine,
+        initialize,
+        do_disconnect,
+        init_thread_session,
+        end_session,
+    )
+    from anchore_engine.db.entities.upgrade import do_create_tables
+
+    conn_str = "sqllite://:memory:"
+
+    config = {"credentials": {"database": {"db_connect": conn_str, "db_echo": do_echo}}}
+
+    try:
+        logger.info("Initializing connection: {}".format(config))
+        ret = initialize(localconfig=config)
+        init_thread_session(force_new=True)
+
+        engine = get_engine()
+        logger.info("Dropping db if found")
+        engine.execute("DROP SCHEMA public CASCADE")
+        engine.execute("CREATE SCHEMA public")
+        engine.execute("GRANT ALL ON SCHEMA public TO postgres")
+        engine.execute("GRANT ALL ON SCHEMA public TO public")
+
+        # Now ready for anchore init (tables etc)
+        logger.info("Creating tables")
+        do_create_tables()
+
+        yield ret
+    finally:
+        logger.info("Cleaning up/disconnect")
+        end_session()
+        do_disconnect()

--- a/tests/integration/services/policy_engine/test_vulnerabilities.py
+++ b/tests/integration/services/policy_engine/test_vulnerabilities.py
@@ -10,6 +10,12 @@ from anchore_engine.services.policy_engine.engine.vulns.providers import (
 from anchore_engine.subsys import logger
 from tests.integration.services.policy_engine.conftest import run_legacy_sync
 from tests.integration.services.policy_engine.utils import reset_feed_sync_time
+from anchore_engine.services.policy_engine import (
+    _init_distro_mappings,
+    init_feed_registry,
+)
+from anchore_engine.services.policy_engine.engine.vulns.providers import LegacyScanner
+
 
 logger.enable_test_logging()
 
@@ -101,7 +107,7 @@ def _img_vulns(id):
         img = db.query(Image).filter_by(id=id, user_id="0").one_or_none()
         assert img, "Image not found {}".format(id)
         total_vulns = [str(x) for x in img.vulnerabilities()] + [
-            str(y) for y in img.cpe_vulnerabilities(None, None)
+            str(y) for y in LegacyScanner().get_cpe_vulnerabilities(img)
         ]
         return total_vulns
     finally:

--- a/tests/unit/anchore_engine/db/fixtures/transformation_data.py
+++ b/tests/unit/anchore_engine/db/fixtures/transformation_data.py
@@ -1,4 +1,4 @@
-signle_cve = [
+single_cve = [
     {"source": "Bugtraq ID", "url": "http://www.securityfocus.com/bid/193"},
     {"source": "Snort Signature ID", "url": "http://www.snort.org/search/sid/1500?r=1"},
     {
@@ -6,6 +6,8 @@ signle_cve = [
         "url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=1999-0449",
     },
 ]
+
+single_cve_references = [(single_cve, ["CVE-1999-0449"])]
 
 multiple_cve = [
     {
@@ -34,6 +36,10 @@ multiple_cve = [
     },
 ]
 
+multiple_cve_references = [
+    (multiple_cve, ["CVE-2018-5146", "CVE-2018-5147", "CVE-2020-20412"])
+]
+
 no_cve = [
     {"source": "Vendor URL", "url": "http://tplink.com"},
     {
@@ -42,3 +48,5 @@ no_cve = [
     },
     {"source": "Exploit Database", "url": "http://www.exploit-db.com/exploits/29802"},
 ]
+
+no_cve_references = [(no_cve, [])]

--- a/tests/unit/anchore_engine/db/test_policy_engine.py
+++ b/tests/unit/anchore_engine/db/test_policy_engine.py
@@ -2,10 +2,11 @@ import pytest
 
 from .fixtures import transformation_data
 from anchore_engine.db.entities import policy_engine as pe
+from itertools import chain
 
 
 class TestPolicyEngine:
-    @pytest.mark.parametrize("single", [transformation_data.signle_cve])
+    @pytest.mark.parametrize("single", [transformation_data.single_cve])
     def test_normalized_id(self, single):
         # import ipdb; ipdb.set_trace()
         vulndb = pe.VulnDBMetadata(references=single)
@@ -25,3 +26,16 @@ class TestPolicyEngine:
         vulndb = pe.VulnDBMetadata(name="FAKEVULNDB-42", references=no_cve)
         res = vulndb.normalized_id
         assert res == "FAKEVULNDB-42"
+
+    @pytest.mark.parametrize(
+        "references, expected",
+        chain(
+            transformation_data.single_cve_references,
+            transformation_data.multiple_cve_references,
+            transformation_data.no_cve_references,
+        ),
+    )
+    def test_referenced_cves(self, references, expected):
+        assert sorted(
+            pe.VulnDBMetadata(name="VULNDB-1", references=references).referenced_cves
+        ) == sorted(expected)

--- a/tests/unit/anchore_engine/services/policy_engine/engine/test_legacy_scanner.py
+++ b/tests/unit/anchore_engine/services/policy_engine/engine/test_legacy_scanner.py
@@ -1,0 +1,51 @@
+import datetime
+
+from anchore_engine.db.entities.policy_engine import (
+    Image,
+    ImageCpe,
+    ImagePackage,
+    ImagePackageVulnerability,
+)
+from anchore_engine.services.policy_engine.engine.vulns.scanners import (
+    LegacyScanner,
+    NonOSCpeMatcher,
+)
+
+import pytest
+
+
+@pytest.fixture
+def alpine_image():
+    img = Image()
+    img.distro_name = "alpine"
+    img.distro_version = "3.10"
+    img.id = "abc123abc123"
+    img.analysis_artifacts = []
+    img.digest = "sha256:abc123abc123"
+    img.created_at = datetime.datetime.utcnow()
+    img.last_modified = img.created_at
+    img.cpes = []
+    img.docker_data_json = {}
+    img.dockerfile_contents = ""
+    img.dockerfile_mode = "guessed"
+    img.docker_history_json = []
+    img.packages = []
+    img.gems = []
+    img.npms = []
+    img.state = "analyzed"
+    img.size = "1000"
+    img.user_id = "admin"
+    return img
+
+
+@pytest.fixture
+def alpine_with_vulns(alpine_image):
+    alpine_image.vulnerabilities = lambda: []
+    alpine_image.cpe_vulnerabilities = lambda x, y: []
+    return alpine_image
+
+
+def test_scanner_basic(alpine_with_vulns):
+    scanner = LegacyScanner()
+    vulns = scanner.get_vulnerabilities(alpine_with_vulns)
+    assert vulns == []

--- a/tests/unit/anchore_engine/services/policy_engine/engine/vulnerabilities/test_cpe_matchers.py
+++ b/tests/unit/anchore_engine/services/policy_engine/engine/vulnerabilities/test_cpe_matchers.py
@@ -1,0 +1,283 @@
+import datetime
+from typing import List, Tuple
+
+import pytest
+
+import anchore_engine.db.entities.common
+import anchore_engine.services.policy_engine.engine.vulns.cpe_matchers
+import anchore_engine.services.policy_engine.engine.vulns.db
+from anchore_engine.services.policy_engine.engine.vulns.cpe_matchers import (
+    cve_ids_for_vuln_record,
+    filter_secdb_entries,
+    cpes_for_image_packages,
+)
+from anchore_engine.services.policy_engine.engine.vulns.cpes import (
+    dedup_cpe_vulnerabilities,
+)
+
+from anchore_engine.db.entities.policy_engine import (
+    Vulnerability,
+    CpeV2Vulnerability,
+    ImageCpe,
+    DistroNamespace,
+    DistroTuple,
+    ImagePackage,
+)
+
+
+@pytest.mark.parametrize(
+    "record, expected",
+    [
+        (
+            Vulnerability(id="ALAS-123", metadata_json={"CVE": ["CVE-2021"]}),
+            ["CVE-2021"],
+        ),
+        (
+            Vulnerability(id="CVE-123", metadata_json={"CVE": ["CVE-2021"]}),
+            ["CVE-123", "CVE-2021"],
+        ),
+        (Vulnerability(id="CVE-123"), ["CVE-123"]),
+    ],
+)
+def test_cve_ids_for_vuln_record(record, expected):
+    assert sorted(cve_ids_for_vuln_record(record)) == sorted(expected)
+
+
+@pytest.mark.parametrize(
+    "matches, expected",
+    [
+        (
+            [
+                (
+                    ImageCpe(name="package1", version="1.0"),
+                    CpeV2Vulnerability(
+                        feed_name="nvdv2:cves",
+                        vulnerability_id="CVE-123",
+                        product="package1",
+                        version="1.0",
+                        created_at=datetime.datetime(year=2021, month=1, day=1),
+                    ),
+                )
+            ],
+            [
+                (
+                    ImageCpe(name="package1", version="1.0"),
+                    CpeV2Vulnerability(
+                        feed_name="nvdv2:cves",
+                        vulnerability_id="CVE-123",
+                        product="package1",
+                        version="1.0",
+                        created_at=datetime.datetime(year=2021, month=1, day=1),
+                    ),
+                )
+            ],
+        ),
+        (
+            [
+                (
+                    ImageCpe(name="package1", version="1.0"),
+                    CpeV2Vulnerability(
+                        feed_name="nvdv2:cves",
+                        vulnerability_id="CVE-123",
+                        product="package1",
+                        version="1.0",
+                        created_at=datetime.datetime(year=2021, month=1, day=1),
+                    ),
+                ),
+                (
+                    ImageCpe(name="package1", version="1.0"),
+                    CpeV2Vulnerability(
+                        feed_name="nvdv2:cves",
+                        vulnerability_id="CVE-123",
+                        product="package1",
+                        version="1.0",
+                        created_at=datetime.datetime(year=2021, month=1, day=1),
+                    ),
+                ),
+            ],
+            [
+                (
+                    ImageCpe(name="package1", version="1.0"),
+                    CpeV2Vulnerability(
+                        feed_name="nvdv2:cves",
+                        vulnerability_id="CVE-123",
+                        product="package1",
+                        version="1.0",
+                        created_at=datetime.datetime(year=2021, month=1, day=1),
+                    ),
+                )
+            ],
+        ),
+        (
+            [
+                (
+                    ImageCpe(name="package1", version="1.0"),
+                    CpeV2Vulnerability(
+                        feed_name="nvdv2:cves",
+                        vulnerability_id="CVE-123",
+                        product="package1",
+                        version="1.0",
+                        created_at=datetime.datetime(year=2021, month=1, day=1),
+                    ),
+                ),
+                (
+                    ImageCpe(name="package1", version="1.0", pkg_path="/foo"),
+                    CpeV2Vulnerability(
+                        feed_name="nvdv2:cves",
+                        vulnerability_id="CVE-123",
+                        product="package1",
+                        version="1.0",
+                        created_at=datetime.datetime(year=2021, month=1, day=1),
+                    ),
+                ),
+            ],
+            [
+                (
+                    ImageCpe(name="package1", version="1.0"),
+                    CpeV2Vulnerability(
+                        feed_name="nvdv2:cves",
+                        vulnerability_id="CVE-123",
+                        product="package1",
+                        version="1.0",
+                        created_at=datetime.datetime(year=2021, month=1, day=1),
+                    ),
+                ),
+                (
+                    ImageCpe(name="package1", version="1.0", pkg_path="/foo"),
+                    CpeV2Vulnerability(
+                        feed_name="nvdv2:cves",
+                        vulnerability_id="CVE-123",
+                        product="package1",
+                        version="1.0",
+                        created_at=datetime.datetime(year=2021, month=1, day=1),
+                    ),
+                ),
+            ],
+        ),
+    ],
+)
+def test_dedup_cpe_vulns(matches, expected):
+    # This equality check isn't very good, but __repr__ should be sufficiently unique for this test
+    assert [(str(x), str(y)) for x, y in dedup_cpe_vulnerabilities(matches)] == [
+        (str(x), str(y)) for x, y in expected
+    ]
+
+
+@pytest.fixture
+def monkeypatched_records_for_namespace(monkeysession, request):
+    def mock_matched_records_for_namespace(
+        namespace_name: str, match_set: List[str]
+    ) -> List[str]:
+        return request.param
+
+    monkeysession.setattr(
+        anchore_engine.services.policy_engine.engine.vulns.db.CpeDBQueryManager,
+        "matched_records_for_namespace",
+        mock_matched_records_for_namespace,
+    )
+
+    return monkeysession
+
+
+@pytest.fixture
+def monkeypatched_distro_mappings(monkeysession):
+    def mock_distros_mapped_to(name: str, version: str) -> List[DistroTuple]:
+        return [DistroTuple(name, version, "")]
+
+    def mock_distros_for(name: str, version: str, flavor: str) -> List[DistroTuple]:
+        return [DistroTuple(name, version, flavor)]
+
+    monkeysession.setattr(
+        anchore_engine.db.entities.policy_engine.DistroMapping,
+        "distros_mapped_to",
+        mock_distros_mapped_to,
+    )
+    monkeysession.setattr(
+        anchore_engine.db.entities.policy_engine.DistroMapping,
+        "distros_for",
+        mock_distros_for,
+    )
+
+    return monkeysession
+
+
+@pytest.fixture
+def mock_db_query_manager(monkeypatched_distro_mappings, request):
+    class MockDbQueryManager:
+        def matched_records_for_namespace(
+            self, namespace_name: str, filter_ids: List[str]
+        ) -> List[str]:
+            return request.param
+
+    return MockDbQueryManager()
+
+
+@pytest.mark.parametrize(
+    "image_matches, mock_db_query_manager, expected",
+    [
+        (["CVE-123"], ["CVE-123"], []),
+        (
+            ["CVE-1"],
+            ["CVE-123"],
+            ["CVE-1"],
+        ),
+        (["CVE-1", "CVE-2"], ["CVE-1"], ["CVE-2"]),
+    ],
+    indirect=["mock_db_query_manager"],
+)
+def test_filter_secdb(
+    image_matches,
+    mock_db_query_manager,
+    expected,
+):
+    namespace = DistroNamespace(
+        name="debian", version="9"
+    )  # This is needed for lookup, but does not change results since the cves are injected
+    filtered = filter_secdb_entries(
+        image_distro=namespace, matches=image_matches, db_manager=mock_db_query_manager
+    )
+    assert filtered == expected
+
+
+pkg1 = ImagePackage(name="pkg1", version="1.0.0")
+pkg2 = ImagePackage(name="pkg-two", version="2.0.0")
+pkg1_cpe = ImageCpe(name="pkg1", version="1.0.0")
+pkg2_cpe1 = ImageCpe(name="pkg-two", version="2.0.0")
+pkg2_cpe2 = ImageCpe(name="pkg_two", version="2.0.0")
+
+
+@pytest.mark.parametrize(
+    "packages, mapped_cpes",
+    [
+        (
+            [pkg1],
+            [(pkg1, pkg1_cpe)],
+        ),
+        (
+            [pkg2],
+            [
+                (pkg2, pkg2_cpe1),
+                (pkg2, pkg2_cpe2),
+            ],
+        ),
+    ],
+)
+def test_cpes_for_images_packages(packages, mapped_cpes):
+    def tuple_sort_key(
+        cpe_tuple: Tuple[ImagePackage, ImageCpe]
+    ) -> Tuple[str, str, str, str]:
+        img = cpe_tuple[0]
+        cpe = cpe_tuple[1]
+        return (
+            img.name,
+            img.version,
+            cpe.name,
+            cpe.version,
+        )
+
+    # For this test, just use simple string tuples to identify the results for equality check
+    # This should be safe since cpes are generated per package, so other package differentiating fields aren't relevant
+    # for the correctness of the cpe generation logic itself
+    sorted_found = sorted(map(tuple_sort_key, cpes_for_image_packages(packages)))
+    sorted_expected = sorted(map(tuple_sort_key, mapped_cpes))
+    assert sorted_found == sorted_expected

--- a/tests/unit/anchore_engine/services/policy_engine/engine/vulnerabilities/test_cpes.py
+++ b/tests/unit/anchore_engine/services/policy_engine/engine/vulnerabilities/test_cpes.py
@@ -1,8 +1,6 @@
-from anchore_engine.services.policy_engine.engine.vulns.scanners import (
-    LegacyScanner,
-)
 from anchore_engine.services.policy_engine.engine.loaders import ImageLoader
 from anchore_engine.db.entities.policy_engine import ImageCpe
+from anchore_engine.services.policy_engine.engine.vulns import cpes
 import pytest
 
 
@@ -40,7 +38,7 @@ def cpe_builder():
     ],
 )
 def test_cpe_field_comparison(lhs, rhs, result):
-    assert LegacyScanner().compare_fields(lhs, rhs) == result
+    assert cpes.compare_fields(lhs, rhs) == result
 
 
 @pytest.mark.parametrize(
@@ -106,4 +104,4 @@ def test_image_cpe_comparison(lhs, rhs, result, cpe_builder):
     lhs_cpe = cpe_builder(lhs)
     rhs_cpe = cpe_builder(rhs)
 
-    assert LegacyScanner().compare_cpes(lhs_cpe, rhs_cpe) == result
+    assert cpes.compare_cpes(lhs_cpe, rhs_cpe) == result


### PR DESCRIPTION
Creates a new CpeMatcher abstraction with 2 implementations: one for non-os only, and one that supports selective distros. The current distro selector is only for "alpine". These are implemented in the LegacyScanner only, as they are not needed in the GrypeScanner