### PR TITLE
factor in release for RPM if present

### DIFF
--- a/anchore_engine/analyzers/hints.py
+++ b/anchore_engine/analyzers/hints.py
@@ -64,12 +64,12 @@ class RPMHint(BaseHint):
     def resolve_rpm_fields(self):
         from anchore_engine.util.rpm import split_rpm_filename
 
-        # if self.release:
-        #     rpm = "{}-{}-{}.{}.rpm".format(
-        #         self.name, self.version, self.release, self.arch
-        #     )
-        # else:
-        rpm = "{}-{}.{}.rpm".format(self.name, self.version, self.arch)
+        if self.release:
+            rpm = "{}-{}-{}.{}.rpm".format(
+                self.name, self.version, self.release, self.arch
+            )
+        else:
+            rpm = "{}-{}.{}.rpm".format(self.name, self.version, self.arch)
         (
             parsed_name,
             parsed_version,

--- a/anchore_engine/analyzers/hints.py
+++ b/anchore_engine/analyzers/hints.py
@@ -64,12 +64,12 @@ class RPMHint(BaseHint):
     def resolve_rpm_fields(self):
         from anchore_engine.util.rpm import split_rpm_filename
 
-        if self.release:
-            rpm = "{}-{}-{}.{}.rpm".format(
-                self.name, self.version, self.release, self.arch
-            )
-        else:
-            rpm = "{}-{}.{}.rpm".format(self.name, self.version, self.arch)
+        # if self.release:
+        #     rpm = "{}-{}-{}.{}.rpm".format(
+        #         self.name, self.version, self.release, self.arch
+        #     )
+        # else:
+        rpm = "{}-{}.{}.rpm".format(self.name, self.version, self.arch)
         (
             parsed_name,
             parsed_version,

--- a/anchore_engine/analyzers/hints.py
+++ b/anchore_engine/analyzers/hints.py
@@ -64,15 +64,19 @@ class RPMHint(BaseHint):
     def resolve_rpm_fields(self):
         from anchore_engine.util.rpm import split_rpm_filename
 
+        if self.release:
+            rpm = "{}-{}-{}.{}.rpm".format(
+                self.name, self.version, self.release, self.arch
+            )
+        else:
+            rpm = "{}-{}.{}.rpm".format(self.name, self.version, self.arch)
         (
             parsed_name,
             parsed_version,
             parsed_release,
             parsed_epoch,
             parsed_arch,
-        ) = split_rpm_filename(
-            "{}-{}.{}.rpm".format(self.name, self.version, self.arch)
-        )
+        ) = split_rpm_filename(rpm)
         if self.name == parsed_version:
             raise HintsTypeError(
                 "hints package version for hints package ({}) is not valid for RPM package type".format(

--- a/tests/unit/anchore_engine/analyzers/test_hints.py
+++ b/tests/unit/anchore_engine/analyzers/test_hints.py
@@ -196,9 +196,15 @@ class TestRPMHint:
                         "version": "35",
                         "release": "0.7",
                         "arch": "noarch",
-                        "type": "rpm"
+                        "type": "rpm",
                     },
-                    "expected": ("fedora-release-identity-container", "35", "0.7", "", "noarch"),
+                    "expected": (
+                        "fedora-release-identity-container",
+                        "35",
+                        "0.7",
+                        "",
+                        "noarch",
+                    ),
                     "expected_error": "",
                 },
                 id="valid-release-no-source",
@@ -210,8 +216,7 @@ class TestRPMHint:
                         "version": "2021a",
                         "release": "1.fc34",
                         "arch": "noarch",
-                        "type": "rpm"
-
+                        "type": "rpm",
                     },
                     "expected": ("tzdata", "2021a", "1.fc34", "", "noarch"),
                     "expected_error": "",

--- a/tests/unit/anchore_engine/analyzers/test_hints.py
+++ b/tests/unit/anchore_engine/analyzers/test_hints.py
@@ -192,6 +192,35 @@ class TestRPMHint:
             pytest.param(
                 {
                     "pkg": {
+                        "name": "fedora-release-identity-container",
+                        "version": "35",
+                        "release": "0.7",
+                        "arch": "noarch",
+                        "type": "rpm"
+                    },
+                    "expected": ("fedora-release-identity-container", "35", "0.7", "", "noarch"),
+                    "expected_error": "",
+                },
+                id="valid-release-no-source",
+            ),
+            pytest.param(
+                {
+                    "pkg": {
+                        "name": "tzdata",
+                        "version": "2021a",
+                        "release": "1.fc34",
+                        "arch": "noarch",
+                        "type": "rpm"
+
+                    },
+                    "expected": ("tzdata", "2021a", "1.fc34", "", "noarch"),
+                    "expected_error": "",
+                },
+                id="valid-release-no-source",
+            ),
+            pytest.param(
+                {
+                    "pkg": {
                         "name": "zlib",
                         "version": "zlib-16.el8_2",
                         "arch": "x86_64",


### PR DESCRIPTION
Signed-off-by: James Petersen <jpetersenames@gmail.com>

<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**: Fixes the RPM hints file not accounting for release when the field is present and source is not.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #:

**Special notes**:


The old code doesn't take the `release` into consideration for RPMHints when parsing out the rpm fields. When the `release` field is present but the `source` field is missing, the logic will call `resolve_rpm_fields()` which didn't make use of the `release` field.

So a hints file with the following contents would fail with the `HintsTypeError`

```json
{
  "packages": [
    {
      "name": "tzdata",
      "version": "2021a",
      "release": "1.fc34",
      "arch": "noarch",
      "type": "rpm"
    }
  ]
}
```

And the following hints file won't throw any errors but it will incorrectly parse `container` out as the version

```json
{
  "packages": [
    {
      "name": "fedora-release-identity-container",
      "version": "35",
      "release": "0.7",
      "arch": "noarch",
      "type": "rpm"
    }
  ]
}
```