### PR TITLE
Bug fixes for image deletion and list comprehension

### DIFF
--- a/anchore_engine/db/entities/policy_engine.py
+++ b/anchore_engine/db/entities/policy_engine.py
@@ -2022,7 +2022,10 @@ class ImagePackage(Base):
     )
 
     vulnerabilities = relationship(
-        "ImagePackageVulnerability", back_populates="package", lazy="dynamic"
+        "ImagePackageVulnerability",
+        back_populates="package",
+        lazy="dynamic",
+        cascade=["all", "delete", "delete-orphan"],
     )
     image = relationship("Image", back_populates="packages")
     pkg_db_entries = relationship(

--- a/anchore_engine/services/policy_engine/engine/vulns/mappers.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/mappers.py
@@ -148,13 +148,11 @@ class ApkgMapper(PackageMapper):
     ):
         artifact = super().to_grype(image_package, location_cpes_dict)
 
-        # populate cpes for os packages
-        artifact["cpes"] = [
-            cpe.get_cpe23_fs_for_sbom()
-            for cpe in location_cpes_dict.get(
-                f"pkgdb/{image_package.name}"  # pkgdb/ prefix is added to all os package locations, it's the only way to associate a package with it's cpes
-            )
-        ]
+        # pkgdb/ prefix is added to all os package locations, it's the only way to associate a package with it's cpes
+        cpes = location_cpes_dict.get(f"pkgdb/{image_package.name}")
+        if cpes:
+            # populate cpes for os packages
+            artifact["cpes"] = [cpe.get_cpe23_fs_for_sbom() for cpe in cpes]
 
         return artifact
 
@@ -537,7 +535,7 @@ def to_grype_sbom(
             artifacts.append(pkg_mapper.to_grype(image_package, location_cpes_dict))
         except Exception:
             log.exception(
-                "Ignoring error in engine->grype transformation for {} package {}, skipping it from sbom",
+                "Ignoring error in engine->grype transformation for %s package %s, skipping it from sbom",
                 image_package.pkg_type,
                 image_package.name,
             )


### PR DESCRIPTION
This PR fixes 
- image deletion errors caused by a missing cascade condition in the persistence context definition
- null checks reference before iterating through it