### PR TITLE
Fixes typo in __repr__ for ImageCpe that had wrong fields

### DIFF
--- a/anchore_engine/db/entities/policy_engine.py
+++ b/anchore_engine/db/entities/policy_engine.py
@@ -2442,7 +2442,6 @@ class ImageCpe(Base):
                 self.image_user_id,
                 self.image_id,
                 self.name,
-                self.name,
                 self.version,
                 self.pkg_type,
                 self.pkg_path,


### PR DESCRIPTION
Fixes a simple copy-paste error that makes the str() output of the entity in the logs confusing.