### PR TITLE
Grype stage db fix

### DIFF
--- a/anchore_engine/services/policy_engine/engine/feeds/feeds.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/feeds.py
@@ -1082,10 +1082,11 @@ class GrypeDBFeed(LogContextMixin, DataFeed):
 
                     # Call grype-wrapper to stage a db update. Wrapper responds with object containing archive and db checksums.
                     engine_metadata = (
-                        GrypeWrapperSingleton.get_instance().stage_grype_db_update(
+                        GrypeWrapperSingleton.get_instance().update_grype_db(
                             grypedb_file.path,
                             checksum,
                             str(record.metadata["version"]),
+                            True,
                         )
                     )
                     db_metadata = (


### PR DESCRIPTION
This PR updates the stage and promote flow in the grype wrapper (and the code that calls it upstream) to only stage dbs from the feed sync, and downstream of that only promote them (without restaging them) from the grype db sync.