### PR TITLE
Rename "grypedb" feed to be called "vulnerabilities".

### DIFF
--- a/anchore_engine/services/policy_engine/__init__.py
+++ b/anchore_engine/services/policy_engine/__init__.py
@@ -34,6 +34,9 @@ from anchore_engine.services.policy_engine.engine.feeds.feeds import (
     VulnerabilityFeed,
     feed_registry,
 )
+from anchore_engine.services.policy_engine.engine.vulns.providers import (
+    get_vulnerabilities_provider,
+)
 from anchore_engine.subsys import logger
 
 # from anchore_engine.subsys.logger import enable_bootstrap_logging
@@ -98,7 +101,11 @@ def process_preflight():
     :return:
     """
 
-    preflight_check_functions = [init_db_content, init_feed_registry]
+    preflight_check_functions = [
+        init_db_content,
+        init_feed_registry,
+        init_display_mapper,
+    ]
 
     for fn in preflight_check_functions:
         try:
@@ -177,6 +184,11 @@ def init_feed_registry():
     ]:
         logger.info("Registering feed handler {}".format(cls_tuple[0].__feed_name__))
         feed_registry.register(cls_tuple[0], is_vulnerability_feed=cls_tuple[1])
+
+
+def init_display_mapper():
+    provider = get_vulnerabilities_provider()
+    provider.init_display_mapper()
 
 
 def do_feed_sync(msg):

--- a/anchore_engine/services/policy_engine/api/controllers/feeds.py
+++ b/anchore_engine/services/policy_engine/api/controllers/feeds.py
@@ -169,9 +169,7 @@ def toggle_group_enabled(feed, group, enabled):
     internal_feed_name = provider.display_mapper.get_internal_name(feed)
     if isinstance(provider, GrypeProvider) and internal_feed_name == GRYPE_DB_FEED_NAME:
         raise HTTPNotImplementedError(
-            message="Enabling and disabling groups for {} feed with the grype vulnerability provider enabled is not currently supported.".format(
-                feed
-            ),
+            message=f"Enabling and disabling groups for {feed} feed with the grype vulnerability provider enabled is not currently supported.",
             detail={},
         )
     session = db.get_session()
@@ -203,9 +201,7 @@ def delete_feed(feed):
     internal_feed_name = provider.display_mapper.get_internal_name(feed)
     if isinstance(provider, GrypeProvider) and internal_feed_name == GRYPE_DB_FEED_NAME:
         raise HTTPNotImplementedError(
-            message="Deleting the {} feed with the grype vulnerability provider enabled is not yet supported.".format(
-                feed
-            ),
+            message=f"Deleting the {feed} feed with the grype vulnerability provider enabled is not yet supported.",
             detail={},
         )
     session = db.get_session()
@@ -245,9 +241,7 @@ def delete_group(feed, group):
     internal_feed_name = provider.display_mapper.get_internal_name(feed)
     if isinstance(provider, GrypeProvider) and internal_feed_name == GRYPE_DB_FEED_NAME:
         raise HTTPNotImplementedError(
-            message="Deleting individual groups for the {} feed with the grype vulnerability provider enabled is not yet supported.".format(
-                feed
-            ),
+            message=f"Deleting individual groups for the {feed} feed with the grype vulnerability provider enabled is not yet supported.",
             detail={},
         )
     session = db.get_session()
@@ -273,7 +267,7 @@ def delete_group(feed, group):
         feed_group_metadata = sync.DataFeeds.delete_feed_group(
             feed_name=internal_feed_name, group_name=group
         )
-        log.info("Flushed group records {}".format(feed_group_metadata))
+        log.info("Flushed group records %r", feed_group_metadata)
         if feed_group_metadata:
             return jsonify(_marshall_group_response(feed_group_metadata).to_json()), 200
         else:
@@ -283,5 +277,5 @@ def delete_group(feed, group):
     except AnchoreApiError:
         raise
     except Exception as exc:
-        log.error("Could not flush feed group {}/{}".format(feed, group))
+        log.error("Could not flush feed group %s/%s", feed, group)
         return jsonify(make_response_error(exc, in_httpcode=500)), 500

--- a/anchore_engine/services/policy_engine/engine/vulns/feed_display_mapper.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/feed_display_mapper.py
@@ -1,0 +1,14 @@
+class FeedDisplayMapper:
+    def __init__(self):
+        self._display_to_internal_map = {}
+        self._internal_to_display_map = {}
+
+    def register(self, internal_name: str, display_name: str) -> None:
+        self._display_to_internal_map[display_name] = internal_name
+        self._internal_to_display_map[internal_name] = display_name
+
+    def get_display_name(self, internal_name: str) -> str:
+        return self._internal_to_display_map[internal_name]
+
+    def get_internal_name(self, display_name: str) -> str:
+        return self._display_to_internal_map[display_name]

--- a/tests/functional/services/policy_engine/feeds_data_tests/test_feed_sync.py
+++ b/tests/functional/services/policy_engine/feeds_data_tests/test_feed_sync.py
@@ -4,6 +4,7 @@ import pytest
 
 import tests.functional.services.policy_engine.utils.api as policy_engine_api
 from anchore_engine.services.policy_engine.engine.feeds.feeds import GrypeDBFeed
+from anchore_engine.services.policy_engine.engine.vulns.providers import GrypeProvider
 from tests.functional.services.policy_engine.conftest import (
     is_legacy_provider,
     read_expected_content,
@@ -45,7 +46,9 @@ def build_feed_sync_test_matrix():
             for group in groups:
                 params.append((feed["name"], group["name"], 10))
     else:
-        feed = GrypeDBFeed.__feed_name__
+        provider = GrypeProvider()
+        provider.init_display_mapper()
+        feed = provider.display_mapper.get_display_name(GrypeDBFeed.__feed_name__)
         expected_groups = read_expected_content(
             __file__, "expected_grype_feed_and_group_counts"
         )


### PR DESCRIPTION
<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**:
This PR adds feed display mappers to policy engine VulnerabilityProvider. These mappers will allow us to rename feeds at ingress(API) and egress(API response). I've purposefully tried to constrain my changes as much as possible to the API layer of the code. If you are wondering why I did not follow the approach of changing the name from the origin of the data throughout the system, the answer is because the policy engine expects parity between configuration, feed source, and the processing of the feed by name (i.e. the name of the feed should match throughout the system). This model is no longer suitable for the future plans for the policy engine, and further work is required to divorce the policy engine from that model. If you are curious about the exploratory work that I did to attempt to implement this change as described above, you can find that here: https://github.com/anchore/anchore-engine/pull/1188

**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #:

**Special notes**:


