### PR TITLE
Iterate analysis over all available tags for a given image digest

### DIFF
--- a/anchore_engine/clients/localanchore_standalone.py
+++ b/anchore_engine/clients/localanchore_standalone.py
@@ -1011,143 +1011,160 @@ def analyze_image(
     event = None
     pullstring = None
     fulltag = None
+    analysis_error = None
 
-    try:
-        imageDigest = image_record["imageDigest"]
+    imageDigest = image_record["imageDigest"]
 
-        dockerfile_mode = image_record.get("dockerfile_mode", "")
+    dockerfile_mode = image_record.get("dockerfile_mode", "")
 
-        image_detail = image_record["image_detail"][0]
-        pullstring = (
-            image_detail["registry"]
-            + "/"
-            + image_detail["repo"]
-            + "@"
-            + image_detail["imageDigest"]
+    image_details = image_record.get("image_detail", [])
+    if not image_details or not isinstance(image_details, list):
+        raise Exception(
+            "Tag details for image digest %s missing. Cannot pull image for analysis"
         )
-        fulltag = (
-            image_detail["registry"]
-            + "/"
-            + image_detail["repo"]
-            + ":"
-            + image_detail["tag"]
-        )
-        imageId = image_detail["imageId"]
-        if image_detail["dockerfile"]:
-            dockerfile_contents = str(
-                base64.decodebytes(image_detail["dockerfile"].encode("utf-8")), "utf-8"
+
+    for image_detail in image_details:
+        try:
+            # image_detail = image_record["image_detail"][0]
+            pullstring = (
+                image_detail["registry"]
+                + "/"
+                + image_detail["repo"]
+                + "@"
+                + image_detail["imageDigest"]
             )
-        else:
-            dockerfile_contents = None
+            fulltag = (
+                image_detail["registry"]
+                + "/"
+                + image_detail["repo"]
+                + ":"
+                + image_detail["tag"]
+            )
+            imageId = image_detail["imageId"]
+            if image_detail["dockerfile"]:
+                dockerfile_contents = str(
+                    base64.decodebytes(image_detail["dockerfile"].encode("utf-8")),
+                    "utf-8",
+                )
+            else:
+                dockerfile_contents = None
 
-        staging_dirs = make_staging_dirs(tmprootdir, use_cache_dir=use_cache_dir)
-        unpackdir = staging_dirs["unpackdir"]
+            staging_dirs = make_staging_dirs(tmprootdir, use_cache_dir=use_cache_dir)
+            unpackdir = staging_dirs["unpackdir"]
 
-        if image_source == "docker-archive":
-            rc = anchore_engine.clients.skopeo_wrapper.copy_image_from_docker_archive(
-                image_source_meta, staging_dirs["copydir"]
+            if image_source == "docker-archive":
+                rc = anchore_engine.clients.skopeo_wrapper.copy_image_from_docker_archive(
+                    image_source_meta, staging_dirs["copydir"]
+                )
+
+                manifest = get_manifest_from_staging(staging_dirs)
+
+            manifest_data = json.loads(manifest)
+
+            if image_source != "docker-archive":
+                rc = retrying_pull_image(
+                    staging_dirs,
+                    pullstring,
+                    registry_creds=registry_creds,
+                    manifest=manifest,
+                    parent_manifest=parent_manifest,
+                )
+
+            if manifest_data["schemaVersion"] == 1:
+                (
+                    docker_history,
+                    layers,
+                    dockerfile_contents,
+                    dockerfile_mode,
+                    imageArch,
+                ) = get_image_metadata_v1(
+                    staging_dirs,
+                    manifest_data,
+                    dockerfile_contents=dockerfile_contents,
+                )
+            elif manifest_data["schemaVersion"] == 2:
+                (
+                    docker_history,
+                    layers,
+                    dockerfile_contents,
+                    dockerfile_mode,
+                    imageArch,
+                ) = get_image_metadata_v2(
+                    staging_dirs,
+                    imageId,
+                    manifest_data,
+                    dockerfile_contents=dockerfile_contents,
+                )
+            else:
+                raise ManifestSchemaVersionError(
+                    schema_version=manifest_data["schemaVersion"],
+                    pull_string=pullstring,
+                    tag=fulltag,
+                )
+
+            familytree = layers
+
+            timer = time.time()
+            imageSize = unpack(staging_dirs, layers)
+            logger.debug(
+                "timing: total unpack time: {} - {}".format(
+                    pullstring, time.time() - timer
+                )
             )
 
-            manifest = get_manifest_from_staging(staging_dirs)
+            familytree = layers
 
-        manifest_data = json.loads(manifest)
-
-        if image_source != "docker-archive":
-            rc = retrying_pull_image(
+            timer = time.time()
+            analyzer_report = run_anchore_analyzers(
                 staging_dirs,
-                pullstring,
-                registry_creds=registry_creds,
-                manifest=manifest,
-                parent_manifest=parent_manifest,
-            )
-
-        if manifest_data["schemaVersion"] == 1:
-            (
-                docker_history,
-                layers,
-                dockerfile_contents,
-                dockerfile_mode,
-                imageArch,
-            ) = get_image_metadata_v1(
-                staging_dirs,
-                manifest_data,
-                dockerfile_contents=dockerfile_contents,
-            )
-        elif manifest_data["schemaVersion"] == 2:
-            (
-                docker_history,
-                layers,
-                dockerfile_contents,
-                dockerfile_mode,
-                imageArch,
-            ) = get_image_metadata_v2(
-                staging_dirs,
+                imageDigest,
                 imageId,
-                manifest_data,
-                dockerfile_contents=dockerfile_contents,
+                localconfig,
+                owned_package_filtering_enabled,
             )
-        else:
-            raise ManifestSchemaVersionError(
-                schema_version=manifest_data["schemaVersion"],
+
+            logger.debug(
+                "timing: total analyzer time: {} - {}".format(
+                    pullstring, time.time() - timer
+                )
+            )
+
+            image_report = generate_image_export(
+                imageId,
+                analyzer_report,
+                imageSize,
+                fulltag,
+                docker_history,
+                dockerfile_mode,
+                dockerfile_contents,
+                layers,
+                familytree,
+                imageArch,
+                pullstring,
+                analyzer_manifest,
+            )
+
+            return image_report, manifest
+        except Exception as err:
+            analysis_error = err
+            logger.warn(
+                "failed to analyze image %s, may retry analyzing the image with another tag",
+                pullstring,
+            )
+        finally:
+            if staging_dirs:
+                delete_staging_dirs(staging_dirs)
+    else:
+        # looped through all tags and failed analysis for every single one of them or the list of tags is empty
+        if analysis_error:
+            raise AnalysisError(
+                cause=analysis_error,
                 pull_string=pullstring,
                 tag=fulltag,
+                msg="failed to download, unpack, analyze, and generate image export",
             )
-
-        familytree = layers
-
-        timer = time.time()
-        imageSize = unpack(staging_dirs, layers)
-        logger.debug(
-            "timing: total unpack time: {} - {}".format(pullstring, time.time() - timer)
-        )
-
-        familytree = layers
-
-        timer = time.time()
-        analyzer_report = run_anchore_analyzers(
-            staging_dirs,
-            imageDigest,
-            imageId,
-            localconfig,
-            owned_package_filtering_enabled,
-        )
-
-        logger.debug(
-            "timing: total analyzer time: {} - {}".format(
-                pullstring, time.time() - timer
-            )
-        )
-
-        image_report = generate_image_export(
-            imageId,
-            analyzer_report,
-            imageSize,
-            fulltag,
-            docker_history,
-            dockerfile_mode,
-            dockerfile_contents,
-            layers,
-            familytree,
-            imageArch,
-            pullstring,
-            analyzer_manifest,
-        )
-    except Exception as err:
-        raise AnalysisError(
-            cause=err,
-            pull_string=pullstring,
-            tag=fulltag,
-            msg="failed to download, unpack, analyze, and generate image export",
-        )
-    finally:
-        if staging_dirs:
-            delete_staging_dirs(staging_dirs)
-
-    # if not imageDigest or not imageId or not manifest or not image_report:
-    if not image_report:
-        raise Exception("failed to analyze")
-
-    return image_report, manifest
+        else:
+            raise Exception("failed to analyze")
 
 
 class AnalysisError(AnchoreException):


### PR DESCRIPTION
This PR addresses the issue of failing analysis for an image that has multiple tag references. If one of the tags in accessible, the analysis for that specific tag fails as expected. However analysis of a different tag that is accessible may also fail. This happens because 
1. the tag reference is not maintained in the analysis request
2. analyzers simply try the 1st tag in the list of tags to pull the image

For instance image x was analyzed with tag y first followed by tag z. After deleting tag y from the registry, force analyzing tag y fails as expected. Force analyzing tag z also fails as the analyzers attempt to pull the image with tag y 

Solution: analyzers should iterate through the list of all available tags until they can successfully pull the image and analyze it