### PR TITLE
Updates for running engine on fips-enabled hosts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,8 @@ FROM registry.access.redhat.com/ubi8/ubi:8.4 as anchore-engine-builder
 ARG CLI_COMMIT
 
 ENV LANG=en_US.UTF-8 LC_ALL=C.UTF-8
-
 ENV GOPATH=/go
-ENV SKOPEO_VERSION=v1.2.1
+
 
 COPY . /buildsource
 WORKDIR /buildsource
@@ -19,7 +18,10 @@ RUN set -ex && \
     echo "installing OS dependencies" && \
     yum update -y && \
     yum module disable -y python36 && yum module enable -y python38 && \
-    yum install -y gcc make python38 git python38-wheel python38-devel go
+    yum install -y gcc make python38 git python38-wheel python38-devel python38-psycopg2 go  && \
+    pip3 install pip==21.0.1 && \
+    yum install -y https://download-ib01.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
+    yum install -y --downloadonly --downloaddir=/build_output/build_deps/ dpkg clamav clamav-update
 
 # create anchore binaries
 RUN set -ex && \
@@ -37,24 +39,12 @@ RUN set -ex && \
     mkdir -p /go
 
 RUN set -ex && \
-    echo "installing Skopeo" && \
-    git clone --branch "$SKOPEO_VERSION" https://github.com/containers/skopeo ${GOPATH}/src/github.com/containers/skopeo && \
-    cd ${GOPATH}/src/github.com/containers/skopeo && \
-    make install-binary DISABLE_CGO=1 && \
-    cp /usr/bin/skopeo /build_output/deps/ && \
-    cp default-policy.json /build_output/configs/skopeo-policy.json
-
-RUN set -ex && \
     echo "installing Syft" && \
     curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /build_output/deps v0.19.1
 
 RUN set -ex && \
     echo "installing Grype" && \
     curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /build_output/deps v0.13.0
-
-# stage RPM dependency binaries
-RUN yum install -y https://download-ib01.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
-    yum install -y --downloadonly --downloaddir=/build_output/deps/ dpkg clamav clamav-update
 
 RUN tar -z -c -v -C /build_output -f /anchore-buildblob.tgz .
 
@@ -150,7 +140,8 @@ EXPOSE ${ANCHORE_SERVICE_PORT}
 RUN set -ex && \
     yum update -y && \
     yum module disable -y python36 && yum module enable -y python38 && \
-    yum install -y python38 python38-wheel procps psmisc
+    yum install -y python38 python38-wheel procps psmisc python38-psycopg2 skopeo && \
+    pip3 install pip==21.0.1
 
 # Setup container default configs and directories
 
@@ -181,19 +172,16 @@ RUN set -ex && \
 RUN set -ex && \
     python3 -m venv /anchore-cli && \
     source /anchore-cli/bin/activate && \
-    pip3 install --no-index --find-links=./ /build_output/cli_wheels/*.whl && \
+    pip3 install --no-index --find-links=/build_output/cli_wheels/ anchorecli && \
     deactivate
 
 # Perform the anchore-engine build and install
 
 RUN set -ex && \
-    pip3 install --no-index --find-links=./ /build_output/wheels/*.whl && \
-    cp /build_output/deps/skopeo /usr/bin/skopeo && \
+    pip3 install --no-index --find-links=/build_output/wheels/ anchore-engine && \
     cp /build_output/deps/syft /usr/bin/syft && \
     cp /build_output/deps/grype /usr/bin/grype && \
-    mkdir -p /etc/containers && \
-    cp /build_output/configs/skopeo-policy.json /etc/containers/policy.json && \
-    yum install -y /build_output/deps/*.rpm && \
+    #yum install -y /build_output/deps/*.rpm && \
     rm -rf /build_output /root/.cache
 
 # Container runtime instructions

--- a/anchore_engine/clients/services/catalog.py
+++ b/anchore_engine/clients/services/catalog.py
@@ -305,10 +305,12 @@ class CatalogClient(InternalServiceClient):
         self, subscription_key=None, subscription_type=None, subscription_id=None
     ):
         if subscription_key and subscription_type:
-            subscription_id = hashlib.md5(
+            subscription_id = hashlib.new(
+                "md5",
                 "+".join(
                     [self.request_namespace, subscription_key, subscription_type]
-                ).encode("utf8")
+                ).encode("utf8"),
+                usedforsecurity=False,
             ).hexdigest()
 
         return self.call_api(
@@ -325,22 +327,26 @@ class CatalogClient(InternalServiceClient):
         if subscription_id:
             pass
         elif subscription_key and subscription_type:
-            subscription_id = hashlib.md5(
+            subscription_id = hashlib.new(
+                "md5",
                 "+".join(
                     [self.request_namespace, subscription_key, subscription_type]
-                ).encode("utf8")
+                ).encode("utf8"),
+                usedforsecurity=False,
             ).hexdigest()
         elif subscriptiondata.get("subscription_key", None) and subscriptiondata.get(
             "subscription_type", None
         ):
-            subscription_id = hashlib.md5(
+            subscription_id = hashlib.new(
+                "md5",
                 "+".join(
                     [
                         self.request_namespace,
                         subscriptiondata.get("subscription_key"),
                         subscriptiondata.get("subscription_type"),
                     ]
-                ).encode("utf8")
+                ).encode("utf8"),
+                usedforsecurity=False,
             ).hexdigest()
         else:
             raise Exception(

--- a/anchore_engine/db/db_queue.py
+++ b/anchore_engine/db/db_queue.py
@@ -54,7 +54,9 @@ def create(
 
 def generate_dataId(inobj):
     datajson = json.dumps(inobj)
-    dataId = hashlib.md5(datajson.encode("utf-8")).hexdigest()
+    dataId = hashlib.new(
+        "md5", datajson.encode("utf-8"), usedforsecurity=False
+    ).hexdigest()
     return dataId, datajson
 
 

--- a/anchore_engine/db/db_subscriptions.py
+++ b/anchore_engine/db/db_subscriptions.py
@@ -6,8 +6,10 @@ from anchore_engine.db import Subscription
 
 
 def _compute_subscription_id(userId, subscription_key, subscription_type):
-    return hashlib.md5(
-        "+".join([userId, subscription_key, subscription_type]).encode("utf-8")
+    return hashlib.new(
+        "md5",
+        "+".join([userId, subscription_key, subscription_type]).encode("utf-8"),
+        usedforsecurity=False,
     ).hexdigest()
 
 

--- a/anchore_engine/db/entities/catalog.py
+++ b/anchore_engine/db/entities/catalog.py
@@ -768,7 +768,7 @@ class ImageImportOperation(Base, UtilMixin):
     contents = relationship("ImageImportContent", back_populates="operation")
 
     __table_args__ = (Index("ix_ae_image_imports_account", account), {})
-    
+
     def to_json(self):
         j = super().to_json()
         j["status"] = self.status.value

--- a/anchore_engine/db/entities/catalog.py
+++ b/anchore_engine/db/entities/catalog.py
@@ -758,7 +758,7 @@ class ImageImportOperation(Base, UtilMixin):
     __tablename__ = "image_imports"
 
     uuid = Column(String, primary_key=True, default=anchore_uuid)
-    account = Column(String, index=True)
+    account = Column(String)
     expires_at = Column(DateTime)
     status = Column(Enum(ImportState))
     created_at = Column(DateTime, default=anchore_now_datetime)
@@ -767,6 +767,8 @@ class ImageImportOperation(Base, UtilMixin):
     )
     contents = relationship("ImageImportContent", back_populates="operation")
 
+    __table_args__ = (Index("ix_ae_image_imports_account", account), {})
+    
     def to_json(self):
         j = super().to_json()
         j["status"] = self.status.value

--- a/anchore_engine/db/entities/identity.py
+++ b/anchore_engine/db/entities/identity.py
@@ -3,7 +3,7 @@ import time
 
 from authlib.integrations.sqla_oauth2.client_mixin import OAuth2ClientMixin
 from authlib.integrations.sqla_oauth2.tokens_mixins import TokenMixin
-from sqlalchemy import Boolean, Column, Enum, ForeignKey, Integer, String, Text
+from sqlalchemy import Boolean, Column, Enum, ForeignKey, Integer, String, Text, Index
 from sqlalchemy.orm import relationship
 
 from anchore_engine.db.entities.common import Base, UtilMixin, anchore_now, anchore_uuid
@@ -86,9 +86,7 @@ class AccountUser(Base, UtilMixin):
     source = Column(String)
     created_at = Column(Integer, default=anchore_now)
     last_updated = Column(Integer, default=anchore_now)
-    uuid = Column(
-        "uuid", String, unique=True, nullable=False, default=anchore_uuid
-    )
+    uuid = Column("uuid", String, unique=True, nullable=False, default=anchore_uuid)
 
     account = relationship(
         "Account", back_populates="users", lazy="joined", innerjoin=True
@@ -100,9 +98,11 @@ class AccountUser(Base, UtilMixin):
         cascade="all, delete-orphan",
     )
 
-    __table_args__ = (Index("ix_ae_account_users_account_name", account_name), Index("ix_ae_account_users_uuid", uuid))
+    __table_args__ = (
+        Index("ix_ae_account_users_account_name", account_name),
+        Index("ix_ae_account_users_uuid", uuid),
+    )
 
-    
     def to_dict(self):
         """
         Override the base imple to include credentials
@@ -167,8 +167,8 @@ class OAuth2Token(Base, UtilMixin, TokenMixin):
     issued_at = Column(Integer, nullable=False, default=lambda: int(time.time()))
     expires_in = Column(Integer, nullable=False, default=0)
 
-    __table_args__ = (Index("ix_ae_oauth2_tokens_refresh_token", refresh_token), {})    
-    
+    __table_args__ = (Index("ix_ae_oauth2_tokens_refresh_token", refresh_token), {})
+
     def get_scope(self):
         return self.scope
 

--- a/anchore_engine/db/entities/identity.py
+++ b/anchore_engine/db/entities/identity.py
@@ -79,7 +79,7 @@ class AccountUser(Base, UtilMixin):
     __tablename__ = "account_users"
 
     username = Column(String, primary_key=True)  # Enforce globally unique user names
-    account_name = Column(String, ForeignKey(Account.name), index=True)
+    account_name = Column(String, ForeignKey(Account.name))
     type = Column(
         Enum(UserTypes, name="user_types"), nullable=False, default=UserTypes.native
     )
@@ -87,7 +87,7 @@ class AccountUser(Base, UtilMixin):
     created_at = Column(Integer, default=anchore_now)
     last_updated = Column(Integer, default=anchore_now)
     uuid = Column(
-        "uuid", String, unique=True, nullable=False, default=anchore_uuid, index=True
+        "uuid", String, unique=True, nullable=False, default=anchore_uuid
     )
 
     account = relationship(
@@ -100,6 +100,9 @@ class AccountUser(Base, UtilMixin):
         cascade="all, delete-orphan",
     )
 
+    __table_args__ = (Index("ix_ae_account_users_account_name", account_name), Index("ix_ae_account_users_uuid", uuid))
+
+    
     def to_dict(self):
         """
         Override the base imple to include credentials
@@ -158,12 +161,14 @@ class OAuth2Token(Base, UtilMixin, TokenMixin):
     client_id = Column(String)
     token_type = Column(String)
     access_token = Column(String, unique=True, nullable=False)
-    refresh_token = Column(String, index=True)
+    refresh_token = Column(String)
     scope = Column(Text, default="")
     revoked = Column(Boolean, default=False)
     issued_at = Column(Integer, nullable=False, default=lambda: int(time.time()))
     expires_in = Column(Integer, nullable=False, default=0)
 
+    __table_args__ = (Index("ix_ae_oauth2_tokens_refresh_token", refresh_token), {})    
+    
     def get_scope(self):
         return self.scope
 

--- a/anchore_engine/db/entities/policy_engine.py
+++ b/anchore_engine/db/entities/policy_engine.py
@@ -151,7 +151,7 @@ class GrypeDBFeedMetadata(Base):
     __tablename__ = "grype_db_feed_metadata"
 
     archive_checksum = Column(String, primary_key=True)
-    db_checksum = Column(String, nullable=True, index=True)
+    db_checksum = Column(String, nullable=True)
     schema_version = Column(String, nullable=False)
     object_url = Column(String, nullable=False)
     active = Column(Boolean, nullable=False)
@@ -166,6 +166,7 @@ class GrypeDBFeedMetadata(Base):
     synced_at = Column(DateTime, nullable=True)
     groups = Column(JSONB, default=[])
 
+    __table_args__ = (Index("ix_ae_grype_db_feed_metadata_db_checksum", db_checksum), {})
 
 class GenericFeedDataRecord(Base):
     """
@@ -843,7 +844,6 @@ class NvdV2Metadata(Base):
             name="vulnerability_severities",
         ),
         nullable=False,
-        index=True,
     )
     description = Column(String, nullable=True)
     cvss_v2 = Column(JSON, nullable=True)
@@ -860,6 +860,8 @@ class NvdV2Metadata(Base):
         DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow
     )
 
+    __table_args__ = (Index("ix_ae_feed_data_nvdv2_vulnerabilities_severity", severity), {})
+    
     def __repr__(self):
         return "<{} name={}, created_at={}>".format(
             self.__class__, self.name, self.created_at
@@ -1083,7 +1085,6 @@ class VulnDBMetadata(Base):
             name="vulnerability_severities",
         ),
         nullable=False,
-        index=True,
     )
     title = Column(String, nullable=True)
     description = Column(String, nullable=True)
@@ -1105,6 +1106,8 @@ class VulnDBMetadata(Base):
         DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow
     )
 
+    __table_args__ = (Index("ix_ae_feed_data_vulndb_vulnerabilities_severity", severity), {})
+    
     def __repr__(self):
         return "<{} name={}, created_at={}>".format(
             self.__class__, self.name, self.created_at
@@ -3378,8 +3381,8 @@ class ImageVulnerabilitiesReport(Base, StorageInterface):
 
     account_id = Column(String, primary_key=True)
     image_digest = Column(String, primary_key=True)
-    report_key = Column(String, index=True)
-    generated_at = Column(DateTime, index=True)
+    report_key = Column(String)
+    generated_at = Column(DateTime)
     result = Column(JSONB)
     created_at = Column(DateTime, default=datetime.datetime.utcnow)
     last_modified = Column(
@@ -3387,6 +3390,8 @@ class ImageVulnerabilitiesReport(Base, StorageInterface):
         default=datetime.datetime.utcnow,
         onupdate=datetime.datetime.utcnow,
     )
+
+    __table_args__ = (Index("ix_ae_image_vulnerabilities_reports_report_key", report_key), Index("ix_ae_image_vulnerabilities_reports_generated_at", generated_at))
 
 
 class CachedPolicyEvaluation(Base, StorageInterface):

--- a/anchore_engine/db/entities/policy_engine.py
+++ b/anchore_engine/db/entities/policy_engine.py
@@ -166,7 +166,11 @@ class GrypeDBFeedMetadata(Base):
     synced_at = Column(DateTime, nullable=True)
     groups = Column(JSONB, default=[])
 
-    __table_args__ = (Index("ix_ae_grype_db_feed_metadata_db_checksum", db_checksum), {})
+    __table_args__ = (
+        Index("ix_ae_grype_db_feed_metadata_db_checksum", db_checksum),
+        {},
+    )
+
 
 class GenericFeedDataRecord(Base):
     """
@@ -860,8 +864,11 @@ class NvdV2Metadata(Base):
         DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow
     )
 
-    __table_args__ = (Index("ix_ae_feed_data_nvdv2_vulnerabilities_severity", severity), {})
-    
+    __table_args__ = (
+        Index("ix_ae_feed_data_nvdv2_vulnerabilities_severity", severity),
+        {},
+    )
+
     def __repr__(self):
         return "<{} name={}, created_at={}>".format(
             self.__class__, self.name, self.created_at
@@ -1106,8 +1113,11 @@ class VulnDBMetadata(Base):
         DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow
     )
 
-    __table_args__ = (Index("ix_ae_feed_data_vulndb_vulnerabilities_severity", severity), {})
-    
+    __table_args__ = (
+        Index("ix_ae_feed_data_vulndb_vulnerabilities_severity", severity),
+        {},
+    )
+
     def __repr__(self):
         return "<{} name={}, created_at={}>".format(
             self.__class__, self.name, self.created_at
@@ -3391,7 +3401,10 @@ class ImageVulnerabilitiesReport(Base, StorageInterface):
         onupdate=datetime.datetime.utcnow,
     )
 
-    __table_args__ = (Index("ix_ae_image_vulnerabilities_reports_report_key", report_key), Index("ix_ae_image_vulnerabilities_reports_generated_at", generated_at))
+    __table_args__ = (
+        Index("ix_ae_image_vulnerabilities_reports_report_key", report_key),
+        Index("ix_ae_image_vulnerabilities_reports_generated_at", generated_at),
+    )
 
 
 class CachedPolicyEvaluation(Base, StorageInterface):

--- a/anchore_engine/services/apiext/api/controllers/policies.py
+++ b/anchore_engine/services/apiext/api/controllers/policies.py
@@ -163,8 +163,10 @@ def add_policy(bundle):
         if "id" in jsondata and jsondata["id"]:
             policyId = jsondata["id"]
         else:
-            policyId = hashlib.md5(
-                str(userId + ":" + jsondata["name"]).encode("utf8")
+            policyId = hashlib.new(
+                "md5",
+                str(userId + ":" + jsondata["name"]).encode("utf8"),
+                usedforsecurity=False,
             ).hexdigest()
             jsondata["id"] = policyId
 

--- a/anchore_engine/services/catalog/catalog_impl.py
+++ b/anchore_engine/services/catalog/catalog_impl.py
@@ -1754,10 +1754,12 @@ def perform_policy_evaluation(
                 curr_evaluation_result["status"] = "fail"
 
         # set up the newest evaluation
-        evalId = hashlib.md5(
+        evalId = hashlib.new(
+            "md5",
             ":".join(
-                [policyId, userId, imageDigest, fulltag, str(curr_final_action)]
-            ).encode("utf8")
+                [policyId, userId, imageDigest, fulltag, str(curr_final_action)],
+            ).encode("utf8"),
+            usedforsecurity=False,
         ).hexdigest()
         curr_evaluation_record = anchore_engine.common.helpers.make_eval_record(
             userId,

--- a/anchore_engine/services/policy_engine/engine/policy/gate.py
+++ b/anchore_engine/services/policy_engine/engine/policy/gate.py
@@ -100,7 +100,8 @@ class TriggerMatch(object):
         # Compute a hash-based trigger_id for matching purposes (this is legacy from Anchore CLI)
         if not self.id:
             gate_id = self.trigger.gate_cls.__gate_name__
-            self.id = hashlib.md5(
+            self.id = hashlib.new(
+                "md5",
                 ensure_bytes(
                     "".join(
                         [
@@ -109,7 +110,8 @@ class TriggerMatch(object):
                             self.msg if self.msg else "",
                         ]
                     )
-                )
+                ),
+                usedforsecurity=False,
             ).hexdigest()
 
     def json(self):

--- a/anchore_engine/services/policy_engine/engine/policy/gates/malware.py
+++ b/anchore_engine/services/policy_engine/engine/policy/gates/malware.py
@@ -23,7 +23,13 @@ class ScanFindingsTrigger(BaseTrigger):
         :return:
         """
         return "{}+{}+{}".format(
-            scanner, signature, ensure_str(hashlib.md5(ensure_bytes(file)).hexdigest())
+            scanner,
+            signature,
+            ensure_str(
+                hashlib.new(
+                    "md5", ensure_bytes(file), usedforsecurity=False
+                ).hexdigest()
+            ),
         )
 
     def evaluate(self, image_obj, context):

--- a/anchore_engine/subsys/object_store/drivers/filesystem.py
+++ b/anchore_engine/subsys/object_store/drivers/filesystem.py
@@ -179,11 +179,15 @@ class FilesystemObjectStorageDriver(ObjectStorageDriver):
             raise err
 
     def _get_archive_filepath(self, userId, bucket, key):
-        filehash = hashlib.md5(key.encode("utf8")).hexdigest()
+        filehash = hashlib.new(
+            "md5", key.encode("utf8"), usedforsecurity=False
+        ).hexdigest()
         fkey = filehash[0:2]
         archive_path = os.path.join(
             self.data_volume,
-            hashlib.md5(userId.encode("utf8")).hexdigest(),
+            hashlib.new(
+                "md5", userId.encode("utf8"), usedforsecurity=False
+            ).hexdigest(),
             bucket,
             fkey,
         )

--- a/anchore_engine/subsys/object_store/manager.py
+++ b/anchore_engine/subsys/object_store/manager.py
@@ -184,7 +184,9 @@ class ObjectStorageManager(object):
             final_payload, is_compressed = self._do_compress(data)
 
             size = len(final_payload)
-            digest = hashlib.md5(final_payload).hexdigest()
+            digest = hashlib.new(
+                "md5", final_payload, usedforsecurity=False
+            ).hexdigest()
 
             url = self.primary_client.put(userId, bucket, archiveid, final_payload)
             with session_scope() as dbsession:
@@ -234,7 +236,9 @@ class ObjectStorageManager(object):
                 found_size = len(content)
 
                 if expected:
-                    found = hashlib.md5(content).hexdigest()
+                    found = hashlib.new(
+                        "md5", content, usedforsecurity=False
+                    ).hexdigest()
                 else:
                     found = None
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,3 +3,5 @@ Flask-Testing
 memory_profiler
 docker==4.3.1
 coverage==5.3.1
+# This is here to ensure that virtualenvs have this installed since our normal docker build installs it via an rpm for fips-support.
+psycopg2-binary==2.8.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ prettytable==0.7.2
 prometheus-client==0.7.1
 prometheus-flask-exporter==0.12.1
 psutil==5.6.7
-psycopg2-binary==2.9.1
 python-dateutil==2.8.1
 python-swiftclient==3.8.1
 pytz==2019.3

--- a/scripts/ci/Dockerfile.functional
+++ b/scripts/ci/Dockerfile.functional
@@ -5,9 +5,9 @@ USER root
 
 RUN set -ex && \
     echo "installing OS dependencies" && \
-    yum update -y && \
-    yum install -y gcc make git python38-wheel python38-devel
+    yum install -y gcc make git python38-wheel python38-devel python38-psycopg2
 
+# Install Docker-in-Docker into the image for testing
 ENV DOCKERVERSION=18.03.1-ce
 RUN curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKERVERSION}.tgz \
   && tar xzvf docker-${DOCKERVERSION}.tgz --strip 1 \

--- a/tests/unit/anchore_engine/services/policy_engine/engine/policy/gates/test_malware.py
+++ b/tests/unit/anchore_engine/services/policy_engine/engine/policy/gates/test_malware.py
@@ -102,7 +102,9 @@ def test_malware_gate_single_finding(
     assert scan_trigger.did_fire
     assert len(scan_trigger.fired) == 1
     assert scan_trigger.fired[0].id == "clamav+" + finding.get("signature") + "+" + str(
-        hashlib.md5(bytes(finding.get("path"), "utf-8")).hexdigest()
+        hashlib.new(
+            "md5", bytes(finding.get("path"), "utf-8"), usedforsecurity=False
+        ).hexdigest()
     )
 
 


### PR DESCRIPTION
Resolves #882 

Fixes md5 usage (non-crypto related) to be explicit that it is not used for security.

Updates Dockerfile (from @nurmi 's branch) to install skopeo and psycopg from CentOS sources that are compiled for FIPs compliance.

Updates all indexes created by SQLAlchemy to have explicit names that do not require SQLAlchemy's truncation mechanism for names, which uses md5 hashes.