### PR TITLE
Update docker entrypoint with certifi path and set

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 if [[ "${SET_HOSTID_TO_HOSTNAME}" == "true" ]]; then
     echo "Setting ANCHORE_HOST_ID to ${HOSTNAME}"
     export ANCHORE_HOST_ID=${HOSTNAME}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,7 +8,7 @@ if [[ "${SET_HOSTID_TO_HOSTNAME}" == "true" ]]; then
 fi
 
 # check if /home/anchore/certs/ exists & has files in it
-if [[ -d "/home/anchore/certs" ]] && [[ ! -z "$(ls -A /home/anchore/certs)" ]]; then
+if [[ -d "/home/anchore/certs" ]] && [[ -n "$(ls -A /home/anchore/certs)" ]]; then
     mkdir -p /home/anchore/certs_override/python
     mkdir -p /home/anchore/certs_override/os
     ### for python

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-SITE_PKG_DIR=${SITE_PKG_DIR:="$(python3 -c 'import site; print(site.getsitepackages())')"}
-
 if [[ "${SET_HOSTID_TO_HOSTNAME}" == "true" ]]; then
     echo "Setting ANCHORE_HOST_ID to ${HOSTNAME}"
     export ANCHORE_HOST_ID=${HOSTNAME}
@@ -12,7 +10,7 @@ if [[ -d "/home/anchore/certs" ]] && [[ ! -z "$(ls -A /home/anchore/certs)" ]]; 
     mkdir -p /home/anchore/certs_override/python
     mkdir -p /home/anchore/certs_override/os
     ### for python
-    cp $SITE_PKG_DIR/certifi/cacert.pem /home/anchore/certs_override/python/cacert.pem
+    cp "$(python3 -m certifi)" /home/anchore/certs_override/python/cacert.pem
     for file in /home/anchore/certs/*; do
         if grep -q 'BEGIN CERTIFICATE' "${file}"; then
             cat "${file}" >> /home/anchore/certs_override/python/cacert.pem


### PR DESCRIPTION
<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**:

# Proposed enhancement

Use the `python3 -m certifi` command which returns the path of the certifi cacert.pem file. This means the script doesn't need to be changed whenever the python version for the container is changed.

Also updated line 13 with [SC2236](https://github.com/koalaman/shellcheck/wiki/SC2236) change to remove double negative.

Use `set` inside the entrypoint so it hard fails whenever there are errors.



**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #:

**Special notes**:


##### To test

```sh
mkdir -p /tmp/certs
openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -keyout /tmp/certs/anchore.key -out /tmp/certs/anchore.crt
# fill out all info with junk, fields don't matter for test

make build
docker run -v /tmp/certs/:/home/anchore/certs/ anchore-engine:dev cat /home/anchore/certs_override/python/cacert.pem
```
