### PR TITLE
Update docker entrypoint with exact cert path

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,18 +1,16 @@
 #!/usr/bin/env bash
 
-SITE_PKG_DIR=${SITE_PKG_DIR:="$(python3 -c 'import site; print(site.getsitepackages())')"}
-
 if [[ "${SET_HOSTID_TO_HOSTNAME}" == "true" ]]; then
     echo "Setting ANCHORE_HOST_ID to ${HOSTNAME}"
     export ANCHORE_HOST_ID=${HOSTNAME}
 fi
 
 # check if /home/anchore/certs/ exists & has files in it
-if [[ -d "/home/anchore/certs" ]] && [[ ! -z "$(ls -A /home/anchore/certs)" ]]; then
+if [[ -d "/home/anchore/certs" ]] && [[ -n "$(ls -A /home/anchore/certs)" ]]; then
     mkdir -p /home/anchore/certs_override/python
     mkdir -p /home/anchore/certs_override/os
     ### for python
-    cp $SITE_PKG_DIR/certifi/cacert.pem /home/anchore/certs_override/python/cacert.pem
+    cp "$(python3 -m certifi)" /home/anchore/certs_override/python/cacert.pem
     for file in /home/anchore/certs/*; do
         if grep -q 'BEGIN CERTIFICATE' "${file}"; then
             cat "${file}" >> /home/anchore/certs_override/python/cacert.pem


### PR DESCRIPTION
The previous fix to this file dynamically found the Python version, but assumed the rest of the path to the certificate.
This patch uses the `python3 -m certifi` command which returns the exact path of the certifi cacert.pem file.  This will
be resilient through Python version changes.

Co-Authored-By: James Petersen <jpetersenames@gmail.com>
Co-Authored-By: Vijay Pillai <vijay.pillai@anchore.com>

Signed-off-by: Ryan Brady <ryan.brady@anchore.com>

<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**:


**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #:

**Special notes**:


