### PR TITLE
Certifi path corrections

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,7 +10,7 @@ if [[ -d "/home/anchore/certs" ]] && [[ ! -z "$(ls -A /home/anchore/certs)" ]]; 
     mkdir -p /home/anchore/certs_override/python
     mkdir -p /home/anchore/certs_override/os
     ### for python
-    cp /usr/local/lib/python3.6/site-packages/certifi/cacert.pem /home/anchore/certs_override/python/cacert.pem
+    cp /usr/local/lib/python3.8/site-packages/certifi/cacert.pem /home/anchore/certs_override/python/cacert.pem
     for file in /home/anchore/certs/*; do
         if grep -q 'BEGIN CERTIFICATE' "${file}"; then
             cat "${file}" >> /home/anchore/certs_override/python/cacert.pem

--- a/docs/content/docs/install/configuration/custom_certs.md
+++ b/docs/content/docs/install/configuration/custom_certs.md
@@ -26,6 +26,7 @@ To add a certificate to the operating system trust store the CA certificate shou
 - For anchore 0.3.X, the base container is Ubuntu 18.04, certifi's cacert.pem is installed in `/usr/local/lib/python3.6/dist-packages/certifi/cacert.pem`
 - For anchore 0.4.X and newer, the base container is Red Hat Universal Base Image 7, certifi's cacert.pem is installed in `/opt/rh/rh-python36/root/usr/lib/python3.6/site-packages/certifi/cacert.pem`
 - For anchore 0.7.X and newer, the base container is Red Hat Universal Base Image 8, certifi's cacert.pem is installed in `/usr/local/lib/python3.6/site-packages/certifi/cacert.pem`
+- For anchore 0.9.x and newer, the base container is Red Hat Universal Base Image 8, certifi's cacert.pem is installed in `/usr/local/lib/python3.8/site-packages/certifi/cacert.pem`
 
 The following Dockerfile illustrates an example of how this general process can be automated to produce your own anchore-engine container (based on version 0.2.4 of anchore-engine) with new custom CA cert installed.  A similiar process can be used for anchore-engine 0.4.X or newer, with the commands adjusted as appropriate with the differences described above.
 


### PR DESCRIPTION
<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**:
Correct path of certifi's cacert.pem file in docker-entrypoint.sh. The broken path was preventing users from adding custom CAs.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #:
Fixes #1073 

**Special notes**:
As suggested by user who reported the issue, we might dynamically determine which python version is being used in the dockerfile rather than hardcoding the path. 

