### PR TITLE
Updated ignore revs hash for isort ordering to correct hash

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,4 +1,4 @@
 # Nov. 2020 commit that mass-reformatted using Black
 5bbbe6b9744f2fb806198ae5d6f0cfe3b367fd9d
 # Jul. 2021 commit that mass-reformatted using isort
-80820a86360f149fb8a71466c1c10bfc84c0513a
+76940420e42f6230f3bafc371e7d18036192d4e2


### PR DESCRIPTION
The hash to ignore the isort ordering in `.git-blame-ignore-revs` was incorrect, likely due to a rebase. This was causing some issues with git blame: 
```
fatal: invalid object name: 80820a86360f149fb8a71466c1c10bfc84c0513a
```

This PR just updates the hash to resolve the issue