### PR TITLE
Support for FeedOutOfDateTrigger in VulnerabilitiesGate for Grype provider 

### DIFF
--- a/anchore_engine/common/models/schemas.py
+++ b/anchore_engine/common/models/schemas.py
@@ -8,7 +8,7 @@ from typing import Dict, Optional
 import marshmallow
 from marshmallow import Schema, fields, post_load
 
-from anchore_engine.utils import datetime_to_rfc3339, rfc3339str_to_datetime
+from anchore_engine.util.time import datetime_to_rfc3339, rfc3339str_to_datetime
 
 # For other modules to import from this one instead of having to know/use marshmallow directly
 ValidationError = marshmallow.ValidationError

--- a/anchore_engine/db/db_archived_images.py
+++ b/anchore_engine/db/db_archived_images.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session, lazyload
 
 from anchore_engine.db import ArchivedImage, ArchivedImageDocker
 from anchore_engine.subsys import logger
-from anchore_engine.utils import epoch_to_rfc3339
+from anchore_engine.util.time import epoch_to_rfc3339
 
 
 def summarize(session: Session):

--- a/anchore_engine/db/entities/catalog.py
+++ b/anchore_engine/db/entities/catalog.py
@@ -21,7 +21,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import relationship
 
-from anchore_engine.utils import datetime_to_rfc3339
+from anchore_engine.util.time import datetime_to_rfc3339
 
 from .common import (
     Base,

--- a/anchore_engine/plugins/authorization/client.py
+++ b/anchore_engine/plugins/authorization/client.py
@@ -6,7 +6,7 @@ from urllib import parse as urlparse
 import requests
 
 from anchore_engine.subsys import logger
-from anchore_engine.utils import datetime_to_rfc3339
+from anchore_engine.util.time import datetime_to_rfc3339
 
 
 class BasicApiClient(object):

--- a/anchore_engine/services/apiext/api/controllers/accounts.py
+++ b/anchore_engine/services/apiext/api/controllers/accounts.py
@@ -40,7 +40,7 @@ from anchore_engine.db.db_accounts import (
 )
 from anchore_engine.subsys import logger
 from anchore_engine.subsys.identities import manager_factory
-from anchore_engine.utils import datetime_to_rfc3339
+from anchore_engine.util.time import datetime_to_rfc3339
 
 authorizer = get_authorizer()
 

--- a/anchore_engine/services/apiext/api/controllers/images.py
+++ b/anchore_engine/services/apiext/api/controllers/images.py
@@ -11,6 +11,7 @@ import anchore_engine.common
 import anchore_engine.common.images
 import anchore_engine.configuration.localconfig
 import anchore_engine.subsys.metrics
+import anchore_engine.util.time
 from anchore_engine import utils
 from anchore_engine.apis import exceptions as api_exceptions
 from anchore_engine.apis.authorization import (
@@ -1089,7 +1090,7 @@ def analyze_image(
                 ts = img_source.get("creation_timestamp_override")
                 if ts:
                     try:
-                        ts = utils.rfc3339str_to_epoch(ts)
+                        ts = anchore_engine.util.time.rfc3339str_to_epoch(ts)
                     except Exception as err:
                         raise api_exceptions.InvalidDateFormat(
                             "source.creation_timestamp_override", ts

--- a/anchore_engine/services/catalog/api/controllers/archives.py
+++ b/anchore_engine/services/catalog/api/controllers/archives.py
@@ -27,7 +27,7 @@ from anchore_engine.services.catalog.archiver import (
 )
 from anchore_engine.subsys import logger
 from anchore_engine.subsys.metrics import flask_metrics
-from anchore_engine.utils import epoch_to_rfc3339
+from anchore_engine.util.time import epoch_to_rfc3339
 
 authorizer = get_authorizer()
 

--- a/anchore_engine/services/catalog/api/controllers/imports.py
+++ b/anchore_engine/services/catalog/api/controllers/imports.py
@@ -15,7 +15,8 @@ from anchore_engine.db.entities.catalog import (
 )
 from anchore_engine.subsys import logger
 from anchore_engine.subsys.object_store import manager
-from anchore_engine.utils import datetime_to_rfc3339, ensure_str
+from anchore_engine.util.time import datetime_to_rfc3339
+from anchore_engine.utils import ensure_str
 
 authorizer = get_authorizer()
 

--- a/anchore_engine/services/catalog/archiver.py
+++ b/anchore_engine/services/catalog/archiver.py
@@ -43,7 +43,8 @@ from anchore_engine.subsys.events import (
     ImageRestoreFailed,
 )
 from anchore_engine.subsys.object_store.manager import ObjectStorageManager
-from anchore_engine.utils import datetime_to_rfc3339, ensure_bytes, ensure_str
+from anchore_engine.util.time import datetime_to_rfc3339
+from anchore_engine.utils import ensure_bytes, ensure_str
 
 DRY_RUN_ENV_VAR = "ANCHORE_ANALYSIS_ARCHIVE_DRYRUN_ENABLED"
 DRY_RUN_MODE = os.getenv(DRY_RUN_ENV_VAR, "false").lower() == "true"

--- a/anchore_engine/services/policy_engine/engine/feeds/client.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/client.py
@@ -24,12 +24,12 @@ from anchore_engine.services.policy_engine.engine.feeds import (
 )
 from anchore_engine.services.policy_engine.engine.feeds.config import SyncConfig
 from anchore_engine.subsys import logger
+from anchore_engine.util.time import rfc3339str_to_datetime
 from anchore_engine.utils import (
     AnchoreException,
     CommandException,
     ensure_bytes,
     ensure_str,
-    rfc3339str_to_datetime,
 )
 
 FEED_DATA_ITEMS_PATH = "data.item"

--- a/anchore_engine/services/policy_engine/engine/feeds/feeds.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/feeds.py
@@ -76,7 +76,7 @@ from anchore_engine.services.policy_engine.engine.vulnerabilities import (
     process_updated_vulnerability,
 )
 from anchore_engine.subsys import logger
-from anchore_engine.utils import rfc3339str_to_datetime
+from anchore_engine.util.time import rfc3339str_to_datetime
 
 IMAGE_VULNERABILITIES_QUEUE = "image_vulnerabilities"
 MESSAGE_BATCH_SIZE = 10

--- a/anchore_engine/services/policy_engine/engine/policy/bundles.py
+++ b/anchore_engine/services/policy_engine/engine/policy/bundles.py
@@ -32,7 +32,7 @@ from anchore_engine.services.policy_engine.engine.policy.gates import *
 from anchore_engine.subsys import logger
 from anchore_engine.util.docker import parse_dockerimage_string
 from anchore_engine.util.matcher import is_match, regexify
-from anchore_engine.utils import rfc3339str_to_datetime
+from anchore_engine.util.time import rfc3339str_to_datetime
 
 
 class VersionedEntityMixin(object):

--- a/anchore_engine/services/policy_engine/engine/policy/gate_util_provider.py
+++ b/anchore_engine/services/policy_engine/engine/policy/gate_util_provider.py
@@ -1,0 +1,105 @@
+import datetime
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from anchore_engine.db import DistroNamespace, session_scope
+from anchore_engine.db.db_grype_db_feed_metadata import (
+    NoActiveGrypeDB,
+    get_most_recent_active_grypedb,
+)
+from anchore_engine.services.policy_engine.engine.feeds.db import (
+    get_feed_group_detached,
+)
+from anchore_engine.services.policy_engine.engine.feeds.feeds import feed_registry
+from anchore_engine.subsys import logger
+
+
+class GateUtilProvider(ABC):
+    """
+    This abstraction is intended to encapsulate all gate-specific logic for the VulnerabilityProviders.
+
+    Note:
+    Any logic that is used in the gates that changes by provider should go here until further refactor is deemed
+    necessary. It is possible that you may need information from the VulnerabilityProvider in order to add a specific
+    function. If that is the case, avoid importing the VulnerabilityProvider and pass the information that you need in
+    via the constructor call for this class in VulnerabilityProvider.get_gate_util_provider()
+    """
+
+    @abstractmethod
+    def oldest_namespace_feed_sync(
+        self, namespace: DistroNamespace
+    ) -> datetime.datetime:
+        """
+        Get the oldest feed sync time for the namespace.
+
+        :param namespace: the namespace for which to fetch the oldest sync time
+        :type namespace: DistroNamespace
+        :return: the time of the oldest feed sync
+        :rtype: datetime.datetime
+        """
+        ...
+
+
+class LegacyGateUtilProvider(GateUtilProvider):
+    """
+    Gate-specific logic for the LegacyProvider.
+    """
+
+    def oldest_namespace_feed_sync(
+        self, namespace: DistroNamespace
+    ) -> datetime.datetime:
+        """
+        Get the oldest feed sync time for the namespace.
+
+        :param namespace: the namespace for which to fetch the oldest sync time
+        :type namespace: DistroNamespace
+        :return: the time of the oldest feed sync
+        :rtype: datetime.datetime
+        """
+        oldest_update = None
+        if not namespace:
+            raise ValueError(
+                "must have valid DistroNamespace object for namespace parameter"
+            )
+
+        for namespace_name in namespace.like_namespace_names:
+            # Check feed names
+            for feed in feed_registry.registered_vulnerability_feed_names():
+                # First match, assume only one matches for the namespace
+                group = get_feed_group_detached(feed, namespace_name)
+                if group:
+                    # No records yet, but we have the feed, so may just not have any data yet
+                    oldest_update = group.last_sync
+                    logger.debug(
+                        "Found date for oldest update in feed %s group %s date = %s",
+                        feed,
+                        group.name,
+                        oldest_update,
+                    )
+                    break
+        return oldest_update
+
+
+class GrypeGateUtilProvider(GateUtilProvider):
+    """
+    Gate-specific logic for the GrypeProvider.
+    """
+
+    def oldest_namespace_feed_sync(
+        self, namespace: DistroNamespace
+    ) -> Optional[datetime.datetime]:
+        """
+        Get the namespace values using the grype feed metadata, returns the value for the whole grypdb, since it is synced
+        atomically, and the returned date is the build date of the db, not the sync date
+
+        :param namespace: the namespace for which to fetch the oldest sync time
+        :type namespace: DistroNamespace
+        :return: the time of the oldest feed sync
+        :rtype: datetime.datetime
+        """
+        with session_scope() as session:
+            try:
+                grypedb = get_most_recent_active_grypedb(session)
+                return grypedb.built_at
+            except NoActiveGrypeDB:
+                return None

--- a/anchore_engine/services/policy_engine/engine/tasks.py
+++ b/anchore_engine/services/policy_engine/engine/tasks.py
@@ -241,7 +241,7 @@ class FeedsUpdateTask(IAsyncTask):
             updated_data_feeds = list()
             updated_data_feeds.extend(
                 DataFeeds.sync(
-                    sync_util_provider=GrypeProvider().get_sync_utils(
+                    sync_util_provider=GrypeProvider().get_sync_util_provider(
                         self.sync_configs
                     ),
                     full_flush=self.full_flush,
@@ -251,7 +251,7 @@ class FeedsUpdateTask(IAsyncTask):
             )
             updated_data_feeds.extend(
                 DataFeeds.sync(
-                    sync_util_provider=LegacyProvider().get_sync_utils(
+                    sync_util_provider=LegacyProvider().get_sync_util_provider(
                         self.sync_configs
                     ),
                     full_flush=self.full_flush,

--- a/anchore_engine/services/policy_engine/engine/vulns/providers.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/providers.py
@@ -60,18 +60,33 @@ from anchore_engine.services.policy_engine.engine.feeds.sync_utils import (
     LegacySyncUtilProvider,
     SyncUtilProvider,
 )
+from anchore_engine.services.policy_engine.engine.policy.gate_util_provider import (
+    GateUtilProvider,
+    GrypeGateUtilProvider,
+    LegacyGateUtilProvider,
+)
 from anchore_engine.services.policy_engine.engine.vulnerabilities import (
     get_imageId_to_record,
     merge_nvd_metadata,
     merge_nvd_metadata_image_packages,
 )
+from anchore_engine.services.policy_engine.engine.vulns.dedup import (
+    get_image_vulnerabilities_deduper,
+    transfer_vulnerability_timestamps,
+)
+from anchore_engine.services.policy_engine.engine.vulns.mappers import (
+    EngineGrypeDBMapper,
+)
+from anchore_engine.services.policy_engine.engine.vulns.scanners import (
+    GrypeScanner,
+    LegacyScanner,
+)
+from anchore_engine.services.policy_engine.engine.vulns.stores import (
+    ImageVulnerabilitiesStore,
+    Status,
+)
 from anchore_engine.subsys import logger, metrics
 from anchore_engine.utils import timer
-
-from .dedup import get_image_vulnerabilities_deduper, transfer_vulnerability_timestamps
-from .mappers import EngineGrypeDBMapper
-from .scanners import GrypeScanner, LegacyScanner
-from .stores import ImageVulnerabilitiesStore, Status
 
 
 class InvalidFeed(Exception):
@@ -263,6 +278,13 @@ class VulnerabilitiesProvider(ABC):
     def delete_image_vulnerabilities(self, image: Image, db_session):
         """
         Delete image vulnerabilities maintained by the provider
+        """
+        ...
+
+    @abstractmethod
+    def get_gate_util_provider(self) -> GateUtilProvider:
+        """
+        Get a GateUtilProvider.
         """
         ...
 
@@ -1051,6 +1073,12 @@ class LegacyProvider(VulnerabilitiesProvider):
         for pkg_vuln in image.vulnerabilities():
             db_session.delete(pkg_vuln)
 
+    def get_gate_util_provider(self) -> LegacyGateUtilProvider:
+        """
+        Get a GateUtilProvider.
+        """
+        return LegacyGateUtilProvider()
+
 
 class GrypeProvider(VulnerabilitiesProvider):
     __scanner__ = GrypeScanner
@@ -1549,6 +1577,12 @@ class GrypeProvider(VulnerabilitiesProvider):
     def delete_image_vulnerabilities(self, image: Image, db_session):
         ImageVulnerabilitiesStore(image_object=image).delete_all(session=db_session)
 
+    def get_gate_util_provider(self) -> GrypeGateUtilProvider:
+        """
+        Get a GateUtilProvider.
+        """
+        return GrypeGateUtilProvider()
+
 
 # Override this map for associating different provider classes
 PROVIDER_CLASSES = [LegacyProvider, GrypeProvider]
@@ -1576,7 +1610,7 @@ def set_provider():
     logger.info("Initialized vulnerabilities provider: %s", PROVIDER.get_config_name())
 
 
-def get_vulnerabilities_provider():
+def get_vulnerabilities_provider() -> VulnerabilitiesProvider:
     if not PROVIDER:
         set_provider()
 

--- a/anchore_engine/services/policy_engine/engine/vulns/providers.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/providers.py
@@ -153,7 +153,9 @@ class VulnerabilitiesProvider(ABC):
         ...
 
     @abstractmethod
-    def get_sync_utils(self, sync_configs: Dict[str, SyncConfig]) -> SyncUtilProvider:
+    def get_sync_util_provider(
+        self, sync_configs: Dict[str, SyncConfig]
+    ) -> SyncUtilProvider:
         """
         Get a SyncUtilProvider.
         """
@@ -930,7 +932,7 @@ class LegacyProvider(VulnerabilitiesProvider):
                 )
                 return "http://<valid endpoint not found>"
 
-    def get_sync_utils(
+    def get_sync_util_provider(
         self, sync_configs: Dict[str, SyncConfig]
     ) -> LegacySyncUtilProvider:
         """
@@ -1498,7 +1500,7 @@ class GrypeProvider(VulnerabilitiesProvider):
 
         return filtered_dicts
 
-    def get_sync_utils(
+    def get_sync_util_provider(
         self, sync_configs: Dict[str, SyncConfig]
     ) -> GrypeDBSyncUtilProvider:
         """

--- a/anchore_engine/util/time.py
+++ b/anchore_engine/util/time.py
@@ -4,8 +4,6 @@ Time utility functions
 import calendar
 import datetime
 
-# TODO: move other time utils into this module from utils.py, and other util* locations
-
 SECONDS_PER_MINUTE = 60
 SECONDS_PER_HOUR = SECONDS_PER_MINUTE * 60
 SECONDS_PER_DAY = SECONDS_PER_HOUR * 24
@@ -17,3 +15,65 @@ def datetime_to_epoch(date_time: datetime.datetime) -> int:
 
 def days_to_seconds(days: int) -> int:
     return days * SECONDS_PER_DAY
+
+
+rfc3339_date_fmt = "%Y-%m-%dT%H:%M:%SZ"
+rfc3339_date_input_fmts = [
+    "%Y-%m-%dT%H:%M:%SZ",
+    "%Y-%m-%dT%H:%M:%S.%fZ",
+    "%Y-%m-%dT%H:%M:%S:%fZ",
+]
+
+
+def rfc3339str_to_epoch(rfc3339_str):
+    return int(rfc3339str_to_datetime(rfc3339_str).timestamp())
+
+
+def rfc3339str_to_datetime(rfc3339_str):
+    """
+    Convert the rfc3339 formatted string (UTC only) to a datatime object with tzinfo explicitly set to utc. Raises an exception if the parsing fails.
+
+    :param rfc3339_str:
+    :return:
+    """
+
+    ret = None
+    for fmt in rfc3339_date_input_fmts:
+        try:
+            ret = datetime.datetime.strptime(rfc3339_str, fmt)
+            # Force this since the formats we support are all utc formats, to support non-utc
+            if ret.tzinfo is None:
+                ret = ret.replace(tzinfo=datetime.timezone.utc)
+            continue
+        except:
+            pass
+
+    if ret is None:
+        raise Exception(
+            "could not convert input value ({}) into datetime using formats in {}".format(
+                rfc3339_str, rfc3339_date_input_fmts
+            )
+        )
+
+    return ret
+
+
+def datetime_to_rfc3339(dt_obj):
+    """
+    Simple utility function. Expects a UTC input, does no tz conversion
+
+    :param dt_obj:
+    :return:
+    """
+
+    return dt_obj.strftime(rfc3339_date_fmt)
+
+
+def epoch_to_rfc3339(epoch_int):
+    """
+    Convert an epoch int value to a RFC3339 datetime string
+
+    :param epoch_int:
+    :return:
+    """
+    return datetime_to_rfc3339(datetime.datetime.utcfromtimestamp(epoch_int))

--- a/anchore_engine/util/time.py
+++ b/anchore_engine/util/time.py
@@ -25,11 +25,11 @@ rfc3339_date_input_fmts = [
 ]
 
 
-def rfc3339str_to_epoch(rfc3339_str):
+def rfc3339str_to_epoch(rfc3339_str: str) -> int:
     return int(rfc3339str_to_datetime(rfc3339_str).timestamp())
 
 
-def rfc3339str_to_datetime(rfc3339_str):
+def rfc3339str_to_datetime(rfc3339_str: str) -> datetime.datetime:
     """
     Convert the rfc3339 formatted string (UTC only) to a datatime object with tzinfo explicitly set to utc. Raises an exception if the parsing fails.
 
@@ -58,7 +58,7 @@ def rfc3339str_to_datetime(rfc3339_str):
     return ret
 
 
-def datetime_to_rfc3339(dt_obj):
+def datetime_to_rfc3339(dt_obj: datetime.datetime) -> str:
     """
     Simple utility function. Expects a UTC input, does no tz conversion
 
@@ -69,7 +69,7 @@ def datetime_to_rfc3339(dt_obj):
     return dt_obj.strftime(rfc3339_date_fmt)
 
 
-def epoch_to_rfc3339(epoch_int):
+def epoch_to_rfc3339(epoch_int: int) -> str:
     """
     Convert an epoch int value to a RFC3339 datetime string
 

--- a/anchore_engine/util/time.py
+++ b/anchore_engine/util/time.py
@@ -1,0 +1,19 @@
+"""
+Time utility functions
+"""
+import calendar
+import datetime
+
+# TODO: move other time utils into this module from utils.py, and other util* locations
+
+SECONDS_PER_MINUTE = 60
+SECONDS_PER_HOUR = SECONDS_PER_MINUTE * 60
+SECONDS_PER_DAY = SECONDS_PER_HOUR * 24
+
+
+def datetime_to_epoch(date_time: datetime.datetime) -> int:
+    return calendar.timegm(date_time.timetuple())
+
+
+def days_to_seconds(days: int) -> int:
+    return days * SECONDS_PER_DAY

--- a/anchore_engine/utils.py
+++ b/anchore_engine/utils.py
@@ -1,7 +1,6 @@
 """
 Generic utilities
 """
-import datetime
 import decimal
 import os
 import platform
@@ -380,68 +379,6 @@ def ensure_bytes(obj):
 
 def ensure_str(obj):
     return str(obj, "utf-8") if type(obj) != str else obj
-
-
-rfc3339_date_fmt = "%Y-%m-%dT%H:%M:%SZ"
-rfc3339_date_input_fmts = [
-    "%Y-%m-%dT%H:%M:%SZ",
-    "%Y-%m-%dT%H:%M:%S.%fZ",
-    "%Y-%m-%dT%H:%M:%S:%fZ",
-]
-
-
-def rfc3339str_to_epoch(rfc3339_str):
-    return int(rfc3339str_to_datetime(rfc3339_str).timestamp())
-
-
-def rfc3339str_to_datetime(rfc3339_str):
-    """
-    Convert the rfc3339 formatted string (UTC only) to a datatime object with tzinfo explicitly set to utc. Raises an exception if the parsing fails.
-
-    :param rfc3339_str:
-    :return:
-    """
-
-    ret = None
-    for fmt in rfc3339_date_input_fmts:
-        try:
-            ret = datetime.datetime.strptime(rfc3339_str, fmt)
-            # Force this since the formats we support are all utc formats, to support non-utc
-            if ret.tzinfo is None:
-                ret = ret.replace(tzinfo=datetime.timezone.utc)
-            continue
-        except:
-            pass
-
-    if ret is None:
-        raise Exception(
-            "could not convert input value ({}) into datetime using formats in {}".format(
-                rfc3339_str, rfc3339_date_input_fmts
-            )
-        )
-
-    return ret
-
-
-def datetime_to_rfc3339(dt_obj):
-    """
-    Simple utility function. Expects a UTC input, does no tz conversion
-
-    :param dt_obj:
-    :return:
-    """
-
-    return dt_obj.strftime(rfc3339_date_fmt)
-
-
-def epoch_to_rfc3339(epoch_int):
-    """
-    Convert an epoch int value to a RFC3339 datetime string
-
-    :param epoch_int:
-    :return:
-    """
-    return datetime_to_rfc3339(datetime.datetime.utcfromtimestamp(epoch_int))
 
 
 def convert_bytes_size(size_str):

--- a/tests/integration/services/policy_engine/conftest.py
+++ b/tests/integration/services/policy_engine/conftest.py
@@ -110,7 +110,7 @@ def run_legacy_sync(
         vulnerabilities_config=config,
         default_provider_sync_config=default_sync_config,
     )
-    sync_utils = vulnerabilities_provider.get_sync_utils(sync_configs)
+    sync_utils = vulnerabilities_provider.get_sync_util_provider(sync_configs)
     sync_utils.get_client = MagicMock(return_value=test_env.feed_client)
     return DataFeeds.sync(sync_util_provider=sync_utils)
 

--- a/tests/unit/anchore_engine/services/catalog/test_catalog_impl.py
+++ b/tests/unit/anchore_engine/services/catalog/test_catalog_impl.py
@@ -6,7 +6,7 @@ import pytest
 
 from anchore_engine.services.catalog import catalog_impl
 from anchore_engine.services.catalog.catalog_impl import is_new_tag
-from anchore_engine.utils import datetime_to_rfc3339
+from anchore_engine.util.time import datetime_to_rfc3339
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/anchore_engine/services/policy_engine/api/test_models.py
+++ b/tests/unit/anchore_engine/services/policy_engine/api/test_models.py
@@ -14,7 +14,7 @@ from anchore_engine.common.models.policy_engine import (
     LegacyTableReport,
     LegacyVulnerabilityReport,
 )
-from anchore_engine.utils import datetime_to_rfc3339
+from anchore_engine.util.time import datetime_to_rfc3339
 
 
 def test_feeds():

--- a/tests/unit/anchore_engine/services/policy_engine/engine/policy/conftest.py
+++ b/tests/unit/anchore_engine/services/policy_engine/engine/policy/conftest.py
@@ -1,0 +1,81 @@
+from contextlib import contextmanager
+from unittest.mock import Mock
+
+import pytest
+
+from anchore_engine.db.db_grype_db_feed_metadata import NoActiveGrypeDB
+from anchore_engine.db.entities.policy_engine import DistroMapping
+from anchore_engine.services.policy_engine import init_feed_registry
+
+DISTRO_MAPPINGS = [
+    DistroMapping(from_distro="alpine", to_distro="alpine", flavor="ALPINE"),
+    DistroMapping(from_distro="busybox", to_distro="busybox", flavor="BUSYB"),
+    DistroMapping(from_distro="centos", to_distro="rhel", flavor="RHEL"),
+    DistroMapping(from_distro="debian", to_distro="debian", flavor="DEB"),
+    DistroMapping(from_distro="fedora", to_distro="rhel", flavor="RHEL"),
+    DistroMapping(from_distro="ol", to_distro="ol", flavor="RHEL"),
+    DistroMapping(from_distro="rhel", to_distro="rhel", flavor="RHEL"),
+    DistroMapping(from_distro="ubuntu", to_distro="ubuntu", flavor="DEB"),
+    DistroMapping(from_distro="amzn", to_distro="amzn", flavor="RHEL"),
+    DistroMapping(from_distro="redhat", to_distro="rhel", flavor="RHEL"),
+]
+MAPPINGS_MAP = {mapping.from_distro: mapping for mapping in DISTRO_MAPPINGS}
+
+
+@pytest.fixture
+def mock_distromapping_query(monkeypatch):
+    # mocks DB query in anchore_engine.db.entities.policy_engine.DistroMapping.distros_for
+    mock_db = Mock()
+    mock_db.query().get = lambda x: MAPPINGS_MAP.get(x, None)
+    monkeypatch.setattr(
+        "anchore_engine.db.entities.policy_engine.get_thread_scoped_session",
+        lambda: mock_db,
+    )
+
+
+@pytest.fixture
+def mock_gate_util_provider_oldest_namespace_feed_sync(
+    monkeypatch, mock_distromapping_query
+):
+    """
+    Mocks for anchore_engine.services.policy_engine.engine.policy.gate_util_provider.GateUtilProvider.oldest_namespace_feed_sync
+    """
+    # required for FeedOutOfDateTrigger.evaluate
+    # setup for anchore_engine.services.policy_engine.engine.feeds.feeds.FeedRegistry.registered_vulnerability_feed_names
+    init_feed_registry()
+
+    @contextmanager
+    def mock_session_scope():
+        """
+        Mock context manager for anchore_engine.db.session_scope.
+        """
+        yield None
+
+    def raise_no_active_grypedb(session):
+        raise NoActiveGrypeDB
+
+    def _setup_mocks(feed_group_metadata=None, grype_db_feed_metadata=None):
+        # required for FeedOutOfDateTrigger.evaluate
+        # mocks anchore_engine.services.policy_engine.engine.feeds.db.get_feed_group_detached
+        monkeypatch.setattr(
+            "anchore_engine.services.policy_engine.engine.policy.gate_util_provider.session_scope",
+            mock_session_scope,
+        )
+        if grype_db_feed_metadata:
+            monkeypatch.setattr(
+                "anchore_engine.services.policy_engine.engine.policy.gate_util_provider.get_most_recent_active_grypedb",
+                lambda x: grype_db_feed_metadata,
+            )
+        else:
+            monkeypatch.setattr(
+                "anchore_engine.services.policy_engine.engine.policy.gate_util_provider.get_most_recent_active_grypedb",
+                raise_no_active_grypedb,
+            )
+        # mocks anchore_engine.db.db_grype_db_feed_metadata.get_most_recent_active_grypedb
+        # if feed_group_metadata:
+        monkeypatch.setattr(
+            "anchore_engine.services.policy_engine.engine.policy.gate_util_provider.get_feed_group_detached",
+            lambda x, y: feed_group_metadata,
+        )
+
+    return _setup_mocks

--- a/tests/unit/anchore_engine/services/policy_engine/engine/policy/test_bundles.py
+++ b/tests/unit/anchore_engine/services/policy_engine/engine/policy/test_bundles.py
@@ -6,7 +6,7 @@ from anchore_engine.db.entities.common import anchore_now_datetime
 from anchore_engine.services.policy_engine.engine.policy.bundles import (
     ExecutableWhitelistItem,
 )
-from anchore_engine.utils import datetime_to_rfc3339
+from anchore_engine.util.time import datetime_to_rfc3339
 
 
 class TestExecutableWhitelistItem:

--- a/tests/unit/anchore_engine/services/policy_engine/engine/policy/test_gate_util_provider.py
+++ b/tests/unit/anchore_engine/services/policy_engine/engine/policy/test_gate_util_provider.py
@@ -1,0 +1,77 @@
+import datetime
+from typing import Optional, Type
+
+import pytest
+
+from anchore_engine.db.entities.policy_engine import (
+    DistroNamespace,
+    FeedGroupMetadata,
+    GrypeDBFeedMetadata,
+)
+from anchore_engine.services.policy_engine.engine.policy.gate_util_provider import (
+    GateUtilProvider,
+    GrypeGateUtilProvider,
+    LegacyGateUtilProvider,
+)
+
+
+class TestGateUtilProvider:
+    sync_time = datetime.datetime.utcnow()
+
+    @pytest.mark.parametrize(
+        "gate_util_provider, feed_group_metadata, grype_db_feed_metadata, expected_oldest_update",
+        [
+            # Case, legacy provider, feed group exists
+            (
+                LegacyGateUtilProvider,
+                FeedGroupMetadata(
+                    last_sync=sync_time,
+                    name="test-feed-out-of-date",
+                ),
+                None,
+                sync_time,
+            ),
+            # Case, legacy provider, feed group does not exist
+            (
+                LegacyGateUtilProvider,
+                None,
+                None,
+                None,
+            ),
+            # Case, grype provider, active grype DB exists
+            (
+                GrypeGateUtilProvider,
+                None,
+                GrypeDBFeedMetadata(built_at=sync_time),
+                sync_time,
+            ),
+            # Case, grype provider, active grype DB does not exist
+            (
+                GrypeGateUtilProvider,
+                None,
+                None,
+                None,
+            ),
+        ],
+    )
+    def test_oldest_namespace_feed_sync(
+        self,
+        gate_util_provider: Type[GateUtilProvider],
+        feed_group_metadata: Optional[FeedGroupMetadata],
+        grype_db_feed_metadata: Optional[GrypeDBFeedMetadata],
+        expected_oldest_update: Optional[datetime.datetime],
+        mock_distromapping_query,
+        mock_gate_util_provider_oldest_namespace_feed_sync,
+    ):
+        ns = DistroNamespace(name="DEB", version="10", like_distro=None)
+        ns.like_namespace_names = ["debian:10"]
+
+        mock_gate_util_provider_oldest_namespace_feed_sync(
+            feed_group_metadata=feed_group_metadata,
+            grype_db_feed_metadata=grype_db_feed_metadata,
+        )
+
+        provider = gate_util_provider()
+        oldest_update = provider.oldest_namespace_feed_sync(ns)
+
+        assert oldest_update == expected_oldest_update

--- a/tests/unit/anchore_engine/util/test_rfc3339.py
+++ b/tests/unit/anchore_engine/util/test_rfc3339.py
@@ -1,6 +1,6 @@
 import datetime
 
-import anchore_engine.utils as utils
+import anchore_engine.util.time
 
 rfc3339_examples = [
     (
@@ -70,26 +70,26 @@ def test_rfc3339():
     # parsing/validation and conversion symmetry
     for rfc_str, assert_targets in rfc3339_examples:
         print("testing input string: {}".format(rfc_str))
-        rc = utils.rfc3339str_to_epoch(rfc_str)
+        rc = anchore_engine.util.time.rfc3339str_to_epoch(rfc_str)
         print("\trfc3339_to_epoch: {}".format(rc))
         assert rc == assert_targets["epoch"]
         print("\tepoch assertion passed")
 
-        rc = utils.rfc3339str_to_datetime(rfc_str)
+        rc = anchore_engine.util.time.rfc3339str_to_datetime(rfc_str)
         print("\trfc3339_to_datetime: {}".format(rc))
         assert rc == assert_targets["dt"]
         print("\tdatetime assertion passed")
 
     for epoch, assert_targets in epoch_examples:
         print("testing input epoch: {}".format(epoch))
-        rc = utils.epoch_to_rfc3339(epoch)
+        rc = anchore_engine.util.time.epoch_to_rfc3339(epoch)
         print("\tepoch_to_rfc3339: {}".format(rc))
         assert rc == assert_targets["rfc3339"]
         print("\tdatetime assertion passed")
 
     for dt, assert_targets in dt_examples:
         print("testing input datetime: {}".format(dt))
-        rc = utils.datetime_to_rfc3339(dt)
+        rc = anchore_engine.util.time.datetime_to_rfc3339(dt)
         print("\tdatetime_to_rfc3339: {}".format(rc))
         assert rc == assert_targets["rfc3339"]
         print("\tdatetime assertion passed")


### PR DESCRIPTION
<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**DO NOT BE ALARMED** by large diff - pr includes a simple refactor of time utilities, and should be reviewed commit-by-commit

**What this PR does / why we need it**:
This PR adds support to the FeedOutOfDateTrigger in VulnerabilitiesGate for the Grype provider. This change will enable the trigger to fire when the grype feed data is stale.

* add support for Grype provider in VulnerabilitiesGate.FeedOutOfDateTrigger
* creates a new module and class for gate specific provider logic called `gate_util_provider.GateUtilProvider`. Hopefully, this will enhance readability and testability while avoiding overloading the VulnerabilityProvider interface.
* update VulnerabilitiesGate unit tests to include grype in test for FeedOutOfDateTrigger
* Adds unit test for  GateUtilProvider.oldest_namespace_feed_sync
* refactor time methods from anchore_engine.utils to new module, anchore_engine.util.time
* add type hints to refactored time methods
* renames VulnerabilityProvider.get_sync_utils to VulnerabilityProvider.get_sync_util_provider

**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*:
fixes #1180

**Special notes**:
This PR is based off of the following fork/branch written by @zhill: https://github.com/zhill/anchore-engine/commit/966365a9dee4fdbe68f135f641d72fe86d8619e9

Note: I could have added tests for the rest of the VulnerabilitesGate for grype, but that seemed out of scope for this ticket.
