### PR TITLE
Add instructions for auto/latest-anchore-tools branch

### DIFF
--- a/.github/workflows/upgrade-anchore-tools.yml
+++ b/.github/workflows/upgrade-anchore-tools.yml
@@ -29,3 +29,10 @@ jobs:
             - [Grype ${{ env.grype_v }}](https://github.com/anchore/grype/releases/tag/${{ env.grype_v }})
 
             This is an auto-generated pull request to the latest versions of Syft and Grype.
+
+            **Do not commit to this branch.**
+
+            - The GitHub Action will force-push over your commits the next time it runs.
+            - If the Syft/Grype upgrade is safe as-is (manual and automated tests pass), go ahead and approve + merge.
+            - If production or test code must be updated, do so in a separate branch.
+            - Run `make upgrade-anchore-tools` to apply the same change the GitHub Action is performing.


### PR DESCRIPTION
See the first auto-generated PR: https://github.com/anchore/anchore-engine/pull/1191

There have been several commits to the `auto/latest-anchore-tools` branch which have been overridden by the GitHub Action force-pushing to it.

This PR adds clarifying text to the PR auto-generated by the GitHub Action.