### PR TITLE
Automate upgrading Anchore tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,11 +48,11 @@ RUN set -ex && \
 
 RUN set -ex && \
     echo "installing Syft" && \
-    curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /build_output/deps $SYFT_VERSION
+    curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /build_output/deps "$SYFT_VERSION"
 
 RUN set -ex && \
     echo "installing Grype" && \
-    curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /build_output/deps $GRYPE_VERSION
+    curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /build_output/deps "$GRYPE_VERSION"
 
 # stage RPM dependency binaries
 RUN yum install -y https://download-ib01.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ ENV LANG=en_US.UTF-8 LC_ALL=C.UTF-8
 
 ENV GOPATH=/go
 ENV SKOPEO_VERSION=v1.2.1
+ENV SYFT_VERSION=v0.19.1
+ENV GRYPE_VERSION=v0.13.0
 
 COPY . /buildsource
 WORKDIR /buildsource
@@ -46,11 +48,11 @@ RUN set -ex && \
 
 RUN set -ex && \
     echo "installing Syft" && \
-    curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /build_output/deps v0.19.1
+    curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /build_output/deps $SYFT_VERSION
 
 RUN set -ex && \
     echo "installing Grype" && \
-    curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /build_output/deps v0.13.0
+    curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /build_output/deps $GRYPE_VERSION
 
 # stage RPM dependency binaries
 RUN yum install -y https://download-ib01.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \

--- a/Makefile
+++ b/Makefile
@@ -251,15 +251,15 @@ endif
 
 SYFT_LATEST_VERSION = $(shell curl "https://api.github.com/repos/anchore/syft/releases/latest" 2>/dev/null | jq -r '.tag_name')
 # Regex note: double-dollarsign for Makefile escaping; % instead of / for Sed to match anchore/syft
-latest-syft: jq-installed
+upgrade-syft: jq-installed ## Upgrade Syft to the latest release
 	# Setting Syft to ${SYFT_LATEST_VERSION}
 	$(SEDI) 's%^(.+anchore/syft.+)v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$$%\1${SYFT_LATEST_VERSION}%' Dockerfile
 
 GRYPE_LATEST_VERSION = $(shell curl "https://api.github.com/repos/anchore/grype/releases/latest" 2>/dev/null | jq -r '.tag_name')
 # Regex note: double-dollarsign for Makefile escaping; % instead of / for Sed to match anchore/syft
-latest-grype: jq-installed
+upgrade-grype: jq-installed ## Upgrade Grype to the latest release
 	# Setting Grype to ${GRYPE_LATEST_VERSION}
 	$(SEDI) 's%^(.+anchore/grype.+)v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$$%\1${GRYPE_LATEST_VERSION}%' Dockerfile
 
 # TODO: Intent is to create a weekly/daily/continuous GitHub Action that runs the following and auto-opens a PR
-latest-anchore-tools: latest-syft latest-grype
+upgrade-anchore-tools: upgrade-syft upgrade-grype ## Upgrade Syft and Grype to the latest release

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ GIT_TAG := $(shell echo $${CIRCLE_TAG:=null})
 .PHONY: push-dev push-nightly push-rc push-prod push-rebuild push-redhat
 .PHONY: compose-up compose-down cluster-up cluster-down
 .PHONY: setup-test-infra venv printvars help
-.PHONY: latest-syft
+.PHONY: upgrade-syft upgrade-grype upgrade-anchore-tools jq-installed
 
 ci: lint build test ## Run full CI pipeline, locally
 

--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,8 @@ help:
 
 jq-installed:
 ifeq ($(OS),Darwin)
-	# Skipping installation of jq for local dev on Mac
+	# Skipping installation of jq for local dev on Mac.
+	# You can install via 'brew install jq' the following command if needed.
 else
 	which jq ; if [ $$? -eq 1 ] ; then sudo apt-get install -y jq ; fi
 endif

--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ ifeq ($(OS),Darwin)
 	# Skipping installation of jq for local dev on Mac.
 	# You can install via 'brew install jq' the following command if needed.
 else
-	which jq ; if [ $$? -eq 1 ] ; then sudo apt-get install -y jq ; fi
+	if ! which jq ; then sudo apt-get install -y jq ; fi
 endif
 
 # BSD and GNU cross-platfrom sed -i ''

--- a/Makefile
+++ b/Makefile
@@ -250,16 +250,14 @@ endif
 #######################
 
 SYFT_LATEST_VERSION = $(shell curl "https://api.github.com/repos/anchore/syft/releases/latest" 2>/dev/null | jq -r '.tag_name')
-# Regex note: double-dollarsign for Makefile escaping; % instead of / for Sed to match anchore/syft
 upgrade-syft: jq-installed ## Upgrade Syft to the latest release
 	# Setting Syft to ${SYFT_LATEST_VERSION}
-	$(SEDI) 's%^(.+anchore/syft.+)v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$$%\1${SYFT_LATEST_VERSION}%' Dockerfile
+	$(SEDI) 's/^(ENV SYFT_VERSION=).+$$/\1${SYFT_LATEST_VERSION}/' Dockerfile
 
 GRYPE_LATEST_VERSION = $(shell curl "https://api.github.com/repos/anchore/grype/releases/latest" 2>/dev/null | jq -r '.tag_name')
-# Regex note: double-dollarsign for Makefile escaping; % instead of / for Sed to match anchore/syft
 upgrade-grype: jq-installed ## Upgrade Grype to the latest release
 	# Setting Grype to ${GRYPE_LATEST_VERSION}
-	$(SEDI) 's%^(.+anchore/grype.+)v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$$%\1${GRYPE_LATEST_VERSION}%' Dockerfile
+	$(SEDI) 's/^(ENV GRYPE_VERSION=).+$$/\1${GRYPE_LATEST_VERSION}/' Dockerfile
 
 # TODO: Intent is to create a weekly/daily/continuous GitHub Action that runs the following and auto-opens a PR
 upgrade-anchore-tools: upgrade-syft upgrade-grype ## Upgrade Syft and Grype to the latest release


### PR DESCRIPTION
**What this PR does / why we need it**:
I would like to see us move toward always having the latest versions of Syft and Grype in Engine. Manually updating the Dockerfile is a minimal step (see https://github.com/anchore/anchore-engine/pull/1169), but I'd like to automate this so that we can get early warning when a Syft or Grype upgrade breaks our automated tests.

This PR adds a Makefile script for updating the Dockerfile with the following outline:
1. `curl` latest release data of Syft & Grype from GitHub
2. Get version via `jq` (install if necessary in CI)
3. Modify `Dockerfile` via `sed`

The full script can be executed with `make latest-anchore-tools`.

I tested from both the Mac command line and within a `circleci/python:3.9` Docker container to ensure that it works with both GNU and BSD versions of `sed`.

A follow-up PR is intended that defines a GitHub Action to auto-open a PR when this script finds a newer version of Syft or Grype. The CircleCI checks will show if tests fail based on the upgrade, so this will have value even if the PRs are not merged rapidly.