### PR TITLE
Ci lint fixup

### DIFF
--- a/scripts/ci/lint
+++ b/scripts/ci/lint
@@ -14,3 +14,11 @@ print_colorized INFO "Linting Anchore Engine code."; echo
 pylint -s n --disable=all --enable=C0325,C0410,C0411,C0412,C0413,C0414,W0611,R0401,W0404,W0406,W0410 anchore_engine
 
 print_colorized INFO "Finished linting Anchore Engine code."; echo
+
+print_colorized INFO "Linting Anchore Engine tests."; echo
+
+# This is specifically enabling checks because the output is too large to
+# fix in one go. As cleanups are done, more checks can be enabled
+pylint -s n --disable=all --enable=C0325,C0410,C0411,C0412,C0413,C0414,W0611,R0401,W0404,W0406,W0410 tests
+
+print_colorized INFO "Finished linting Anchore Engine tests."; echo

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -3,7 +3,9 @@ import time
 import uuid
 from distutils.version import LooseVersion
 
-from . import *
+import requests
+
+from tests.functional import get_engine_version
 
 # Functional tests for user management flows for the api
 anchore_user = os.environ["ANCHORE_CLI_USER"]

--- a/tests/functional/test_systemstatus.py
+++ b/tests/functional/test_systemstatus.py
@@ -1,7 +1,9 @@
 import os
 from distutils.version import LooseVersion
 
-from . import *
+import requests
+
+from tests.functional import get_engine_version
 
 # Functional tests for system status as a basic connectivity/anchore-engine up test
 anchore_user = os.environ["ANCHORE_CLI_USER"]

--- a/tests/integration/db/test_FixedArtifact_fix_observed_at.py
+++ b/tests/integration/db/test_FixedArtifact_fix_observed_at.py
@@ -207,6 +207,6 @@ def test_FixedArtifact_fix_observed_at_behavior(anchore_db):
 
     except Exception as err:
         logger.error("FAIL: exception - {}".format(err))
-        raise (err)
+        raise err
     finally:
         tearDown()

--- a/tests/unit/anchore_engine/subsys/events/test_util.py
+++ b/tests/unit/anchore_engine/subsys/events/test_util.py
@@ -1,11 +1,10 @@
 import pytest
 
 from anchore_engine.subsys.events.util import (
-    fulltag_from_detail,
     analysis_complete_notification_factory,
+    fulltag_from_detail,
 )
-from anchore_engine.subsys.taskstate import complete_state, base_state
-
+from anchore_engine.subsys.taskstate import base_state, complete_state
 
 ACCOUNT = "test"
 IMAGE_DIGEST = "sha256:e4ca2ed0202e76be184e75fb26d14bf974193579039d5573fb2348664deef76e"


### PR DESCRIPTION
I forgot to make sure that the pylint CI job was running on the tests directory when working on the import sorting update (https://github.com/anchore/anchore-engine/pull/1147). This PR enables pylint to run on the tests directory as well. This will prevent us from regressing in terms of code cleanup on import sorting, etc. I've also fixed the remaining linter warnings that are generated as a result of this change, which are primarily around an `import *` in the functional tests.

