### PR TITLE
Fixes integration tests deadlock

### DIFF
--- a/anchore_engine/services/policy_engine/engine/feeds/db.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/db.py
@@ -115,6 +115,8 @@ def get_feed_detached(feed_name: str) -> Optional[FeedMetadata]:
             feed_name,
         )
         raise e
+    finally:
+        db_session.rollback()
 
 
 def get_all_feeds_detached():


### PR DESCRIPTION
The integration tests have been consistently failing on `tests/integration/services/policy_engine/engine/policy/gates/test_dockerfile.py::DockerfileGateTest::test_directivechecktrigger_equals` for the last week. @zburstein did some investigation during his RRT rotation and traced the problem down to tests.fixtures.cls_anchore_db when the DROP SCHEMA command is executed. Following up on his investigation, I decided to run the tests locally until they hanged at the test in question. When this happened, I [checked the locks](https://www.postgresql.org/docs/current/view-pg-locks.html) in the database using the following query:
```
SELECT * FROM pg_locks pl LEFT JOIN pg_stat_activity psa ON pl.pid = psa.pid;
```

Paraphrased results:
```
| locktype   |            mode      |        backend_start          |                   query                       |
|  relation  |   AccessShareLock    | 2021-07-21 21:55:34.513941+00 | SELECT * FROM feeds WHERE feeds.name = 'test' |
| virtualxid |     ExclusiveLock    | 2021-07-21 21:55:34.513941+00 | SELECT * FROM feeds WHERE feeds.name = 'test' |
|  relation  |   AccessShareLock    | 2021-07-21 21:55:35.573897+00 | DROP SCHEMA public CASCADE                    |
| virtualxid |     ExclusiveLock    | 2021-07-21 21:55:35.573897+00 | DROP SCHEMA public CASCADE                    |
|  relation  | AccessExclusiveLock  | 2021-07-21 21:55:35.573897+00 | DROP SCHEMA public CASCADE                    |
...
```

As you can see, a second before the drop schema command runs, a select creates an AccessShareLock and an ExclusiveLock are created by a select on the feeds table. I read this [StackOverflow answer](https://stackoverflow.com/a/65831232), which explains that creation of a table with foreign keys creates a trigger for each foreign key on both tables. Deleting these triggers requires AccessExclusiveLock. Running a select on the table (in this case, the feeds table) creates an AccessShareLock. Trying to delete the table in the subsequent transaction requires AccessExclusiveLock. The AccessExclusiveLock on the feed table will not be able to lock until the AccessShareLock is released. The AccessShareLock will not be released until the transaction is committed or rolled back.

Tox runs the tests in a consistent order. Looking at the execution results, we can see that `tests/integration/services/policy_engine/db/test_get_feeds.py` runs before `test_dockerfile.py`. 

```
tests/integration/services/policy_engine/db/test_get_feeds.py::test_get_feed_detached PASSED [ 44%]
tests/integration/services/policy_engine/db/test_models.py::test_cmp PASSED [ 45%]
tests/integration/services/policy_engine/engine/policy/gates/test_dockerfile.py::DockerfileGateTest::test_directivechecktrigger_equals
```

This is likely the test that is causing the deadlock. This specific test is testing the `anchore_engine.services.policy_engine.engine.feeds.db.get_feed_detached` method. Digging into that method, we can see that it's running a select on feeds, but it never commits or tries to rollback the transaction:
```
def get_feed_detached(feed_name: str) -> Optional[FeedMetadata]:
    """
    Returns a FeedMetadata object or none based upon provided feed name. Detached from the session

    :return: FeedMetadata object or none
    :rtype FeedMetadata or None
    """
    db_session = get_session()
    try:
        feed = FeedMetadata.get_by_name(db_session, feed_name)

        if not feed:
            return None

        return feed.to_detached()

    except MultipleResultsFound as e:
        logger.error(
            "Failed to retrieve %s feed in detached state because more than one exists",
            feed_name,
        )
        raise e
```

I added a finally clause to the try/except with a rollback. This seems to have corrected the deadlock.