### PR TITLE
Image vulnerabilities differ for notifications

### DIFF
--- a/anchore_engine/services/catalog/catalog_impl.py
+++ b/anchore_engine/services/catalog/catalog_impl.py
@@ -37,6 +37,7 @@ import anchore_engine.subsys.events
 from anchore_engine.db import session_scope
 from collections import namedtuple
 from anchore_engine.util.docker import DockerImageReference
+from anchore_engine.services.catalog.utils import diff_image_vulnerabilities
 
 DeleteImageResponse = namedtuple("DeleteImageResponse", ["digest", "status", "detail"])
 
@@ -1602,12 +1603,11 @@ def perform_vulnerability_scan(
         doqueue = False
 
         vdiff = {}
-        # TODO implement the differ correctly for the new format
-        # if last_vuln_result and curr_vuln_result:
-        #     vdiff = anchore_utils.process_cve_status(
-        #         old_cves_result=last_vuln_result["legacy_report"],
-        #         new_cves_result=curr_vuln_result["legacy_report"],
-        #     )
+        if last_vuln_result and curr_vuln_result:
+            vdiff = diff_image_vulnerabilities(
+                old_result=last_vuln_result,
+                new_result=curr_vuln_result,
+            )
 
         obj_store.put_document(
             userId, "vulnerability_scan", archiveId, curr_vuln_result

--- a/anchore_engine/services/catalog/utils.py
+++ b/anchore_engine/services/catalog/utils.py
@@ -1,0 +1,281 @@
+from anchore_engine.common.models.policy_engine import (
+    ImageVulnerabilitiesReport,
+    VulnerabilityMatch,
+)
+from dataclasses import dataclass
+from typing import List, Dict, Tuple
+from operator import itemgetter
+from anchore_engine.subsys import logger
+from marshmallow.exceptions import ValidationError
+
+
+@dataclass(eq=True, frozen=True)  # for comparison ops
+class VulnerabilitySummary:
+    """
+    Backwards compatible condensed representation of vulnerability used for handling vulnerability notifications
+
+    Copied from summary_elements of anchore_engine/utils.py
+    """
+
+    CVE_ID: str
+    Severity: str
+    Vulnerable_Package: str
+    Fix_Available: str
+    URL: str
+    Package_Name: str
+    Package_Version: str
+    Package_Type: str
+    Feed: str
+    Feed_Group: str
+
+    @staticmethod
+    def from_match(match: VulnerabilityMatch):
+        return VulnerabilitySummary(
+            CVE_ID=match.vulnerability.vulnerability_id,
+            Severity=match.vulnerability.severity,
+            Vulnerable_Package="{}-{}".format(
+                match.artifact.name, match.artifact.version
+            ),
+            Fix_Available=",".join(match.fix.versions)
+            if match.fix.versions
+            else "None",
+            URL=match.vulnerability.link,
+            Package_Name=match.artifact.name,
+            Package_Version=match.artifact.version,
+            Package_Type=match.artifact.pkg_type,
+            Feed=match.vulnerability.feed,
+            Feed_Group=match.vulnerability.feed_group,
+        )
+
+    @staticmethod
+    def from_tuple(summary_tuple: Tuple):
+        return VulnerabilitySummary(*summary_tuple)
+
+
+def diff_image_vulnerabilities(old_result=None, new_result=None):
+    """
+    Returns the diff of two cve results. Only compares two valid results, if either is None or empty, will return empty.
+
+    :param cve_record:
+    :return: dict with diff results: {'added': [], 'updated': [], 'removed': []}
+    """
+
+    if not old_result or not new_result:
+        return {}  # Nothing to do
+
+    old_vuln_map = get_normalized_identity_summary_map(old_result)
+    new_vuln_map = get_normalized_identity_summary_map(new_result)
+
+    return diff_identity_summary_maps(old_vuln_map, new_vuln_map)
+
+
+def get_normalized_identity_summary_map(api_response):
+    """
+    Given an API response for image vulnerabilities - legacy table or new format, returns a dictionary with key value
+    pairs that represent the vulnerability identity and summary respectively.
+
+    An identity-summary key-value pair is necessary since the diffs have to compute added, removed and updated items.
+    Identity is used for computing items that were added or removed, summary is used for computing the updates
+    """
+    try:
+        # try parsing the report into new format
+        report = ImageVulnerabilitiesReport.from_json(api_response)
+        return get_normalized_map_from_report(report)
+    except ValidationError:
+        logger.warn(
+            "Unable to parse api response as a report object, falling back to legacy table format"
+        )
+        # fall back to old table format
+        return get_normalized_map_from_table(api_response)
+
+
+def get_normalized_map_from_report(
+    report: ImageVulnerabilitiesReport,
+) -> Dict[Tuple, VulnerabilitySummary]:
+    """
+    Transforms the input into a dictionary. Each match object in the report is transformed into a key value pair
+    where the key is an identity tuple and value is an instance of VulnerabilitySummary
+
+    Example of a match instance transformed into key value pair
+    (
+        'GHSA-v6wp-4m6f-gcjg',
+        'github:python',
+        'aiohttp',
+        '3.7.3',
+        '/usr/lib/python3.8/site-packages/aiohttp'
+    ): VulnerabilitySummary(
+            CVE_ID='GHSA-v6wp-4m6f-gcjg',
+            Severity='Low',
+            Vulnerable_Package='aiohttp-3.7.3',
+            Fix_Available='3.7.4',
+            URL='https://github.com/advisories/GHSA-v6wp-4m6f-gcjg',
+            Package_Name='aiohttp',
+            Package_Version='3.7.3',
+            Package_Type='python',
+            Feed='vulnerabilities',
+            Feed_Group='github:python'
+        )
+    }
+
+    """
+
+    if not report or not report.results:
+        return {}
+
+    return {
+        match.identity_tuple(): VulnerabilitySummary.from_match(match)
+        for match in report.results
+    }
+
+
+def get_normalized_map_from_table(table) -> Dict[Tuple, VulnerabilitySummary]:
+    """
+    Transforms the legacy image vulnerabilities response into a dictionary. Each row of results is transformed into a key-value pair where in
+    key is an identity tuple and value is an instance of VulnerabilitySummary
+
+    For instance, the following row result in legacy report
+
+    [
+        "GHSA-v6wp-4m6f-gcjg",
+        "Low",
+        1,
+        "aiohttp-3.7.3",
+        "3.7.4",
+        "8d4db62fbc412dd3a19f55bdf3d15bed65a7cdf9a3cf00630da685af565e2d25",
+        "None",
+        "https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
+        "python",
+        "vulnerabilities",
+        "github:python",
+        "aiohttp",
+        "/usr/lib/python3.8/site-packages/aiohttp",
+        "3.7.3",
+        "{\"nvd_data\": [], \"vendor_data\": []}"
+    ]
+
+    is transformed to the below key-value pair
+
+    (
+        'GHSA-v6wp-4m6f-gcjg',
+        'github:python',
+        'aiohttp',
+        '3.7.3',
+        '/usr/lib/python3.8/site-packages/aiohttp'
+    ): VulnerabilitySummary(
+        CVE_ID='GHSA-v6wp-4m6f-gcjg',
+        Severity='Low',
+        Vulnerable_Package='aiohttp-3.7.3',
+        Fix_Available='3.7.4',
+        URL='https://github.com/advisories/GHSA-v6wp-4m6f-gcjg',
+        Package_Name='aiohttp',
+        Package_Version='3.7.3',
+        Package_Type='python',
+        Feed='vulnerabilities',
+        Feed_Group='github:python'
+        )
+    }
+
+    Partially lifted from anchore_engine/utils.py. Can be deprecated and removed after legacy format is no longer widely used
+
+    """
+
+    table_header = table["legacy_report"]["multi"]["result"]["header"]
+    table_rows = table["legacy_report"]["multi"]["result"]["rows"]
+
+    if not table_header or not table_rows:
+        return {}
+
+    # header is a list
+    # [
+    #     "CVE_ID",
+    #     "Severity",
+    #     "*Total_Affected",
+    #     "Vulnerable_Package",
+    #     "Fix_Available",
+    #     "Fix_Images",
+    #     "Rebuild_Images",
+    #     "URL",
+    #     "Package_Type",
+    #     "Feed",
+    #     "Feed_Group",
+    #     "Package_Name",
+    #     "Package_Path",
+    #     "Package_Version",
+    #     "CVES",
+    # ]
+
+    # this mimics the VulnerabilityMatch.identity_tuple(),
+    # not bothering with a dataclass since 1. tuples are slightly faster 2. this function will be deprecated in the near future after the switch to new format is complete
+    identity_elements = [
+        "CVE_ID",
+        "Feed_Group",
+        "Package_Name",
+        "Package_Version",
+        "Package_Type",
+        "Package_Path",
+    ]
+
+    summary_elements = [
+        "CVE_ID",
+        "Severity",
+        "Vulnerable_Package",
+        "Fix_Available",
+        "URL",
+        "Package_Name",
+        "Package_Version",
+        "Package_Type",
+        "Feed",
+        "Feed_Group",
+    ]
+
+    identiy_indices = [table_header.index(item) for item in identity_elements]
+    summary_indices = [table_header.index(item) for item in summary_elements]
+
+    return {
+        itemgetter(*identiy_indices)(row): VulnerabilitySummary.from_tuple(
+            itemgetter(*summary_indices)(row)
+        )
+        for row in table_rows
+    }
+
+
+def diff_identity_summary_maps(
+    old_vuln_map: Dict[Tuple, VulnerabilitySummary] = None,
+    new_vuln_map: Dict[Tuple, VulnerabilitySummary] = None,
+):
+    """
+    Given previous vuln-scan map and new vuln-scan map for the same image, return a diff as a dictionary
+
+    Keys:
+    {
+        'added': [],
+        'removed': [],
+        'updated': []
+    }
+
+    Borrowed from anchore_engine/utils.py item_diffs()
+    """
+
+    if not old_vuln_map:
+        old_vuln_map = {}
+
+    if not new_vuln_map:
+        new_vuln_map = {}
+
+    old_identities = set(old_vuln_map.keys())
+    new_identities = set(new_vuln_map.keys())
+
+    added = [
+        new_vuln_map[x].__dict__ for x in new_identities.difference(old_identities)
+    ]
+    removed = [
+        old_vuln_map[x].__dict__ for x in old_identities.difference(new_identities)
+    ]
+
+    updated = [
+        new_vuln_map[x].__dict__
+        for x in new_identities.intersection(old_identities)
+        if new_vuln_map[x] != old_vuln_map[x]
+    ]
+
+    return {"added": added, "removed": removed, "updated": updated}

--- a/anchore_engine/services/policy_engine/api/controllers/synchronous_operations.py
+++ b/anchore_engine/services/policy_engine/api/controllers/synchronous_operations.py
@@ -240,10 +240,9 @@ def delete_image(user_id, image_id):
         )
         img = db.query(Image).get((image_id, user_id))
         if img:
-            for pkg_vuln in img.vulnerabilities():
-                db.delete(pkg_vuln)
-            # for pkg_vuln in img.java_vulnerabilities():
-            #    db.delete(pkg_vuln)
+            get_vulnerabilities_provider().delete_image_vulnerabilities(
+                image=img, db_session=db
+            )
             try:
                 conn_timeout = ApiRequestContextProxy.get_service().configuration.get(
                     "catalog_client_conn_timeout", DEFAULT_CACHE_CONN_TIMEOUT

--- a/anchore_engine/services/policy_engine/engine/vulns/providers.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/providers.py
@@ -262,6 +262,13 @@ class VulnerabilitiesProvider(ABC):
                 list(self.__default_sync_config__.keys()),
             )
 
+    @abstractmethod
+    def delete_image_vulnerabilities(self, image: Image, db_session):
+        """
+        Delete image vulnerabilities maintained by the provider
+        """
+        ...
+
 
 class LegacyProvider(VulnerabilitiesProvider):
     """
@@ -1039,6 +1046,10 @@ class LegacyProvider(VulnerabilitiesProvider):
 
         return groups
 
+    def delete_image_vulnerabilities(self, image: Image, db_session):
+        for pkg_vuln in image.vulnerabilities():
+            db_session.delete(pkg_vuln)
+
 
 class GrypeProvider(VulnerabilitiesProvider):
     __scanner__ = GrypeScanner
@@ -1531,6 +1542,9 @@ class GrypeProvider(VulnerabilitiesProvider):
         store_manager = self.__store__(image)
 
         return store_manager.is_modified(session=db_session, since=since)
+
+    def delete_image_vulnerabilities(self, image: Image, db_session):
+        ImageVulnerabilitiesStore(image_object=image).delete_all(session=db_session)
 
 
 # Override this map for associating different provider classes

--- a/tests/unit/anchore_engine/services/catalog/test_utils.py
+++ b/tests/unit/anchore_engine/services/catalog/test_utils.py
@@ -1,0 +1,489 @@
+import json
+import pytest
+from anchore_engine.services.catalog.utils import (
+    get_normalized_map_from_table,
+    get_normalized_map_from_report,
+    diff_identity_summary_maps,
+    VulnerabilitySummary,
+)
+from anchore_engine.common.models.policy_engine import (
+    VulnerabilityMatch,
+    ImageVulnerabilitiesReport,
+)
+
+
+@pytest.mark.parametrize(
+    "test_input, expected",
+    [
+        pytest.param(
+            [
+                [
+                    "GHSA-v6wp-4m6f-gcjg",
+                    "Low",
+                    1,
+                    "aiohttp-3.7.3",
+                    "3.7.4",
+                    "8d4db62fbc412dd3a19f55bdf3d15bed65a7cdf9a3cf00630da685af565e2d25",
+                    "None",
+                    "https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
+                    "python",
+                    "vulnerabilities",
+                    "github:python",
+                    "aiohttp",
+                    "/usr/lib/python3.8/site-packages/aiohttp",
+                    "3.7.3",
+                    '{"nvd_data": [], "vendor_data": []}',
+                ]
+            ],
+            {
+                (
+                    "GHSA-v6wp-4m6f-gcjg",
+                    "github:python",
+                    "aiohttp",
+                    "3.7.3",
+                    "python",
+                    "/usr/lib/python3.8/site-packages/aiohttp",
+                ): VulnerabilitySummary(
+                    CVE_ID="GHSA-v6wp-4m6f-gcjg",
+                    Severity="Low",
+                    Vulnerable_Package="aiohttp-3.7.3",
+                    Fix_Available="3.7.4",
+                    URL="https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
+                    Package_Name="aiohttp",
+                    Package_Version="3.7.3",
+                    Package_Type="python",
+                    Feed="vulnerabilities",
+                    Feed_Group="github:python",
+                )
+            },
+            id="valid",
+        ),
+        pytest.param(
+            [],
+            {},
+            id="empty-rows",
+        ),
+        pytest.param(
+            None,
+            {},
+            id="none-rows",
+        ),
+    ],
+)
+def test_get_normalized_map_from_table(test_input, expected):
+    api_response = {
+        "legacy_report": {
+            "multi": {
+                "result": {
+                    "header": [
+                        "CVE_ID",
+                        "Severity",
+                        "*Total_Affected",
+                        "Vulnerable_Package",
+                        "Fix_Available",
+                        "Fix_Images",
+                        "Rebuild_Images",
+                        "URL",
+                        "Package_Type",
+                        "Feed",
+                        "Feed_Group",
+                        "Package_Name",
+                        "Package_Path",
+                        "Package_Version",
+                        "CVES",
+                    ],
+                    "rows": test_input,
+                }
+            }
+        }
+    }
+
+    assert get_normalized_map_from_table(api_response) == expected
+
+
+@pytest.mark.parametrize(
+    "test_input, error",
+    [
+        pytest.param(
+            {
+                "legacy_report": {
+                    "multi": {
+                        "result": {
+                            "header": [
+                                "*Total_Affected",
+                                "Vulnerable_Package",
+                                "Fix_Images",
+                                "Rebuild_Images",
+                                "URL",
+                                "CVES",
+                            ],
+                            "rows": [
+                                [
+                                    "1",
+                                    "2",
+                                    3,
+                                    "4",
+                                    "5",
+                                    "6",
+                                    "7",
+                                    "8",
+                                    "9",
+                                    "10",
+                                    "11",
+                                    "12",
+                                    "13",
+                                    "14",
+                                    "15",
+                                ]
+                            ],
+                        }
+                    }
+                }
+            },
+            ValueError,
+            id="invalid-header",
+        ),
+        pytest.param(
+            {
+                "legacy_report": {
+                    "multi": {
+                        "result": {
+                            "header": [
+                                "CVE_ID",
+                                "Severity",
+                                "*Total_Affected",
+                                "Vulnerable_Package",
+                                "Fix_Available",
+                                "Fix_Images",
+                                "Rebuild_Images",
+                                "URL",
+                                "Package_Type",
+                                "Feed",
+                                "Feed_Group",
+                                "Package_Name",
+                                "Package_Path",
+                                "Package_Version",
+                                "CVES",
+                            ],
+                            "rows": [
+                                [
+                                    "GHSA-v6wp-4m6f-gcjg",
+                                    "Low",
+                                    1,
+                                ]
+                            ],
+                        }
+                    }
+                }
+            },
+            IndexError,
+            id="invalid-row",
+        ),
+        pytest.param(
+            {
+                "result": {
+                    "header": [
+                        "CVE_ID",
+                        "Severity",
+                        "*Total_Affected",
+                        "Vulnerable_Package",
+                        "Fix_Available",
+                    ],
+                    "rows": [
+                        [
+                            "GHSA-v6wp-4m6f-gcjg",
+                            "Low",
+                            1,
+                        ]
+                    ],
+                }
+            },
+            KeyError,
+            id="invalid-response-format",
+        ),
+    ],
+)
+def test_get_normalized_map_from_table_exceptions(test_input, error):
+    with pytest.raises(error):
+        assert get_normalized_map_from_table(test_input) == {}
+
+
+@pytest.mark.parametrize(
+    "test_input, expected",
+    [
+        pytest.param(
+            [
+                VulnerabilityMatch.from_json(
+                    {
+                        "artifact": {
+                            "cpe": None,
+                            "cpes": [],
+                            "location": "/usr/lib/python3.8/site-packages/aiohttp",
+                            "name": "aiohttp",
+                            "pkg_type": "python",
+                            "version": "3.7.3",
+                        },
+                        "fix": {
+                            "advisories": [],
+                            "observed_at": "2021-03-31T17:30:49Z",
+                            "versions": ["3.7.4"],
+                            "wont_fix": False,
+                        },
+                        "match": {"detected_at": "2021-06-07T20:20:47Z"},
+                        "nvd": [],
+                        "vulnerability": {
+                            "cvss": [],
+                            "description": None,
+                            "feed": "vulnerabilities",
+                            "feed_group": "github:python",
+                            "link": "https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
+                            "severity": "Low",
+                            "vulnerability_id": "GHSA-v6wp-4m6f-gcjg",
+                        },
+                    }
+                )
+            ],
+            {
+                (
+                    "GHSA-v6wp-4m6f-gcjg",
+                    "github:python",
+                    "aiohttp",
+                    "3.7.3",
+                    "python",
+                    "/usr/lib/python3.8/site-packages/aiohttp",
+                ): VulnerabilitySummary(
+                    CVE_ID="GHSA-v6wp-4m6f-gcjg",
+                    Severity="Low",
+                    Vulnerable_Package="aiohttp-3.7.3",
+                    Fix_Available="3.7.4",
+                    URL="https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
+                    Package_Name="aiohttp",
+                    Package_Version="3.7.3",
+                    Package_Type="python",
+                    Feed="vulnerabilities",
+                    Feed_Group="github:python",
+                )
+            },
+            id="valid",
+        ),
+        pytest.param(
+            [],
+            {},
+            id="empty-results",
+        ),
+        pytest.param(
+            None,
+            {},
+            id="none-results",
+        ),
+    ],
+)
+def test_get_normalized_map_from_report(test_input, expected):
+    report = ImageVulnerabilitiesReport(results=test_input)
+    assert get_normalized_map_from_report(report) == expected
+
+
+@pytest.mark.parametrize(
+    "old_input, new_input, diff",
+    [
+        pytest.param(
+            {
+                (
+                    "GHSA-v6wp-4m6f-gcjg",
+                    "github:python",
+                    "aiohttp",
+                    "3.7.3",
+                    "python",
+                    "/usr/lib/python3.8/site-packages/aiohttp",
+                ): VulnerabilitySummary(
+                    CVE_ID="GHSA-v6wp-4m6f-gcjg",
+                    Severity="Low",
+                    Vulnerable_Package="aiohttp-3.7.3",
+                    Fix_Available="3.7.4",
+                    URL="https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
+                    Package_Name="aiohttp",
+                    Package_Version="3.7.3",
+                    Package_Type="python",
+                    Feed="vulnerabilities",
+                    Feed_Group="github:python",
+                )
+            },
+            {
+                (
+                    "GHSA-v6wp-4m6f-gcjg",
+                    "github:python",
+                    "aiohttp",
+                    "3.7.3",
+                    "python",
+                    "/usr/lib/python3.8/site-packages/aiohttp",
+                ): VulnerabilitySummary(
+                    CVE_ID="GHSA-v6wp-4m6f-gcjg",
+                    Severity="Low",
+                    Vulnerable_Package="aiohttp-3.7.3",
+                    Fix_Available="3.7.4",
+                    URL="https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
+                    Package_Name="aiohttp",
+                    Package_Version="3.7.3",
+                    Package_Type="python",
+                    Feed="vulnerabilities",
+                    Feed_Group="github:python",
+                )
+            },
+            {
+                "added": [],
+                "removed": [],
+                "updated": [],
+            },
+            id="same",
+        ),
+        pytest.param(
+            {
+                (
+                    "GHSA-v6wp-4m6f-gcjg",
+                    "github:python",
+                    "aiohttp",
+                ): VulnerabilitySummary(
+                    CVE_ID="GHSA-v6wp-4m6f-gcjg",
+                    Severity="Low",
+                    Vulnerable_Package="aiohttp-3.7.3",
+                    Fix_Available="3.7.4",
+                    URL="https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
+                    Package_Name="aiohttp",
+                    Package_Version="3.7.3",
+                    Package_Type="python",
+                    Feed="vulnerabilities",
+                    Feed_Group="github:python",
+                )
+            },
+            {},
+            {
+                "added": [],
+                "removed": [
+                    VulnerabilitySummary(
+                        CVE_ID="GHSA-v6wp-4m6f-gcjg",
+                        Severity="Low",
+                        Vulnerable_Package="aiohttp-3.7.3",
+                        Fix_Available="3.7.4",
+                        URL="https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
+                        Package_Name="aiohttp",
+                        Package_Version="3.7.3",
+                        Package_Type="python",
+                        Feed="vulnerabilities",
+                        Feed_Group="github:python",
+                    ).__dict__
+                ],
+                "updated": [],
+            },
+            id="removed",
+        ),
+        pytest.param(
+            {},
+            {
+                (
+                    "GHSA-v6wp-4m6f-gcjg",
+                    "github:python",
+                    "aiohttp",
+                ): VulnerabilitySummary(
+                    CVE_ID="GHSA-v6wp-4m6f-gcjg",
+                    Severity="Low",
+                    Vulnerable_Package="aiohttp-3.7.3",
+                    Fix_Available="3.7.4",
+                    URL="https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
+                    Package_Name="aiohttp",
+                    Package_Version="3.7.3",
+                    Package_Type="python",
+                    Feed="vulnerabilities",
+                    Feed_Group="github:python",
+                )
+            },
+            {
+                "added": [
+                    VulnerabilitySummary(
+                        CVE_ID="GHSA-v6wp-4m6f-gcjg",
+                        Severity="Low",
+                        Vulnerable_Package="aiohttp-3.7.3",
+                        Fix_Available="3.7.4",
+                        URL="https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
+                        Package_Name="aiohttp",
+                        Package_Version="3.7.3",
+                        Package_Type="python",
+                        Feed="vulnerabilities",
+                        Feed_Group="github:python",
+                    ).__dict__
+                ],
+                "removed": [],
+                "updated": [],
+            },
+            id="added",
+        ),
+        pytest.param(
+            {
+                (
+                    "GHSA-v6wp-4m6f-gcjg",
+                    "github:python",
+                    "aiohttp",
+                    "3.7.3",
+                    "python",
+                    "/usr/lib/python3.8/site-packages/aiohttp",
+                ): VulnerabilitySummary(
+                    CVE_ID="GHSA-v6wp-4m6f-gcjg",
+                    Severity="Low",
+                    Vulnerable_Package="aiohttp-3.7.3",
+                    Fix_Available="3.7.4",
+                    URL="https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
+                    Package_Name="aiohttp",
+                    Package_Version="3.7.3",
+                    Package_Type="python",
+                    Feed="vulnerabilities",
+                    Feed_Group="github:python",
+                )
+            },
+            {
+                (
+                    "GHSA-v6wp-4m6f-gcjg",
+                    "github:python",
+                    "aiohttp",
+                    "3.7.3",
+                    "python",
+                    "/usr/lib/python3.8/site-packages/aiohttp",
+                ): VulnerabilitySummary(
+                    CVE_ID="GHSA-v6wp-4m6f-gcjg",
+                    Severity="High",
+                    Vulnerable_Package="aiohttp-3.7.3",
+                    Fix_Available="3.7.4",
+                    URL="https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
+                    Package_Name="aiohttp",
+                    Package_Version="3.7.3",
+                    Package_Type="python",
+                    Feed="vulnerabilities",
+                    Feed_Group="github:python",
+                )
+            },
+            {
+                "added": [],
+                "removed": [],
+                "updated": [
+                    VulnerabilitySummary(
+                        CVE_ID="GHSA-v6wp-4m6f-gcjg",
+                        Severity="High",
+                        Vulnerable_Package="aiohttp-3.7.3",
+                        Fix_Available="3.7.4",
+                        URL="https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
+                        Package_Name="aiohttp",
+                        Package_Version="3.7.3",
+                        Package_Type="python",
+                        Feed="vulnerabilities",
+                        Feed_Group="github:python",
+                    ).__dict__
+                ],
+            },
+            id="updated",
+        ),
+        pytest.param({}, {}, {"added": [], "removed": [], "updated": []}, id="empty"),
+        pytest.param(
+            None, None, {"added": [], "removed": [], "updated": []}, id="none"
+        ),
+    ],
+)
+def test_diff_identity_summary_maps(old_input, new_input, diff):
+    assert diff_identity_summary_maps(old_input, new_input) == diff


### PR DESCRIPTION
table format response for image vulns was gutted and replaced by a new report style format in the policy-engine. This meant all the clients using the response format had to be updated as well. One final holdout is the catalog differ - it computes the diffs between  results for a given image for notifying the user of changes. This PR adds 
- adds the logic for normalizing both the legacy and new formats 
- diffs the normalized data 