### PR TITLE
Filter unsupported artifact types from analyzer sbom regardless of ANCHORE_ENABLE_PACKAGE_FILTERING configuration.

### DIFF
--- a/tests/unit/anchore_engine/analyzers/syft/test_syft.py
+++ b/tests/unit/anchore_engine/analyzers/syft/test_syft.py
@@ -108,25 +108,6 @@ class TestFilterArtifacts:
     @pytest.mark.parametrize(
         "pkg_type",
         [
-            "bogus",
-            "",
-        ],
-    )
-    def test_filter_artifact_by_type(self, pkg_type):
-        artifacts = [
-            {
-                "id": "pkg-id",
-                "name": "pkg-name",
-                "type": pkg_type,
-            },
-        ]
-
-        actual = filter_artifacts(artifacts, [])
-        assert not [a["name"] for a in actual]
-
-    @pytest.mark.parametrize(
-        "pkg_type",
-        [
             "npm",
             "apk",
             "deb",

--- a/tests/unit/anchore_engine/analyzers/syft/test_syft.py
+++ b/tests/unit/anchore_engine/analyzers/syft/test_syft.py
@@ -1,6 +1,9 @@
+import json
+import os
+
 import pytest
 
-from anchore_engine.analyzers.syft import filter_artifacts
+from anchore_engine.analyzers.syft import convert_syft_to_engine, filter_artifacts
 
 
 class TestFilterArtifacts:
@@ -126,3 +129,34 @@ class TestFilterArtifacts:
 
         actual = filter_artifacts(artifacts, [])
         assert [a["name"] for a in actual] == ["pkg-name"]
+
+
+@pytest.fixture
+def test_sbom(request):
+    module_path = os.path.dirname(request.module.__file__)
+    test_name = os.path.splitext(os.path.basename(request.module.__file__))[0]
+    with open(
+        os.path.join(
+            module_path, test_name, "{}.json".format(request.node.originalname)
+        )
+    ) as file:
+        return json.load(file)
+
+
+class TestConvertSyftToEngine:
+    @pytest.mark.parametrize(
+        "enable_package_filtering",
+        [False, True],
+    )
+    def test_filter_artifact_by_type(self, test_sbom, enable_package_filtering):
+        findings = convert_syft_to_engine(test_sbom, enable_package_filtering)
+        for pkg_list in findings["package_list"]:
+            if pkg_list == "pkgfiles.all":
+                continue
+            assert (
+                "UNSUPPORTED-PACKAGE"
+                not in findings["package_list"][pkg_list]["base"].keys()
+            )
+            assert (
+                "SUPPORTED-PACKAGE" in findings["package_list"][pkg_list]["base"].keys()
+            )

--- a/tests/unit/anchore_engine/analyzers/syft/test_syft/test_filter_artifact_by_type.json
+++ b/tests/unit/anchore_engine/analyzers/syft/test_syft/test_filter_artifact_by_type.json
@@ -1,0 +1,53 @@
+{
+    "distro": {
+        "name": "ubuntu",
+        "version": "18.04",
+        "idLike": "debian"
+    },
+    "artifactRelationships": [],
+    "artifacts": [
+        {
+            "id": "5953b29b-74b5-452e-b6b4-ec55a4a8cdc8",
+            "name": "UNSUPPORTED-PACKAGE",
+            "version": "v0.4.1",
+            "type": "TEST-TYPE"
+        },
+        {
+            "id": "bb512892-a598-4efe-b8fb-9d377e1e77cc",
+            "name": "SUPPORTED-PACKAGE",
+            "version": "3.5.44",
+            "type": "deb",
+            "foundBy": "dpkgdb-cataloger",
+            "locations": [
+                {
+                    "path": "/usr/share/doc/SUPPORTED-PACKAGE/copyright",
+                    "layerID": "sha256:8f8f0266f8349dd17fdca5a1c827a7c8b11d84903b1226b05c6fbdc7edd30652"
+                }
+            ],
+            "licenses": ["GPL-2", "PD"],
+            "language": "",
+            "cpes": ["cpe:2.3:a:*:base_passwd:3.5.44:*:*:*:*:*:*:*"],
+            "purl": "pkg:deb/ubuntu/SUPPORTED-PACKAGE@3.5.44?arch=amd64",
+            "metadataType": "DpkgMetadata",
+            "metadata": {
+                "package": "SUPPORTED-PACKAGE",
+                "source": "",
+                "version": "3.5.44",
+                "sourceVersion": "",
+                "architecture": "amd64",
+                "maintainer": "Sherlock Holmes <person@debian.org>",
+                "installedSize": 228,
+                "files": [
+                    {
+                        "path": "/usr/sbin/update-passwd",
+                        "digest": {
+                            "algorithm": "md5",
+                            "value": "6eb1a51290610f95397b6b2f7761ddc7"
+                        },
+                        "isConfigFile": false
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Move filtering of unsupported types from filter_artifacts to convert_syft_to_engine.

This change will prevent unsupported artifact types from causing a KeyError to be raised when package filtering is disabled.

Behavior before change:
```
[service:enterprise-analyzer] 2021-07-12 12:17:51+0000 [-] Traceback (most recent call last):
[service:enterprise-analyzer] 2021-07-12 12:17:51+0000 [-] File "/usr/local/lib/python3.8/site-packages/anchore_engine/clients/localanchore_standalone.py", line 1112, in analyze_image
[service:enterprise-analyzer] 2021-07-12 12:17:51+0000 [-] analyzer_report = run_anchore_analyzers(
[service:enterprise-analyzer] 2021-07-12 12:17:51+0000 [-] File "/usr/local/lib/python3.8/site-packages/anchore_engine/clients/localanchore_standalone.py", line 909, in run_anchore_analyzers
[service:enterprise-analyzer] 2021-07-12 12:17:51+0000 [-] analyzer_report = analyzer_manager.run(
[service:enterprise-analyzer] 2021-07-12 12:17:51+0000 [-] File "/usr/local/lib/python3.8/site-packages/anchore_engine/analyzers/manager.py", line 26, in run
[service:enterprise-analyzer] 2021-07-12 12:17:51+0000 [-] _run_syft(
[service:enterprise-analyzer] 2021-07-12 12:17:51+0000 [-] File "/usr/local/lib/python3.8/site-packages/anchore_engine/analyzers/manager.py", line 117, in _run_syft
[service:enterprise-analyzer] 2021-07-12 12:17:51+0000 [-] results = syft.catalog_image(
[service:enterprise-analyzer] 2021-07-12 12:17:51+0000 [-] File "/usr/local/lib/python3.8/site-packages/anchore_engine/analyzers/syft/_init_.py", line 43, in catalog_image
[service:enterprise-analyzer] 2021-07-12 12:17:51+0000 [-] return convert_syft_to_engine(all_results, package_filtering_enabled)
[service:enterprise-analyzer] 2021-07-12 12:17:51+0000 [-] File "/usr/local/lib/python3.8/site-packages/anchore_engine/analyzers/syft/_init_.py", line 80, in convert_syft_to_engine
[service:enterprise-analyzer] 2021-07-12 12:17:51+0000 [-] handler = modules_by_artifact_type[artifact["type"]]
[service:enterprise-analyzer] 2021-07-12 12:17:51+0000 [-] KeyError: 'go-module'
[service:enterprise-analyzer] 2021-07-12 12:17:51+0000 [-]
[service:enterprise-analyzer] 2021-07-12 12:17:51+0000 [-] During handling of the above exception, another exception occurred:
[service:enterprise-analyzer] 2021-07-12 12:17:51+0000 [-]
[service:enterprise-analyzer] 2021-07-12 12:17:51+0000 [-] Traceback (most recent call last):
[service:enterprise-analyzer] 2021-07-12 12:17:51+0000 [-] File "/usr/local/lib/python3.8/site-packages/anchore_engine/services/analyzer/analysis.py", line 340, in process_analyzer_job
[service:enterprise-analyzer] 2021-07-12 12:17:51+0000 [-] image_data = perform_analyze(
[service:enterprise-analyzer] 2021-07-12 12:17:51+0000 [-] File "/usr/local/lib/python3.8/site-packages/anchore_engine/services/analyzer/analysis.py", line 194, in perform_analyze
[service:enterprise-analyzer] 2021-07-12 12:17:51+0000 [-] analyzed_image_report, manifest_raw = localanchore_standalone.analyze_image(
[service:enterprise-analyzer] 2021-07-12 12:17:51+0000 [-] File "/usr/local/lib/python3.8/site-packages/anchore_engine/clients/localanchore_standalone.py", line 1141, in analyze_image
[service:enterprise-analyzer] 2021-07-12 12:17:51+0000 [-] raise AnalysisError(
[service:enterprise-analyzer] 2021-07-12 12:17:51+0000 [-] anchore_engine.clients.localanchore_standalone.AnalysisError: failed to download, unpack, analyze, and generate image export (<REDACTED>@sha256:ed7dde042d73fef24fe61c1637fdf7cbdf6a75c68372bb884651a113cb7898b1) - exception: 'go-module'
[service:enterprise-analyzer] 2021-07-12 12:17:51+0000 [-] [Thread-513546] [anchore_engine.services.analyzer.analysis/process_analyzer_job()] [ERROR] problem analyzing image - exception: failed to download, unpack, analyze, and generate image export (<REDACTED>@sha256:ed7dde042d73fef24fe61c1637fdf7cbdf6a75c68372bb884651a113cb7898b1) - exception: 'go-module'
```

Behavior after change:
```
analyzer_1       | [service:worker] 2021-07-21 17:12:24+0000 [-] [Thread-20] [anchore_engine.analyzers.syft/convert_syft_to_engine()] [INFO] filtering owned packages
analyzer_1       | [service:worker] 2021-07-21 17:12:24+0000 [-] [Thread-20] [anchore_engine.analyzers.syft/convert_syft_to_engine()] [WARN] Handler for artifact type go-module not available. Skipping package <REDACTED>.
analyzer_1       | [service:worker] 2021-07-21 17:12:24+0000 [-] [Thread-20] [anchore_engine.analyzers.syft/convert_syft_to_engine()] [WARN] Handler for artifact type go-module not available. Skipping package <REDACTED>.
analyzer_1       | [service:worker] 2021-07-21 17:12:24+0000 [-] [Thread-20] [anchore_engine.analyzers.syft/convert_syft_to_engine()] [WARN] Handler for artifact type go-module not available. Skipping package <REDACTED>.
analyzer_1       | [service:worker] 2021-07-21 17:12:24+0000 [-] [Thread-20] [anchore_engine.analyzers.syft/convert_syft_to_engine()] [WARN] Handler for artifact type go-module not available. Skipping package <REDACTED>.
analyzer_1       | [service:worker] 2021-07-21 17:12:24+0000 [-] [Thread-20] [anchore_engine.analyzers.syft/convert_syft_to_engine()] [WARN] Handler for artifact type go-module not available. Skipping package <REDACTED>.
analyzer_1       | [service:worker] 2021-07-21 17:12:24+0000 [-] [Thread-20] [anchore_engine.analyzers.syft/convert_syft_to_engine()] [WARN] Handler for artifact type go-module not available. Skipping package github.com/golang/protobuf.
analyzer_1       | [service:worker] 2021-07-21 17:12:24+0000 [-] [Thread-20] [anchore_engine.analyzers.syft/convert_syft_to_engine()] [WARN] Handler for artifact type go-module not available. Skipping package github.com/pkg/errors.
analyzer_1       | [service:worker] 2021-07-21 17:12:24+0000 [-] [Thread-20] [anchore_engine.analyzers.syft/convert_syft_to_engine()] [WARN] Handler for artifact type go-module not available. Skipping package github.com/spf13/viper.
analyzer_1       | [service:worker] 2021-07-21 17:12:24+0000 [-] [Thread-20] [anchore_engine.analyzers.syft/convert_syft_to_engine()] [WARN] Handler for artifact type go-module not available. Skipping package github.com/stretchr/testify.
analyzer_1       | [service:worker] 2021-07-21 17:12:24+0000 [-] [Thread-20] [anchore_engine.analyzers.syft/convert_syft_to_engine()] [WARN] Handler for artifact type go-module not available. Skipping package <REDACTED>.
analyzer_1       | [service:worker] 2021-07-21 17:12:24+0000 [-] [Thread-20] [anchore_engine.analyzers.syft/convert_syft_to_engine()] [WARN] Handler for artifact type go-module not available. Skipping package <REDACTED>.
analyzer_1       | [service:worker] 2021-07-21 17:12:24+0000 [-] [Thread-20] [anchore_engine.analyzers.syft/convert_syft_to_engine()] [WARN] Handler for artifact type go-module not available. Skipping package <REDACTED>.
analyzer_1       | [service:worker] 2021-07-21 17:12:24+0000 [-] [Thread-20] [anchore_engine.analyzers.syft/convert_syft_to_engine()] [WARN] Handler for artifact type go-module not available. Skipping package <REDACTED>.
analyzer_1       | [service:worker] 2021-07-21 17:12:24+0000 [-] [Thread-20] [anchore_engine.analyzers.syft/convert_syft_to_engine()] [WARN] Handler for artifact type go-module not available. Skipping package <REDACTED>.
analyzer_1       | [service:worker] 2021-07-21 17:12:24+0000 [-] [Thread-20] [anchore_engine.analyzers.syft/convert_syft_to_engine()] [WARN] Handler for artifact type go-module not available. Skipping package golang.org/x/net.
analyzer_1       | [service:worker] 2021-07-21 17:12:25+0000 [-] [Thread-20] [anchore_engine.services.analyzer.analysis/perform_analyze()] [INFO] performing analysis on image complete: 192.168.0.1:5000/customer-debug@sha256:ed7dde042d73fef24fe61c1637fdf7cbdf6a75c68372bb884651a113cb7898b1
```
