### PR TITLE
Add will_not_fix to vunl endpoints

### DIFF
--- a/anchore_engine/common/models/policy_engine.py
+++ b/anchore_engine/common/models/policy_engine.py
@@ -722,7 +722,7 @@ class Advisory(JsonSerializable):
 class FixedArtifact(JsonSerializable):
     class FixedArtifactV1Schema(Schema):
         versions = fields.List(fields.Str())
-        wont_fix = fields.Bool()
+        will_not_fix = fields.Bool()
         observed_at = RFC3339DateTime(
             allow_none=True,
             missing=None,
@@ -735,9 +735,11 @@ class FixedArtifact(JsonSerializable):
 
     __schema__ = FixedArtifactV1Schema()
 
-    def __init__(self, versions=None, wont_fix=None, observed_at=None, advisories=None):
+    def __init__(
+        self, versions=None, will_not_fix=None, observed_at=None, advisories=None
+    ):
         self.versions = versions
-        self.wont_fix = wont_fix
+        self.will_not_fix = will_not_fix
         self.observed_at = observed_at
         self.advisories = advisories
 

--- a/anchore_engine/services/apiext/api/controllers/utils.py
+++ b/anchore_engine/services/apiext/api/controllers/utils.py
@@ -46,6 +46,7 @@ eltemplate = {
     "feed_group": "None",
     "nvd_data": "None",
     "vendor_data": "None",
+    "wont_fix": "None",
 }
 
 
@@ -528,6 +529,7 @@ def make_response_vulnerability_report(vulnerability_type, vulnerability_report)
         vuln_dict["package_path"] = result.artifact.location
         vuln_dict["feed"] = result.vulnerability.feed
         vuln_dict["feed_group"] = result.vulnerability.feed_group
+        vuln_dict["wont_fix"] = result.fix.wont_fix
         # backwards compatibility hack
         if result.vulnerability.feed_group and "nvd" in result.vulnerability.feed_group:
             vuln_dict["nvd_data"] = get_nvd_data_from_vulnerability(

--- a/anchore_engine/services/apiext/api/controllers/utils.py
+++ b/anchore_engine/services/apiext/api/controllers/utils.py
@@ -46,7 +46,7 @@ eltemplate = {
     "feed_group": "None",
     "nvd_data": "None",
     "vendor_data": "None",
-    "wont_fix": "None",
+    "will_not_fix": "None",
 }
 
 
@@ -529,7 +529,7 @@ def make_response_vulnerability_report(vulnerability_type, vulnerability_report)
         vuln_dict["package_path"] = result.artifact.location
         vuln_dict["feed"] = result.vulnerability.feed
         vuln_dict["feed_group"] = result.vulnerability.feed_group
-        vuln_dict["wont_fix"] = result.fix.wont_fix
+        vuln_dict["will_not_fix"] = result.fix.will_not_fix
         # backwards compatibility hack
         if result.vulnerability.feed_group and "nvd" in result.vulnerability.feed_group:
             vuln_dict["nvd_data"] = get_nvd_data_from_vulnerability(

--- a/anchore_engine/services/apiext/swagger/swagger.yaml
+++ b/anchore_engine/services/apiext/swagger/swagger.yaml
@@ -745,7 +745,7 @@ paths:
           in: query
           type: boolean
           required: false
-          description: Filter results to include only vulnerabilities that are not marked as invalid by upstream OS vendor data. When set to true, it will filter out all vulnerabilities where `wont_fix` is False. If false all vulnerabilities are returned regardless of `wont_fix`
+          description: Filter results to include only vulnerabilities that are not marked as invalid by upstream OS vendor data. When set to true, it will filter out all vulnerabilities where `will_not_fix` is False. If false all vulnerabilities are returned regardless of `will_not_fix`
         - $ref: "#/parameters/AsAccountParameter"
       responses:
         200:
@@ -2951,7 +2951,7 @@ definitions:
       type:
         type: string
         description: Package type (e.g. package, rpm, deb, apk, jar, npm, gem, ...)
-      wont_fix:
+      will_not_fix:
         type: boolean
         description: Whether a vendor will or will not fix a vulnerabitlity
     description: A record of a software item which is vulnerable or carries a fix for a vulnerability
@@ -3940,7 +3940,7 @@ definitions:
       package_path:
         type: string
         description: The location (if applicable) of the vulnerable package in the container filesystem
-      wont_fix:
+      will_not_fix:
         type: string
         description: Whether a vendor will fix or not fix the vulnerability
       nvd_data:

--- a/anchore_engine/services/apiext/swagger/swagger.yaml
+++ b/anchore_engine/services/apiext/swagger/swagger.yaml
@@ -745,6 +745,7 @@ paths:
           in: query
           type: boolean
           required: false
+          description: Filter results to include only vulnerabilities that are not marked as invalid by upstream OS vendor data. When set to true, it will filter out all vulnerabilities where `wont_fix` is False. If false all vulnerabilities are returned regardless of `wont_fix`
         - $ref: "#/parameters/AsAccountParameter"
       responses:
         200:
@@ -3936,6 +3937,9 @@ definitions:
       package_path:
         type: string
         description: The location (if applicable) of the vulnerable package in the container filesystem
+      wont_fix:
+        type: string
+        description: Whether a vendor will fix or not fix the vulnerability
       nvd_data:
         $ref: "#/definitions/NvdDataList"
       vendor_data:

--- a/anchore_engine/services/apiext/swagger/swagger.yaml
+++ b/anchore_engine/services/apiext/swagger/swagger.yaml
@@ -2951,6 +2951,9 @@ definitions:
       type:
         type: string
         description: Package type (e.g. package, rpm, deb, apk, jar, npm, gem, ...)
+      wont_fix:
+        type: boolean
+        description: Whether a vendor will or will not fix a vulnerabitlity
     description: A record of a software item which is vulnerable or carries a fix for a vulnerability
   VulnerablePackageReference:
     type: object

--- a/anchore_engine/services/apiext/swagger/swagger.yaml
+++ b/anchore_engine/services/apiext/swagger/swagger.yaml
@@ -1,7 +1,7 @@
 swagger: "2.0"
 info:
   description: "This is the Anchore Engine API. Provides the primary external API for users of the service."
-  version: "0.1.18"
+  version: "0.1.19"
   title: "Anchore Engine API Server"
   contact:
     email: "nurmi@anchore.com"

--- a/anchore_engine/services/policy_engine/engine/policy/gates/vulnerabilities.py
+++ b/anchore_engine/services/policy_engine/engine/policy/gates/vulnerabilities.py
@@ -335,7 +335,7 @@ class VulnerabilityMatchTrigger(BaseTrigger):
 
                     # Check vendor_only flag specified by the user in policy
                     if is_vendor_only:
-                        if fix_obj.wont_fix:
+                        if fix_obj.will_not_fix:
                             logger.debug(
                                 "{} vulnerability {} for package {} is marked by vendor as won't fix, skipping".format(
                                     new_vuln_pkg_class,
@@ -731,7 +731,7 @@ class VulnerabilityBlacklistTrigger(BaseTrigger):
             matches = context.data.get("loaded_vulnerabilities")
             for match in matches:
                 if is_vendor_only:
-                    if match.fix.wont_fix:
+                    if match.fix.will_not_fix:
                         continue
                 # search for vid in all vulns
                 if vid == match.vulnerability.vulnerability_id:

--- a/anchore_engine/services/policy_engine/engine/vulns/mappers.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/mappers.py
@@ -325,11 +325,11 @@ class VulnerabilityMapper:
         # parse fix details
         fix_dict = vuln_dict.get("fix")
         fix_obj = FixedArtifact(
-            versions=[], wont_fix=False, observed_at=None, advisories=[]
+            versions=[], will_not_fix=False, observed_at=None, advisories=[]
         )
         if fix_dict:
             fix_obj.versions = fix_dict.get("versions", [])
-            fix_obj.wont_fix = (
+            fix_obj.will_not_fix = (
                 fix_dict.get("state").lower() == "wont-fix"
             )  # TODO format check with toolbox
             fix_obj.observed_at = now if fix_obj.versions else None
@@ -689,7 +689,7 @@ class EngineGrypeDBMapper:
                         "name": grype_vulnerability.package_name,
                         "type": grype_vulnerability.version_format,
                         "version": version,
-                        "wont_fix": grype_vulnerability.fix_state == "wont-fix",
+                        "will_not_fix": grype_vulnerability.fix_state == "wont-fix",
                     }
                 )
 

--- a/anchore_engine/services/policy_engine/engine/vulns/mappers.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/mappers.py
@@ -689,6 +689,7 @@ class EngineGrypeDBMapper:
                         "name": grype_vulnerability.package_name,
                         "type": grype_vulnerability.version_format,
                         "version": version,
+                        "wont_fix": grype_vulnerability.fix_state == "wont-fix",
                     }
                 )
 

--- a/anchore_engine/services/policy_engine/engine/vulns/providers.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/providers.py
@@ -429,7 +429,9 @@ class LegacyProvider(VulnerabilitiesProvider):
                         ),
                         fix=FixedArtifact(
                             versions=[fixed_in] if fixed_in else [],
-                            wont_fix=vuln.fix_has_no_advisory(fixed_in=fixed_artifact),
+                            will_not_fix=vuln.fix_has_no_advisory(
+                                fixed_in=fixed_artifact
+                            ),
                             observed_at=fixed_artifact.fix_observed_at
                             if fixed_artifact
                             else None,
@@ -491,7 +493,7 @@ class LegacyProvider(VulnerabilitiesProvider):
                             ),
                             fix=FixedArtifact(
                                 versions=vulnerability_cpe.get_fixed_in(),
-                                wont_fix=False,
+                                will_not_fix=False,
                                 observed_at=vulnerability_cpe.created_at
                                 if vulnerability_cpe.get_fixed_in()
                                 else None,
@@ -612,7 +614,7 @@ class LegacyProvider(VulnerabilitiesProvider):
                             "name": v_pkg.name,
                             "version": v_pkg.version,
                             "type": "*",
-                            "wont_fix": False,
+                            "will_not_fix": False,
                         }
                         namespace_el["affected_packages"].append(pkg_el)
 
@@ -687,7 +689,7 @@ class LegacyProvider(VulnerabilitiesProvider):
                             "name": v_pkg.name,
                             "version": v_pkg.version,
                             "type": v_pkg.version_format,
-                            "wont_fix": v_pkg.vendor_no_advisory,
+                            "will_not_fix": v_pkg.vendor_no_advisory,
                         }
                         if not v_pkg.version or v_pkg.version.lower() == "none":
                             pkg_el["version"] = "*"
@@ -1084,7 +1086,7 @@ class GrypeProvider(VulnerabilitiesProvider):
                 if not isinstance(report, ImageVulnerabilitiesReport):
                     report = ImageVulnerabilitiesReport.from_json(report)
 
-                report.results = self._exclude_wont_fix(report.results)
+                report.results = self._exclude_will_not_fix(report.results)
                 report = report.to_json()
             else:
                 if isinstance(report, ImageVulnerabilitiesReport):
@@ -1110,20 +1112,22 @@ class GrypeProvider(VulnerabilitiesProvider):
                 report = ImageVulnerabilitiesReport.from_json(report)
 
             if vendor_only:
-                report.results = self._exclude_wont_fix(report.results)
+                report.results = self._exclude_will_not_fix(report.results)
 
             return report
 
     @staticmethod
-    def _exclude_wont_fix(matches: List[VulnerabilityMatch]):
+    def _exclude_will_not_fix(matches: List[VulnerabilityMatch]):
         """
-        Exclude matches that are explicitly marked wont_fix = True. Includes all other matches, wont_fix = False, None or any string which should never be the case
+        Exclude matches that are explicitly marked will_not_fix = True. Includes all other matches, will_not_fix = False, None or any string which should never be the case
         """
         return (
             list(
                 filter(
                     lambda x: not (
-                        x.fix and isinstance(x.fix.wont_fix, bool) and x.fix.wont_fix
+                        x.fix
+                        and isinstance(x.fix.will_not_fix, bool)
+                        and x.fix.will_not_fix
                     ),
                     matches,
                 )
@@ -1329,7 +1333,7 @@ class GrypeProvider(VulnerabilitiesProvider):
         #                         "advisories": [],
         #                         "observed_at": "2021-06-04T02:27:35Z",
         #                         "versions": ["8.232.09-r0"],
-        #                         "wont_fix": False,
+        #                         "will_not_fix": False,
         #                     },
         #                     "match": {"detected_at": "2021-06-03T05:20:09Z"},
         #                     "nvd": [],
@@ -1448,7 +1452,7 @@ class GrypeProvider(VulnerabilitiesProvider):
                 if (
                     isinstance(vendor_only, bool)
                     and vendor_only  # true means vendor may fix
-                    and match.fix.wont_fix  # true means vendor won't fix
+                    and match.fix.will_not_fix  # true means vendor won't fix
                 ):
                     continue
 

--- a/anchore_engine/services/policy_engine/engine/vulns/providers.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/providers.py
@@ -612,6 +612,7 @@ class LegacyProvider(VulnerabilitiesProvider):
                             "name": v_pkg.name,
                             "version": v_pkg.version,
                             "type": "*",
+                            "wont_fix": False,
                         }
                         namespace_el["affected_packages"].append(pkg_el)
 
@@ -686,6 +687,7 @@ class LegacyProvider(VulnerabilitiesProvider):
                             "name": v_pkg.name,
                             "version": v_pkg.version,
                             "type": v_pkg.version_format,
+                            "wont_fix": v_pkg.vendor_no_advisory,
                         }
                         if not v_pkg.version or v_pkg.version.lower() == "none":
                             pkg_el["version"] = "*"

--- a/anchore_engine/services/policy_engine/swagger/swagger.yaml
+++ b/anchore_engine/services/policy_engine/swagger/swagger.yaml
@@ -1428,7 +1428,7 @@ definitions:
           properties:
             version:
               type: string
-            wont_fix:
+            will_not_fix:
               type: boolean
             observed_at:
               type: string

--- a/tests/functional/services/api/images/by_id/test_get.py
+++ b/tests/functional/services/api/images/by_id/test_get.py
@@ -79,28 +79,3 @@ class TestImagesByIDAPIGetReturns200:
         resp = http_get(["images", "by_id", image_id, "content", "os"], config=api_conf)
 
         assert resp == APIResponse(200)
-
-    def test_get_image_vuln_types(self, add_alpine_latest_image):
-        add_resp, api_conf = add_alpine_latest_image
-        image_id = get_image_id(add_resp)
-
-        resp = http_get(["images", "by_id", image_id, "vuln"], config=api_conf)
-
-        assert resp == APIResponse(200)
-
-    def test_get_all_image_vulns_by_type(self, add_alpine_latest_image):
-        add_resp, api_conf = add_alpine_latest_image
-        image_id = get_image_id(add_resp)
-
-        resp = http_get(["images", "by_id", image_id, "vuln"], config=api_conf)
-
-        assert resp == APIResponse(200)
-
-        wait_for_image_to_analyze(image_id, api_conf)
-
-        vuln_types = resp.body
-        for v_type in vuln_types:
-            resp = http_get(
-                ["images", "by_id", image_id, "vuln", v_type], config=api_conf
-            )
-            assert resp == APIResponse(200)

--- a/tests/functional/services/api/images/by_id/test_vulns.py
+++ b/tests/functional/services/api/images/by_id/test_vulns.py
@@ -1,0 +1,42 @@
+from tests.functional.services.api.images import get_image_id, wait_for_image_to_analyze
+from tests.functional.services.utils.http_utils import APIResponse, http_get
+
+
+class TestVulns:
+    def test_get_image_vuln_types(self, add_alpine_latest_image):
+        add_resp, api_conf = add_alpine_latest_image
+        image_id = get_image_id(add_resp)
+
+        resp = http_get(["images", "by_id", image_id, "vuln"], config=api_conf)
+
+        # Doing it with this one I think
+        assert resp == APIResponse(200)
+
+    def test_get_all_image_vulns_by_type(self, add_alpine_latest_image):
+        add_resp, api_conf = add_alpine_latest_image
+        image_id = get_image_id(add_resp)
+
+        resp = http_get(["images", "by_id", image_id, "vuln"], config=api_conf)
+
+        assert resp == APIResponse(200)
+
+        wait_for_image_to_analyze(image_id, api_conf)
+
+        vuln_types = resp.body
+        for v_type in vuln_types:
+            resp = http_get(
+                ["images", "by_id", image_id, "vuln", v_type], config=api_conf
+            )
+            assert resp == APIResponse(200)
+
+    def test_vendor_only_field_present(self, add_alpine_latest_image):
+        add_resp, api_conf = add_alpine_latest_image
+        image_id = get_image_id(add_resp)
+        wait_for_image_to_analyze(image_id, api_conf)
+
+        resp = http_get(["images", "by_id", image_id, "vuln", "all"], config=api_conf)
+
+        assert resp == APIResponse(200)
+
+        for vuln in resp.body["vulnerabilities"]:
+            assert "wont_fix" in vuln

--- a/tests/functional/services/api/images/by_id/test_vulns.py
+++ b/tests/functional/services/api/images/by_id/test_vulns.py
@@ -39,4 +39,4 @@ class TestVulns:
         assert resp == APIResponse(200)
 
         for vuln in resp.body["vulnerabilities"]:
-            assert "wont_fix" in vuln
+            assert "will_not_fix" in vuln

--- a/tests/functional/services/api/query/test_query_vulnerabilities.py
+++ b/tests/functional/services/api/query/test_query_vulnerabilities.py
@@ -35,5 +35,5 @@ class TestQueryVulnerabilities:
 
         for vuln in resp.body["vulnerabilities"]:
             for package in vuln["affected_packages"]:
-                assert "wont_fix" in package
-                assert isinstance(package["wont_fix"], bool) is True
+                assert "will_not_fix" in package
+                assert isinstance(package["will_not_fix"], bool) is True

--- a/tests/functional/services/api/query/test_query_vulnerabilities.py
+++ b/tests/functional/services/api/query/test_query_vulnerabilities.py
@@ -1,0 +1,39 @@
+from tests.functional import get_logger
+from tests.functional.services.api.images import (
+    get_alpine_latest_image_os_vuln,
+    get_image_digest,
+    get_image_id,
+)
+from tests.functional.services.utils.http_utils import APIResponse, http_get
+
+
+class TestQueryVulnerabilities:
+    _logger = get_logger(__name__)
+
+    def test_query_vuln(self, add_alpine_latest_image):
+        add_resp, api_conf = add_alpine_latest_image
+        # Arbitrarily get the first vuln from the os vuln response for alpine image
+        try:
+            first_vuln = (
+                get_alpine_latest_image_os_vuln(
+                    get_image_id(add_resp), get_image_digest(add_resp), api_conf
+                )
+                .body.get("vulnerabilities", [])[0]
+                .get("vuln", None)
+            )
+        except IndexError:
+            self._logger.warning(
+                "No vulnerabilities found, cannot test query vulnerabilities"
+            )
+            return
+
+        assert first_vuln is not None
+        resp = http_get(
+            ["query", "vulnerabilities"], {"id": first_vuln}, config=api_conf
+        )
+        assert resp == APIResponse(200)
+
+        for vuln in resp.body["vulnerabilities"]:
+            for package in vuln["affected_packages"]:
+                assert "wont_fix" in package
+                assert isinstance(package["wont_fix"], bool) is True

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_query_vulnerabilities/multiple_cves.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_query_vulnerabilities/multiple_cves.json
@@ -5,745 +5,745 @@
         "name": "gnupg",
         "type": "*",
         "version": "0.0.0",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.1.0",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.1.1",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.1.2",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.1.3",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.2.0",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.2.10",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.2.11",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.2.12",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.2.13",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.2.14",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.2.15",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.2.16",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.2.17",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.2.18",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.2.19",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.2.1",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.2.2",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.2.3",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.2.4",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.2.5",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.2.6",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.2.7",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.2.8",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.2.9",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.3.0",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.3.1",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.3.2",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.3.3",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.3.4",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.3.5",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.4.0",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.4.1",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.4.2",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.4.3",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.4.4",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.4.5",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.9.0",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.9.10",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.9.11",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.9.1",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.9.2",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.9.3",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.9.4",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.9.5",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.9.6",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.9.7",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.9.8",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "0.9.9",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.0.0",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.0.1",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.0.2",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.0.3",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.0.4",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.0.4",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.0.5",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.0.5",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.0.6",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.0.7",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.1.90",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.1.91",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.1.92",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.2.0",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.2.1",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.2.1",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.2.2",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.2.3",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.2.4",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.2.5",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.2.6",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.2.7",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.2.8",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.3.0",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.3.1",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.3.2",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.3.3",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.3.4",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.3.6",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.3.90",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.3.91",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.3.92",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.3.93",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.4.0",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.4.10",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.4.11",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.4.12",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.4.13",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.4.14",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.4.15",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.4.16",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.4.1",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.4.2",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.4.3",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.4.4",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.4.5",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.4.6",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.4.7",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.4.8",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "1.4.9",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "2.0.10",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "2.0.11",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "2.0.12",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "2.0.13",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "2.0.14",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "2.0.15",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "2.0.16",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "2.0.17",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "2.0.18",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "2.0.19",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "2.0.1",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "2.0.20",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "2.0.21",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "2.0.22",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "2.0.23",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "2.0.3",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "2.0.4",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "2.0.5",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "2.0.6",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "2.0.7",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "2.0.8",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
         "version": "2.0",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "debian_linux",
         "type": "*",
         "version": "7.0",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "opensuse",
         "type": "*",
         "version": "12.3",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "opensuse",
         "type": "*",
         "version": "13.1",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": "The do_uncompress function in g10/compress.c in GnuPG 1.x before 1.4.17 and 2.x before 2.0.24 allows context-dependent attackers to cause a denial of service (infinite loop) via malformed compressed packets, as demonstrated by an a3 01 5b ff byte sequence.",
@@ -871,7 +871,7 @@
         "name": "pcre",
         "type": "*",
         "version": "8.40",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": "Stack-based buffer overflow in the pcre32_copy_substring function in pcre_get.c in libpcre1 in PCRE 8.40 allows remote attackers to cause a denial of service (WRITE of size 4) or possibly have unspecified other impact via a crafted file.",
@@ -961,7 +961,7 @@
         "name": "kerberos",
         "type": "*",
         "version": "5-1.16",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": "An issue was discovered in MIT Kerberos 5 (aka krb5) through 1.16. There is a variable \"dbentry->n_key_data\" in kadmin/dbutil/dump.c that can store 16-bit data but unknowingly the developer has assigned a \"u4\" variable to it, which is for 32-bit data. An attacker can use this vulnerability to affect other artifacts of the database as we know that a Kerberos database dump file contains trusted data.",
@@ -1037,7 +1037,7 @@
         "name": "pcre",
         "type": "apk",
         "version": "8.41-r0",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -1100,7 +1100,7 @@
         "name": "gnupg2",
         "type": "dpkg",
         "version": "2.0.24-1",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -1146,7 +1146,7 @@
         "name": "krb5",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -1209,7 +1209,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -1272,7 +1272,7 @@
         "name": "gnupg2",
         "type": "dpkg",
         "version": "2.0.24-1",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -1318,7 +1318,7 @@
         "name": "krb5",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -1381,7 +1381,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -1500,13 +1500,13 @@
         "name": "gnupg2",
         "type": "dpkg",
         "version": "2.0.19-2+deb7u2",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "dpkg",
         "version": "1.4.12-7+deb7u4",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -1552,7 +1552,7 @@
         "name": "krb5",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -1615,13 +1615,13 @@
         "name": "gnupg2",
         "type": "dpkg",
         "version": "2.0.24-1",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "dpkg",
         "version": "1.4.16-1.2",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -1667,7 +1667,7 @@
         "name": "krb5",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -1730,7 +1730,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": true
+        "will_not_fix": true
       }
     ],
     "description": null,
@@ -1793,7 +1793,7 @@
         "name": "gnupg2",
         "type": "dpkg",
         "version": "2.0.24-1",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -1839,7 +1839,7 @@
         "name": "krb5",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -1902,7 +1902,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -1965,7 +1965,7 @@
         "name": "gnupg2",
         "type": "dpkg",
         "version": "2.0.24-1",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -2011,7 +2011,7 @@
         "name": "krb5",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -2074,7 +2074,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -2137,7 +2137,7 @@
         "name": "pcre",
         "type": "rpm",
         "version": "*",
-        "wont_fix": true
+        "will_not_fix": true
       }
     ],
     "description": null,
@@ -2200,13 +2200,13 @@
         "name": "gnupg",
         "type": "rpm",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg2",
         "type": "rpm",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -2252,13 +2252,13 @@
         "name": "glib2",
         "type": "rpm",
         "version": "*",
-        "wont_fix": true
+        "will_not_fix": true
       },
       {
         "name": "pcre",
         "type": "rpm",
         "version": "*",
-        "wont_fix": true
+        "will_not_fix": true
       }
     ],
     "description": null,
@@ -2321,7 +2321,7 @@
         "name": "gnupg2",
         "type": "rpm",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -2367,19 +2367,19 @@
         "name": "glib2",
         "type": "rpm",
         "version": "*",
-        "wont_fix": true
+        "will_not_fix": true
       },
       {
         "name": "virtuoso-opensource",
         "type": "rpm",
         "version": "*",
-        "wont_fix": true
+        "will_not_fix": true
       },
       {
         "name": "pcre",
         "type": "rpm",
         "version": "*",
-        "wont_fix": true
+        "will_not_fix": true
       }
     ],
     "description": null,
@@ -2442,7 +2442,7 @@
         "name": "gnupg2",
         "type": "rpm",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -2488,13 +2488,13 @@
         "name": "gnupg2",
         "type": "dpkg",
         "version": "2.0.17-2ubuntu2.12.04.4",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "dpkg",
         "version": "1.4.11-3ubuntu2.6",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -2540,7 +2540,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -2603,13 +2603,13 @@
         "name": "gnupg2",
         "type": "dpkg",
         "version": "2.0.22-3ubuntu1.1",
-        "wont_fix": false
+        "will_not_fix": false
       },
       {
         "name": "gnupg",
         "type": "dpkg",
         "version": "1.4.16-1ubuntu2.1",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -2711,7 +2711,7 @@
         "name": "krb5",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -2774,7 +2774,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -2837,7 +2837,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -3012,7 +3012,7 @@
         "name": "krb5",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -3075,7 +3075,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -3194,7 +3194,7 @@
         "name": "krb5",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -3257,7 +3257,7 @@
         "name": "krb5",
         "type": "apk",
         "version": "1.15.3-r0",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -3376,7 +3376,7 @@
         "name": "krb5",
         "type": "apk",
         "version": "1.15.3-r0",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -3439,7 +3439,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -3502,7 +3502,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -3565,7 +3565,7 @@
         "name": "krb5",
         "type": "apk",
         "version": "1.15.3-r0",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -3684,7 +3684,7 @@
         "name": "krb5",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -3747,7 +3747,7 @@
         "name": "krb5",
         "type": "apk",
         "version": "1.15.3-r0",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -3810,7 +3810,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -3929,7 +3929,7 @@
         "name": "krb5",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -3992,7 +3992,7 @@
         "name": "krb5",
         "type": "apk",
         "version": "1.15.3-r0",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -4055,7 +4055,7 @@
         "name": "krb5",
         "type": "apk",
         "version": "1.15.3-r0",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -4118,7 +4118,7 @@
         "name": "krb5",
         "type": "apk",
         "version": "1.15.3-r0",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_query_vulnerabilities/multiple_cves.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_query_vulnerabilities/multiple_cves.json
@@ -4,622 +4,746 @@
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.0.0"
+        "version": "0.0.0",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.1.0"
+        "version": "0.1.0",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.1.1"
+        "version": "0.1.1",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.1.2"
+        "version": "0.1.2",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.1.3"
+        "version": "0.1.3",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.2.0"
+        "version": "0.2.0",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.2.10"
+        "version": "0.2.10",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.2.11"
+        "version": "0.2.11",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.2.12"
+        "version": "0.2.12",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.2.13"
+        "version": "0.2.13",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.2.14"
+        "version": "0.2.14",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.2.15"
+        "version": "0.2.15",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.2.16"
+        "version": "0.2.16",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.2.17"
+        "version": "0.2.17",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.2.18"
+        "version": "0.2.18",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.2.19"
+        "version": "0.2.19",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.2.1"
+        "version": "0.2.1",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.2.2"
+        "version": "0.2.2",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.2.3"
+        "version": "0.2.3",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.2.4"
+        "version": "0.2.4",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.2.5"
+        "version": "0.2.5",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.2.6"
+        "version": "0.2.6",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.2.7"
+        "version": "0.2.7",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.2.8"
+        "version": "0.2.8",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.2.9"
+        "version": "0.2.9",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.3.0"
+        "version": "0.3.0",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.3.1"
+        "version": "0.3.1",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.3.2"
+        "version": "0.3.2",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.3.3"
+        "version": "0.3.3",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.3.4"
+        "version": "0.3.4",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.3.5"
+        "version": "0.3.5",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.4.0"
+        "version": "0.4.0",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.4.1"
+        "version": "0.4.1",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.4.2"
+        "version": "0.4.2",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.4.3"
+        "version": "0.4.3",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.4.4"
+        "version": "0.4.4",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.4.5"
+        "version": "0.4.5",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.9.0"
+        "version": "0.9.0",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.9.10"
+        "version": "0.9.10",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.9.11"
+        "version": "0.9.11",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.9.1"
+        "version": "0.9.1",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.9.2"
+        "version": "0.9.2",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.9.3"
+        "version": "0.9.3",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.9.4"
+        "version": "0.9.4",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.9.5"
+        "version": "0.9.5",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.9.6"
+        "version": "0.9.6",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.9.7"
+        "version": "0.9.7",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.9.8"
+        "version": "0.9.8",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "0.9.9"
+        "version": "0.9.9",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.0.0"
+        "version": "1.0.0",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.0.1"
+        "version": "1.0.1",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.0.2"
+        "version": "1.0.2",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.0.3"
+        "version": "1.0.3",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.0.4"
+        "version": "1.0.4",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.0.4"
+        "version": "1.0.4",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.0.5"
+        "version": "1.0.5",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.0.5"
+        "version": "1.0.5",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.0.6"
+        "version": "1.0.6",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.0.7"
+        "version": "1.0.7",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.1.90"
+        "version": "1.1.90",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.1.91"
+        "version": "1.1.91",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.1.92"
+        "version": "1.1.92",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.2.0"
+        "version": "1.2.0",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.2.1"
+        "version": "1.2.1",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.2.1"
+        "version": "1.2.1",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.2.2"
+        "version": "1.2.2",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.2.3"
+        "version": "1.2.3",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.2.4"
+        "version": "1.2.4",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.2.5"
+        "version": "1.2.5",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.2.6"
+        "version": "1.2.6",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.2.7"
+        "version": "1.2.7",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.2.8"
+        "version": "1.2.8",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.3.0"
+        "version": "1.3.0",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.3.1"
+        "version": "1.3.1",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.3.2"
+        "version": "1.3.2",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.3.3"
+        "version": "1.3.3",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.3.4"
+        "version": "1.3.4",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.3.6"
+        "version": "1.3.6",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.3.90"
+        "version": "1.3.90",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.3.91"
+        "version": "1.3.91",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.3.92"
+        "version": "1.3.92",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.3.93"
+        "version": "1.3.93",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.4.0"
+        "version": "1.4.0",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.4.10"
+        "version": "1.4.10",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.4.11"
+        "version": "1.4.11",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.4.12"
+        "version": "1.4.12",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.4.13"
+        "version": "1.4.13",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.4.14"
+        "version": "1.4.14",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.4.15"
+        "version": "1.4.15",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.4.16"
+        "version": "1.4.16",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.4.1"
+        "version": "1.4.1",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.4.2"
+        "version": "1.4.2",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.4.3"
+        "version": "1.4.3",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.4.4"
+        "version": "1.4.4",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.4.5"
+        "version": "1.4.5",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.4.6"
+        "version": "1.4.6",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.4.7"
+        "version": "1.4.7",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.4.8"
+        "version": "1.4.8",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "1.4.9"
+        "version": "1.4.9",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "2.0.10"
+        "version": "2.0.10",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "2.0.11"
+        "version": "2.0.11",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "2.0.12"
+        "version": "2.0.12",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "2.0.13"
+        "version": "2.0.13",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "2.0.14"
+        "version": "2.0.14",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "2.0.15"
+        "version": "2.0.15",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "2.0.16"
+        "version": "2.0.16",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "2.0.17"
+        "version": "2.0.17",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "2.0.18"
+        "version": "2.0.18",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "2.0.19"
+        "version": "2.0.19",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "2.0.1"
+        "version": "2.0.1",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "2.0.20"
+        "version": "2.0.20",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "2.0.21"
+        "version": "2.0.21",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "2.0.22"
+        "version": "2.0.22",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "2.0.23"
+        "version": "2.0.23",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "2.0.3"
+        "version": "2.0.3",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "2.0.4"
+        "version": "2.0.4",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "2.0.5"
+        "version": "2.0.5",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "2.0.6"
+        "version": "2.0.6",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "2.0.7"
+        "version": "2.0.7",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "2.0.8"
+        "version": "2.0.8",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "*",
-        "version": "2.0"
+        "version": "2.0",
+        "wont_fix": false
       },
       {
         "name": "debian_linux",
         "type": "*",
-        "version": "7.0"
+        "version": "7.0",
+        "wont_fix": false
       },
       {
         "name": "opensuse",
         "type": "*",
-        "version": "12.3"
+        "version": "12.3",
+        "wont_fix": false
       },
       {
         "name": "opensuse",
         "type": "*",
-        "version": "13.1"
+        "version": "13.1",
+        "wont_fix": false
       }
     ],
     "description": "The do_uncompress function in g10/compress.c in GnuPG 1.x before 1.4.17 and 2.x before 2.0.24 allows context-dependent attackers to cause a denial of service (infinite loop) via malformed compressed packets, as demonstrated by an a3 01 5b ff byte sequence.",
@@ -746,7 +870,8 @@
       {
         "name": "pcre",
         "type": "*",
-        "version": "8.40"
+        "version": "8.40",
+        "wont_fix": false
       }
     ],
     "description": "Stack-based buffer overflow in the pcre32_copy_substring function in pcre_get.c in libpcre1 in PCRE 8.40 allows remote attackers to cause a denial of service (WRITE of size 4) or possibly have unspecified other impact via a crafted file.",
@@ -835,7 +960,8 @@
       {
         "name": "kerberos",
         "type": "*",
-        "version": "5-1.16"
+        "version": "5-1.16",
+        "wont_fix": false
       }
     ],
     "description": "An issue was discovered in MIT Kerberos 5 (aka krb5) through 1.16. There is a variable \"dbentry->n_key_data\" in kadmin/dbutil/dump.c that can store 16-bit data but unknowingly the developer has assigned a \"u4\" variable to it, which is for 32-bit data. An attacker can use this vulnerability to affect other artifacts of the database as we know that a Kerberos database dump file contains trusted data.",
@@ -910,7 +1036,8 @@
       {
         "name": "pcre",
         "type": "apk",
-        "version": "8.41-r0"
+        "version": "8.41-r0",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -972,7 +1099,8 @@
       {
         "name": "gnupg2",
         "type": "dpkg",
-        "version": "2.0.24-1"
+        "version": "2.0.24-1",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -1017,7 +1145,8 @@
       {
         "name": "krb5",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -1079,7 +1208,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -1141,7 +1271,8 @@
       {
         "name": "gnupg2",
         "type": "dpkg",
-        "version": "2.0.24-1"
+        "version": "2.0.24-1",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -1186,7 +1317,8 @@
       {
         "name": "krb5",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -1248,7 +1380,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -1366,12 +1499,14 @@
       {
         "name": "gnupg2",
         "type": "dpkg",
-        "version": "2.0.19-2+deb7u2"
+        "version": "2.0.19-2+deb7u2",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "dpkg",
-        "version": "1.4.12-7+deb7u4"
+        "version": "1.4.12-7+deb7u4",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -1416,7 +1551,8 @@
       {
         "name": "krb5",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -1478,12 +1614,14 @@
       {
         "name": "gnupg2",
         "type": "dpkg",
-        "version": "2.0.24-1"
+        "version": "2.0.24-1",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "dpkg",
-        "version": "1.4.16-1.2"
+        "version": "1.4.16-1.2",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -1528,7 +1666,8 @@
       {
         "name": "krb5",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -1590,7 +1729,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": true
       }
     ],
     "description": null,
@@ -1652,7 +1792,8 @@
       {
         "name": "gnupg2",
         "type": "dpkg",
-        "version": "2.0.24-1"
+        "version": "2.0.24-1",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -1697,7 +1838,8 @@
       {
         "name": "krb5",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -1759,7 +1901,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -1821,7 +1964,8 @@
       {
         "name": "gnupg2",
         "type": "dpkg",
-        "version": "2.0.24-1"
+        "version": "2.0.24-1",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -1866,7 +2010,8 @@
       {
         "name": "krb5",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -1928,7 +2073,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -1990,7 +2136,8 @@
       {
         "name": "pcre",
         "type": "rpm",
-        "version": "*"
+        "version": "*",
+        "wont_fix": true
       }
     ],
     "description": null,
@@ -2052,12 +2199,14 @@
       {
         "name": "gnupg",
         "type": "rpm",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       },
       {
         "name": "gnupg2",
         "type": "rpm",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -2102,12 +2251,14 @@
       {
         "name": "glib2",
         "type": "rpm",
-        "version": "*"
+        "version": "*",
+        "wont_fix": true
       },
       {
         "name": "pcre",
         "type": "rpm",
-        "version": "*"
+        "version": "*",
+        "wont_fix": true
       }
     ],
     "description": null,
@@ -2169,7 +2320,8 @@
       {
         "name": "gnupg2",
         "type": "rpm",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -2214,17 +2366,20 @@
       {
         "name": "glib2",
         "type": "rpm",
-        "version": "*"
+        "version": "*",
+        "wont_fix": true
       },
       {
         "name": "virtuoso-opensource",
         "type": "rpm",
-        "version": "*"
+        "version": "*",
+        "wont_fix": true
       },
       {
         "name": "pcre",
         "type": "rpm",
-        "version": "*"
+        "version": "*",
+        "wont_fix": true
       }
     ],
     "description": null,
@@ -2286,7 +2441,8 @@
       {
         "name": "gnupg2",
         "type": "rpm",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -2331,12 +2487,14 @@
       {
         "name": "gnupg2",
         "type": "dpkg",
-        "version": "2.0.17-2ubuntu2.12.04.4"
+        "version": "2.0.17-2ubuntu2.12.04.4",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "dpkg",
-        "version": "1.4.11-3ubuntu2.6"
+        "version": "1.4.11-3ubuntu2.6",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -2381,7 +2539,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -2443,12 +2602,14 @@
       {
         "name": "gnupg2",
         "type": "dpkg",
-        "version": "2.0.22-3ubuntu1.1"
+        "version": "2.0.22-3ubuntu1.1",
+        "wont_fix": false
       },
       {
         "name": "gnupg",
         "type": "dpkg",
-        "version": "1.4.16-1ubuntu2.1"
+        "version": "1.4.16-1ubuntu2.1",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -2549,7 +2710,8 @@
       {
         "name": "krb5",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -2611,7 +2773,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -2673,7 +2836,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -2847,7 +3011,8 @@
       {
         "name": "krb5",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -2909,7 +3074,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -3027,7 +3193,8 @@
       {
         "name": "krb5",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -3089,7 +3256,8 @@
       {
         "name": "krb5",
         "type": "apk",
-        "version": "1.15.3-r0"
+        "version": "1.15.3-r0",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -3207,7 +3375,8 @@
       {
         "name": "krb5",
         "type": "apk",
-        "version": "1.15.3-r0"
+        "version": "1.15.3-r0",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -3269,7 +3438,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -3331,7 +3501,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -3393,7 +3564,8 @@
       {
         "name": "krb5",
         "type": "apk",
-        "version": "1.15.3-r0"
+        "version": "1.15.3-r0",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -3511,7 +3683,8 @@
       {
         "name": "krb5",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -3573,7 +3746,8 @@
       {
         "name": "krb5",
         "type": "apk",
-        "version": "1.15.3-r0"
+        "version": "1.15.3-r0",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -3635,7 +3809,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -3753,7 +3928,8 @@
       {
         "name": "krb5",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -3815,7 +3991,8 @@
       {
         "name": "krb5",
         "type": "apk",
-        "version": "1.15.3-r0"
+        "version": "1.15.3-r0",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -3877,7 +4054,8 @@
       {
         "name": "krb5",
         "type": "apk",
-        "version": "1.15.3-r0"
+        "version": "1.15.3-r0",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -3939,7 +4117,8 @@
       {
         "name": "krb5",
         "type": "apk",
-        "version": "1.15.3-r0"
+        "version": "1.15.3-r0",
+        "wont_fix": false
       }
     ],
     "description": null,

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_query_vulnerabilities/multiple_cves_filter_affected_package.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_query_vulnerabilities/multiple_cves_filter_affected_package.json
@@ -4,7 +4,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -66,7 +67,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -128,7 +130,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -190,7 +193,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -252,7 +256,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -314,7 +319,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": true
       }
     ],
     "description": null,
@@ -376,7 +382,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -438,7 +445,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -500,7 +508,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -562,7 +571,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -624,7 +634,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -686,7 +697,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -748,7 +760,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -810,7 +823,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -872,7 +886,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -934,7 +949,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -996,7 +1012,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -1058,7 +1075,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -1120,7 +1138,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -1182,7 +1201,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -1244,7 +1264,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -1306,7 +1327,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -1368,7 +1390,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -1430,7 +1453,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_query_vulnerabilities/multiple_cves_filter_affected_package.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_query_vulnerabilities/multiple_cves_filter_affected_package.json
@@ -5,7 +5,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -68,7 +68,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -131,7 +131,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -194,7 +194,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -257,7 +257,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -320,7 +320,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": true
+        "will_not_fix": true
       }
     ],
     "description": null,
@@ -383,7 +383,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -446,7 +446,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -509,7 +509,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -572,7 +572,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -635,7 +635,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -698,7 +698,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -761,7 +761,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -824,7 +824,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -887,7 +887,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -950,7 +950,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -1013,7 +1013,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -1076,7 +1076,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -1139,7 +1139,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -1202,7 +1202,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -1265,7 +1265,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -1328,7 +1328,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -1391,7 +1391,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -1454,7 +1454,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_query_vulnerabilities/multiple_cves_multiple_filters.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_query_vulnerabilities/multiple_cves_multiple_filters.json
@@ -5,7 +5,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -68,7 +68,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_query_vulnerabilities/multiple_cves_multiple_filters.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_query_vulnerabilities/multiple_cves_multiple_filters.json
@@ -4,69 +4,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
-      }
-    ],
-    "description": null,
-    "id": "CVE-2017-11164",
-    "link": "https://security-tracker.debian.org/tracker/CVE-2017-11164",
-    "namespace": "debian:10",
-    "nvd_data": [
-      {
-        "cvss_v2": {
-          "additional_information": {
-            "ac_insuf_info": null,
-            "obtain_all_privilege": false,
-            "obtain_other_privilege": false,
-            "obtain_user_privilege": false,
-            "user_interaction_required": false
-          },
-          "base_metrics": {
-            "access_complexity": "LOW",
-            "access_vector": "NETWORK",
-            "authentication": "NONE",
-            "availability_impact": "COMPLETE",
-            "base_score": 7.8,
-            "confidentiality_impact": "NONE",
-            "exploitability_score": 10.0,
-            "impact_score": 6.9,
-            "integrity_impact": "NONE"
-          },
-          "severity": "High",
-          "vector_string": "AV:N/AC:L/Au:N/C:N/I:N/A:C",
-          "version": "2.0"
-        },
-        "cvss_v3": {
-          "base_metrics": {
-            "attack_complexity": "LOW",
-            "attack_vector": "NETWORK",
-            "availability_impact": "HIGH",
-            "base_score": 7.5,
-            "base_severity": "High",
-            "confidentiality_impact": "NONE",
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "integrity_impact": "NONE",
-            "privileges_required": "NONE",
-            "scope": "UNCHANGED",
-            "user_interaction": "NONE"
-          },
-          "vector_string": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-          "version": "3.0"
-        },
-        "id": "CVE-2017-11164"
-      }
-    ],
-    "references": null,
-    "severity": "Negligible",
-    "vendor_data": []
-  },
-  {
-    "affected_packages": [
-      {
-        "name": "pcre3",
-        "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -117,6 +56,69 @@
           "version": "3.0"
         },
         "id": "CVE-2017-7245"
+      }
+    ],
+    "references": null,
+    "severity": "Negligible",
+    "vendor_data": []
+  },
+  {
+    "affected_packages": [
+      {
+        "name": "pcre3",
+        "type": "dpkg",
+        "version": "*",
+        "wont_fix": false
+      }
+    ],
+    "description": null,
+    "id": "CVE-2017-11164",
+    "link": "https://security-tracker.debian.org/tracker/CVE-2017-11164",
+    "namespace": "debian:10",
+    "nvd_data": [
+      {
+        "cvss_v2": {
+          "additional_information": {
+            "ac_insuf_info": null,
+            "obtain_all_privilege": false,
+            "obtain_other_privilege": false,
+            "obtain_user_privilege": false,
+            "user_interaction_required": false
+          },
+          "base_metrics": {
+            "access_complexity": "LOW",
+            "access_vector": "NETWORK",
+            "authentication": "NONE",
+            "availability_impact": "COMPLETE",
+            "base_score": 7.8,
+            "confidentiality_impact": "NONE",
+            "exploitability_score": 10.0,
+            "impact_score": 6.9,
+            "integrity_impact": "NONE"
+          },
+          "severity": "High",
+          "vector_string": "AV:N/AC:L/Au:N/C:N/I:N/A:C",
+          "version": "2.0"
+        },
+        "cvss_v3": {
+          "base_metrics": {
+            "attack_complexity": "LOW",
+            "attack_vector": "NETWORK",
+            "availability_impact": "HIGH",
+            "base_score": 7.5,
+            "base_severity": "High",
+            "confidentiality_impact": "NONE",
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "integrity_impact": "NONE",
+            "privileges_required": "NONE",
+            "scope": "UNCHANGED",
+            "user_interaction": "NONE"
+          },
+          "vector_string": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "version": "3.0"
+        },
+        "id": "CVE-2017-11164"
       }
     ],
     "references": null,

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_query_vulnerabilities/single_cve.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_query_vulnerabilities/single_cve.json
@@ -4,7 +4,8 @@
       {
         "name": "pcre",
         "type": "*",
-        "version": "8.40"
+        "version": "8.40",
+        "wont_fix": false
       }
     ],
     "description": "Stack-based buffer overflow in the pcre32_copy_substring function in pcre_get.c in libpcre1 in PCRE 8.40 allows remote attackers to cause a denial of service (WRITE of size 4) or possibly have unspecified other impact via a crafted file.",
@@ -93,7 +94,8 @@
       {
         "name": "pcre",
         "type": "apk",
-        "version": "8.41-r0"
+        "version": "8.41-r0",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -155,7 +157,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -217,7 +220,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -335,7 +339,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": true
       }
     ],
     "description": null,
@@ -397,7 +402,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -459,7 +465,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -521,7 +528,8 @@
       {
         "name": "pcre",
         "type": "rpm",
-        "version": "*"
+        "version": "*",
+        "wont_fix": true
       }
     ],
     "description": null,
@@ -583,12 +591,14 @@
       {
         "name": "glib2",
         "type": "rpm",
-        "version": "*"
+        "version": "*",
+        "wont_fix": true
       },
       {
         "name": "pcre",
         "type": "rpm",
-        "version": "*"
+        "version": "*",
+        "wont_fix": true
       }
     ],
     "description": null,
@@ -650,17 +660,20 @@
       {
         "name": "pcre",
         "type": "rpm",
-        "version": "*"
+        "version": "*",
+        "wont_fix": true
       },
       {
         "name": "glib2",
         "type": "rpm",
-        "version": "*"
+        "version": "*",
+        "wont_fix": true
       },
       {
         "name": "virtuoso-opensource",
         "type": "rpm",
-        "version": "*"
+        "version": "*",
+        "wont_fix": true
       }
     ],
     "description": null,
@@ -722,7 +735,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -784,7 +798,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -846,7 +861,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -964,7 +980,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -1082,7 +1099,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -1144,7 +1162,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -1262,7 +1281,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_query_vulnerabilities/single_cve.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_query_vulnerabilities/single_cve.json
@@ -5,7 +5,7 @@
         "name": "pcre",
         "type": "*",
         "version": "8.40",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": "Stack-based buffer overflow in the pcre32_copy_substring function in pcre_get.c in libpcre1 in PCRE 8.40 allows remote attackers to cause a denial of service (WRITE of size 4) or possibly have unspecified other impact via a crafted file.",
@@ -95,7 +95,7 @@
         "name": "pcre",
         "type": "apk",
         "version": "8.41-r0",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -158,7 +158,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -221,7 +221,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -340,7 +340,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": true
+        "will_not_fix": true
       }
     ],
     "description": null,
@@ -403,7 +403,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -466,7 +466,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -529,7 +529,7 @@
         "name": "pcre",
         "type": "rpm",
         "version": "*",
-        "wont_fix": true
+        "will_not_fix": true
       }
     ],
     "description": null,
@@ -592,13 +592,13 @@
         "name": "glib2",
         "type": "rpm",
         "version": "*",
-        "wont_fix": true
+        "will_not_fix": true
       },
       {
         "name": "pcre",
         "type": "rpm",
         "version": "*",
-        "wont_fix": true
+        "will_not_fix": true
       }
     ],
     "description": null,
@@ -661,19 +661,19 @@
         "name": "pcre",
         "type": "rpm",
         "version": "*",
-        "wont_fix": true
+        "will_not_fix": true
       },
       {
         "name": "glib2",
         "type": "rpm",
         "version": "*",
-        "wont_fix": true
+        "will_not_fix": true
       },
       {
         "name": "virtuoso-opensource",
         "type": "rpm",
         "version": "*",
-        "wont_fix": true
+        "will_not_fix": true
       }
     ],
     "description": null,
@@ -736,7 +736,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -799,7 +799,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -862,7 +862,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -981,7 +981,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -1100,7 +1100,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -1163,7 +1163,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -1282,7 +1282,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_query_vulnerabilities/single_cve_filter_affected_package.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_query_vulnerabilities/single_cve_filter_affected_package.json
@@ -4,7 +4,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -66,7 +67,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -128,7 +130,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": true
       }
     ],
     "description": null,
@@ -190,7 +193,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -252,7 +256,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -314,7 +319,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -376,7 +382,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -438,7 +445,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -500,7 +508,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -562,7 +571,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -624,7 +634,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,
@@ -686,7 +697,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_query_vulnerabilities/single_cve_filter_affected_package.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_query_vulnerabilities/single_cve_filter_affected_package.json
@@ -5,7 +5,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -68,7 +68,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -131,7 +131,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": true
+        "will_not_fix": true
       }
     ],
     "description": null,
@@ -194,7 +194,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -257,7 +257,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -320,7 +320,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -383,7 +383,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -446,7 +446,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -509,7 +509,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -572,7 +572,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -635,7 +635,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,
@@ -698,7 +698,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_query_vulnerabilities/single_cve_multiple_filters.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_query_vulnerabilities/single_cve_multiple_filters.json
@@ -5,7 +5,7 @@
         "name": "pcre3",
         "type": "dpkg",
         "version": "*",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": null,

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_query_vulnerabilities/single_cve_multiple_filters.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_query_vulnerabilities/single_cve_multiple_filters.json
@@ -4,7 +4,8 @@
       {
         "name": "pcre3",
         "type": "dpkg",
-        "version": "*"
+        "version": "*",
+        "wont_fix": false
       }
     ],
     "description": null,

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_query_vulnerabilities/single_cve_multiple_filters_2.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_query_vulnerabilities/single_cve_multiple_filters_2.json
@@ -5,7 +5,7 @@
         "name": "coreutils",
         "type": "*",
         "version": "8.9",
-        "wont_fix": false
+        "will_not_fix": false
       }
     ],
     "description": "In GNU Coreutils through 8.29, chown-core.c in chown and chgrp does not prevent replacement of a plain file with a symlink during use of the POSIX \"-R -L\" options, which allows local users to modify the ownership of arbitrary files by leveraging a race condition.",

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_query_vulnerabilities/single_cve_multiple_filters_2.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_query_vulnerabilities/single_cve_multiple_filters_2.json
@@ -4,7 +4,8 @@
       {
         "name": "coreutils",
         "type": "*",
-        "version": "8.9"
+        "version": "8.9",
+        "wont_fix": false
       }
     ],
     "description": "In GNU Coreutils through 8.29, chown-core.c in chown and chgrp does not prevent replacement of a plain file with a symlink during use of the POSIX \"-R -L\" options, which allows local users to modify the ownership of arbitrary files by leveraging a race condition.",

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/grype/sha256:406413437f26223183d133ccc7186f24c827729e1b21adc7330dd43fcdc030b3.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/grype/sha256:406413437f26223183d133ccc7186f24c827729e1b21adc7330dd43fcdc030b3.json
@@ -12,7 +12,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -64,7 +64,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -116,7 +116,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -163,7 +163,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -207,7 +207,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -259,7 +259,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -304,7 +304,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -356,7 +356,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -408,7 +408,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -460,7 +460,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -512,7 +512,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -557,7 +557,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -602,7 +602,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -656,7 +656,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -700,7 +700,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -752,7 +752,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -797,7 +797,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -849,7 +849,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -901,7 +901,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -953,7 +953,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -1007,7 +1007,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -1051,7 +1051,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -1096,7 +1096,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -1148,7 +1148,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -1200,7 +1200,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -1245,7 +1245,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -1290,7 +1290,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -1342,7 +1342,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -1387,7 +1387,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -1439,7 +1439,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -1486,7 +1486,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -1530,7 +1530,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -1582,7 +1582,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -1637,7 +1637,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -1681,7 +1681,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -1733,7 +1733,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -1780,7 +1780,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -1824,7 +1824,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -1876,7 +1876,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -1921,7 +1921,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -1966,7 +1966,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -2011,7 +2011,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -2063,7 +2063,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -2115,7 +2115,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -2167,7 +2167,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -2219,7 +2219,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -2271,7 +2271,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -2323,7 +2323,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -2375,7 +2375,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -2430,7 +2430,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -2476,7 +2476,7 @@
       "versions": [
         "1.8.3-1+deb10u1"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -2505,7 +2505,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -2557,7 +2557,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -2602,7 +2602,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -2654,7 +2654,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -2706,7 +2706,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -2758,7 +2758,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -2812,7 +2812,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -2856,7 +2856,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -2908,7 +2908,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -2963,7 +2963,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -3007,7 +3007,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -3059,7 +3059,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -3111,7 +3111,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -3156,7 +3156,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -3210,7 +3210,7 @@
       "versions": [
         "11.0.11+9-1~deb10u1"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -3262,7 +3262,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -3314,7 +3314,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -3359,7 +3359,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -3411,7 +3411,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -3463,7 +3463,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -3515,7 +3515,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -3567,7 +3567,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -3619,7 +3619,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -3671,7 +3671,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -3723,7 +3723,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -3768,7 +3768,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -3820,7 +3820,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -3872,7 +3872,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -3924,7 +3924,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -3969,7 +3969,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -3998,7 +3998,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -4050,7 +4050,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -4102,7 +4102,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -4157,7 +4157,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -4201,7 +4201,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -4253,7 +4253,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -4282,7 +4282,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -4334,7 +4334,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -4386,7 +4386,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -4438,7 +4438,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -4483,7 +4483,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -4535,7 +4535,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -4587,7 +4587,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -4639,7 +4639,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -4691,7 +4691,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -4743,7 +4743,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -4788,7 +4788,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -4840,7 +4840,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"
@@ -4892,7 +4892,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:34:56Z"

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/grype/sha256:80a31c3ce2e99c3691c27ac3b1753163214494e9b2ca07bfdccf29a5cca2bfbe.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/grype/sha256:80a31c3ce2e99c3691c27ac3b1753163214494e9b2ca07bfdccf29a5cca2bfbe.json
@@ -15,7 +15,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:16:01Z"
@@ -61,7 +61,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:16:01Z"
@@ -107,7 +107,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:16:01Z"
@@ -153,7 +153,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:16:01Z"
@@ -199,7 +199,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:16:01Z"
@@ -245,7 +245,7 @@
       "versions": [
         "2.10.6-r0"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:16:01Z"
@@ -277,7 +277,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:16:01Z"
@@ -323,7 +323,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:16:01Z"
@@ -370,7 +370,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:16:01Z"
@@ -416,7 +416,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:16:01Z"
@@ -463,7 +463,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:16:01Z"
@@ -509,7 +509,7 @@
       "versions": [
         "1.31.1-r20"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:16:01Z"
@@ -563,7 +563,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:16:01Z"

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/grype/sha256:fe3ca35038008b0eac0fa4e686bd072c9430000ab7d7853001bde5f5b8ccf60c.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/grype/sha256:fe3ca35038008b0eac0fa4e686bd072c9430000ab7d7853001bde5f5b8ccf60c.json
@@ -14,7 +14,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:35:50Z"
@@ -60,7 +60,7 @@
       "versions": [
         "0:7.29.0-59.el7_9.1"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:35:50Z"
@@ -123,7 +123,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:35:50Z"
@@ -167,7 +167,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:35:50Z"
@@ -241,7 +241,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:35:50Z"
@@ -286,7 +286,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:35:50Z"
@@ -340,7 +340,7 @@
       "versions": [
         "0:2.56.1-9.el7_9"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:35:50Z"
@@ -402,7 +402,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:35:50Z"
@@ -448,7 +448,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:35:50Z"
@@ -494,7 +494,7 @@
       "versions": [
         "0:3.53.1-7.el7_9"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:35:50Z"
@@ -556,7 +556,7 @@
       "versions": [
         "0:7.29.0-59.el7_9.1"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:35:50Z"
@@ -619,7 +619,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:35:50Z"
@@ -665,7 +665,7 @@
       "versions": [
         "0:2.4.44-23.el7_9"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:35:50Z"
@@ -728,7 +728,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:35:50Z"
@@ -772,7 +772,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:35:50Z"
@@ -819,7 +819,7 @@
       "versions": [
         "0:3.53.1-7.el7_9"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:35:50Z"
@@ -881,7 +881,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:35:50Z"
@@ -925,7 +925,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:35:50Z"
@@ -980,7 +980,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:35:50Z"
@@ -1024,7 +1024,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:35:50Z"
@@ -1091,7 +1091,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:35:50Z"
@@ -1138,7 +1138,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:35:50Z"
@@ -1182,7 +1182,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:35:50Z"
@@ -1229,7 +1229,7 @@
       "versions": [
         "0:3.53.1-7.el7_9"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:35:50Z"
@@ -1291,7 +1291,7 @@
       "versions": [
         "1:1.0.2k-21.el7_9"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:35:50Z"
@@ -1353,7 +1353,7 @@
       "versions": [
         "0:2.7.5-90.el7"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:35:50Z"
@@ -1420,7 +1420,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:35:50Z"
@@ -1467,7 +1467,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:35:50Z"
@@ -1513,7 +1513,7 @@
       "versions": [
         "0:2.7.5-90.el7"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:35:50Z"
@@ -1580,7 +1580,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:35:50Z"
@@ -1627,7 +1627,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-08T20:35:50Z"

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/legacy/sha256:406413437f26223183d133ccc7186f24c827729e1b21adc7330dd43fcdc030b3.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/legacy/sha256:406413437f26223183d133ccc7186f24c827729e1b21adc7330dd43fcdc030b3.json
@@ -12,7 +12,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -64,7 +64,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -109,7 +109,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -161,7 +161,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -206,7 +206,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -258,7 +258,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -310,7 +310,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -362,7 +362,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -407,7 +407,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -459,7 +459,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -511,7 +511,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -556,7 +556,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -608,7 +608,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -660,7 +660,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -705,7 +705,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -757,7 +757,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -809,7 +809,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -863,7 +863,7 @@
       "versions": [
         "30.0-jre"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -915,7 +915,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -960,7 +960,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -1012,7 +1012,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -1064,7 +1064,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -1116,7 +1116,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -1168,7 +1168,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -1220,7 +1220,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -1272,7 +1272,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -1324,7 +1324,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -1376,7 +1376,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -1421,7 +1421,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -1468,7 +1468,7 @@
       "versions": [
         "24.1.1-jre"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -1520,7 +1520,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -1574,7 +1574,7 @@
       "versions": [
         "0.5.0"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -1626,7 +1626,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -1678,7 +1678,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -1723,7 +1723,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -1775,7 +1775,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -1827,7 +1827,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -1872,7 +1872,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -1924,7 +1924,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -1976,7 +1976,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -2028,7 +2028,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -2080,7 +2080,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -2119,7 +2119,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-03-31T17:11:12Z"
@@ -2163,7 +2163,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -2215,7 +2215,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -2267,7 +2267,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -2312,7 +2312,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -2364,7 +2364,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -2409,7 +2409,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -2456,7 +2456,7 @@
       "versions": [
         "3.7.4"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -2508,7 +2508,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -2560,7 +2560,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -2612,7 +2612,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -2664,7 +2664,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -2709,7 +2709,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -2761,7 +2761,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -2813,7 +2813,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -2865,7 +2865,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -2910,7 +2910,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -2962,7 +2962,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -3014,7 +3014,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -3066,7 +3066,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -3111,7 +3111,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -3163,7 +3163,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -3215,7 +3215,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -3267,7 +3267,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -3319,7 +3319,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -3371,7 +3371,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -3416,7 +3416,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -3461,7 +3461,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -3515,7 +3515,7 @@
       "versions": [
         "24.1.1-jre"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -3567,7 +3567,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -3619,7 +3619,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -3671,7 +3671,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -3716,7 +3716,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -3768,7 +3768,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -3820,7 +3820,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -3865,7 +3865,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -3917,7 +3917,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -3969,7 +3969,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -4021,7 +4021,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -4073,7 +4073,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -4118,7 +4118,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -4170,7 +4170,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -4222,7 +4222,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -4274,7 +4274,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -4321,7 +4321,7 @@
       "versions": [
         "30.0-jre"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -4373,7 +4373,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -4425,7 +4425,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -4470,7 +4470,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -4522,7 +4522,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -4567,7 +4567,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"
@@ -4619,7 +4619,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:49Z"

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/legacy/sha256:80a31c3ce2e99c3691c27ac3b1753163214494e9b2ca07bfdccf29a5cca2bfbe.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/legacy/sha256:80a31c3ce2e99c3691c27ac3b1753163214494e9b2ca07bfdccf29a5cca2bfbe.json
@@ -14,7 +14,7 @@
       "versions": [
         "24.1.1-jre"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:47Z"
@@ -68,7 +68,7 @@
       "versions": [
         "0.5.0"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:47Z"
@@ -122,7 +122,7 @@
       "versions": [
         "3.7.4"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:47Z"
@@ -176,7 +176,7 @@
       "versions": [
         "30.0-jre"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:47Z"
@@ -230,7 +230,7 @@
       "versions": [
         "30.0-jre"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:47Z"
@@ -284,7 +284,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-03-31T17:11:12Z"
@@ -330,7 +330,7 @@
       "versions": [
         "24.1.1-jre"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:47Z"

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/legacy/sha256:fe3ca35038008b0eac0fa4e686bd072c9430000ab7d7853001bde5f5b8ccf60c.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/legacy/sha256:fe3ca35038008b0eac0fa4e686bd072c9430000ab7d7853001bde5f5b8ccf60c.json
@@ -12,7 +12,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:50Z"
@@ -64,7 +64,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:50Z"
@@ -111,7 +111,7 @@
       "versions": [
         "24.1.1-jre"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:50Z"
@@ -165,7 +165,7 @@
       "versions": [
         "0:7.29.0-59.el7_9.1"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:50Z"
@@ -217,7 +217,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:50Z"
@@ -271,7 +271,7 @@
       "versions": [
         "0:2.7.5-90.el7"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:50Z"
@@ -325,7 +325,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-03-31T17:11:12Z"
@@ -369,7 +369,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:50Z"
@@ -423,7 +423,7 @@
       "versions": [
         "0.5.0"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:50Z"
@@ -477,7 +477,7 @@
       "versions": [
         "3.7.4"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:50Z"
@@ -529,7 +529,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:50Z"
@@ -581,7 +581,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:50Z"
@@ -633,7 +633,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:50Z"
@@ -680,7 +680,7 @@
       "versions": [
         "1:1.0.2k-21.el7_9"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:50Z"
@@ -732,7 +732,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:50Z"
@@ -784,7 +784,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:50Z"
@@ -836,7 +836,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:50Z"
@@ -888,7 +888,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:50Z"
@@ -940,7 +940,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:50Z"
@@ -987,7 +987,7 @@
       "versions": [
         "0:7.29.0-59.el7_9.1"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:50Z"
@@ -1041,7 +1041,7 @@
       "versions": [
         "30.0-jre"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:50Z"
@@ -1095,7 +1095,7 @@
       "versions": [
         "30.0-jre"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:50Z"
@@ -1147,7 +1147,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:50Z"
@@ -1201,7 +1201,7 @@
       "versions": [
         "0.5.0"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:50Z"
@@ -1253,7 +1253,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:50Z"
@@ -1298,7 +1298,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:50Z"
@@ -1350,7 +1350,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:50Z"
@@ -1395,7 +1395,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:50Z"
@@ -1447,7 +1447,7 @@
       "advisories": [],
       "observed_at": null,
       "versions": [],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:50Z"
@@ -1494,7 +1494,7 @@
       "versions": [
         "0:2.7.5-90.el7"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:50Z"
@@ -1548,7 +1548,7 @@
       "versions": [
         "24.1.1-jre"
       ],
-      "wont_fix": false
+      "will_not_fix": false
     },
     "match": {
       "detected_at": "2021-06-07T20:20:50Z"

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/schema_files/vulnerability_report.schema.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/schema_files/vulnerability_report.schema.json
@@ -106,7 +106,7 @@
             "type": "string"
           }
         },
-        "wont_fix": {
+        "will_not_fix": {
           "type": "boolean"
         },
         "advisories": {

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/test_query_vulnerabilities.py
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/test_query_vulnerabilities.py
@@ -81,8 +81,8 @@ class TestQueryVulnerabilities:
 
             # Validate that every entry in affected package has staging_dummy set
             for package in vuln["affected_packages"]:
-                assert "wont_fix" in package
-                assert isinstance(package["wont_fix"], bool)
+                assert "will_not_fix" in package
+                assert isinstance(package["will_not_fix"], bool)
 
             if query.query_metadata.affected_package:
                 # build dict where key is name and value is array of affected versions

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/test_query_vulnerabilities.py
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/test_query_vulnerabilities.py
@@ -79,6 +79,11 @@ class TestQueryVulnerabilities:
             if query.query_metadata.namespace:
                 assert vuln["namespace"] == query.query_metadata.namespace
 
+            # Validate that every entry in affected package has staging_dummy set
+            for package in vuln["affected_packages"]:
+                assert "wont_fix" in package
+                assert isinstance(package["wont_fix"], bool)
+
             if query.query_metadata.affected_package:
                 # build dict where key is name and value is array of affected versions
                 package_versions = defaultdict(lambda: [])

--- a/tests/unit/anchore_engine/services/catalog/test_utils.py
+++ b/tests/unit/anchore_engine/services/catalog/test_utils.py
@@ -227,7 +227,7 @@ def test_get_normalized_map_from_table_exceptions(test_input, error):
                             "advisories": [],
                             "observed_at": "2021-03-31T17:30:49Z",
                             "versions": ["3.7.4"],
-                            "wont_fix": False,
+                            "will_not_fix": False,
                         },
                         "match": {"detected_at": "2021-06-07T20:20:47Z"},
                         "nvd": [],

--- a/tests/unit/anchore_engine/services/policy_engine/engine/policy/gates/test_vulnerabilities/debian_1_non-os_will-fix.json
+++ b/tests/unit/anchore_engine/services/policy_engine/engine/policy/gates/test_vulnerabilities/debian_1_non-os_will-fix.json
@@ -4,7 +4,7 @@
   "results": [
     {
       "fix": {
-        "wont_fix": false,
+        "will_not_fix": false,
         "advisories": [],
         "versions": [],
         "observed_at": null

--- a/tests/unit/anchore_engine/services/policy_engine/engine/policy/gates/test_vulnerabilities/debian_1_os_will-fix.json
+++ b/tests/unit/anchore_engine/services/policy_engine/engine/policy/gates/test_vulnerabilities/debian_1_os_will-fix.json
@@ -4,7 +4,7 @@
   "results": [
     {
       "fix": {
-        "wont_fix": false,
+        "will_not_fix": false,
         "advisories": [],
         "versions": [],
         "observed_at": null

--- a/tests/unit/anchore_engine/services/policy_engine/engine/policy/gates/test_vulnerabilities/debian_1_os_will-fix_fix-available.json
+++ b/tests/unit/anchore_engine/services/policy_engine/engine/policy/gates/test_vulnerabilities/debian_1_os_will-fix_fix-available.json
@@ -4,7 +4,7 @@
   "results": [
     {
       "fix": {
-        "wont_fix": false,
+        "will_not_fix": false,
         "advisories": [],
         "versions": [
           "0.6.1-3"

--- a/tests/unit/anchore_engine/services/policy_engine/engine/policy/gates/test_vulnerabilities/debian_1_os_will-fix_vendor_cvssv3.json
+++ b/tests/unit/anchore_engine/services/policy_engine/engine/policy/gates/test_vulnerabilities/debian_1_os_will-fix_vendor_cvssv3.json
@@ -4,7 +4,7 @@
   "results": [
     {
       "fix": {
-        "wont_fix": false,
+        "will_not_fix": false,
         "advisories": [],
         "versions": [],
         "observed_at": null

--- a/tests/unit/anchore_engine/services/policy_engine/engine/policy/gates/test_vulnerabilities/debian_1_os_wont-fix.json
+++ b/tests/unit/anchore_engine/services/policy_engine/engine/policy/gates/test_vulnerabilities/debian_1_os_wont-fix.json
@@ -4,7 +4,7 @@
   "results": [
     {
       "fix": {
-        "wont_fix": true,
+        "will_not_fix": true,
         "advisories": [],
         "versions": [],
         "observed_at": null

--- a/tests/unit/anchore_engine/services/policy_engine/engine/vulnerabilities/test_providers.py
+++ b/tests/unit/anchore_engine/services/policy_engine/engine/vulnerabilities/test_providers.py
@@ -14,19 +14,19 @@ class TestGrypeProvider:
         "test_input",
         [
             pytest.param(
-                [VulnerabilityMatch(fix=FixedArtifact(wont_fix="true"))],
+                [VulnerabilityMatch(fix=FixedArtifact(will_not_fix="true"))],
                 id="str",
             ),
             pytest.param(
-                [VulnerabilityMatch(fix=FixedArtifact(wont_fix="  "))],
+                [VulnerabilityMatch(fix=FixedArtifact(will_not_fix="  "))],
                 id="whitespace",
             ),
             pytest.param(
-                [VulnerabilityMatch(fix=FixedArtifact(wont_fix=""))],
+                [VulnerabilityMatch(fix=FixedArtifact(will_not_fix=""))],
                 id="blank",
             ),
             pytest.param(
-                [VulnerabilityMatch(fix=FixedArtifact(wont_fix=False))],
+                [VulnerabilityMatch(fix=FixedArtifact(will_not_fix=False))],
                 id="boolean_false",
             ),
             pytest.param(
@@ -35,20 +35,20 @@ class TestGrypeProvider:
             ),
         ],
     )
-    def test_exclude_wont_fix_false(self, test_input):
-        assert len(GrypeProvider._exclude_wont_fix(test_input)) == 1
+    def test_exclude_will_not_fix_false(self, test_input):
+        assert len(GrypeProvider._exclude_will_not_fix(test_input)) == 1
 
     @pytest.mark.parametrize(
         "test_input",
         [
             pytest.param(
-                [VulnerabilityMatch(fix=FixedArtifact(wont_fix=True))],
+                [VulnerabilityMatch(fix=FixedArtifact(will_not_fix=True))],
                 id="boolean_true",
             ),
         ],
     )
-    def test_exclude_wont_fix_true(self, test_input):
-        assert len(GrypeProvider._exclude_wont_fix(test_input)) == 0
+    def test_exclude_will_not_fix_true(self, test_input):
+        assert len(GrypeProvider._exclude_will_not_fix(test_input)) == 0
 
     @pytest.mark.parametrize(
         "test_input, expected_output",
@@ -173,7 +173,7 @@ class TestGrypeProvider:
         vuln_match = VulnerabilityMatch(
             vulnerability=Vulnerability(vulnerability_id="CVE-xyz"),
             artifact=Artifact(name="foo"),
-            fix=FixedArtifact(wont_fix=test_input),
+            fix=FixedArtifact(will_not_fix=test_input),
         )
 
         results = GrypeProvider._filter_vulnerability_matches(


### PR DESCRIPTION
This PR does a couple things: 

1. renames `wont_fix` to `will_not_fix` both internally and in api responses
2. Adds `will_not_fix` to the api service response for `GET /images/{imageDigest}/vuln/{vtype}`
3. Adds `will_not_fix` to policy-engine and api service response for `GET /query/vulnerabilities`
4. Adds functional tests for both endpoints
5. Updates swagger spec documentation 
6. Updates api version 

