### PR TITLE
rename grype db feed in vulnerability report to 'vulnerabilities'

### DIFF
--- a/anchore_engine/services/policy_engine/engine/vulns/mappers.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/mappers.py
@@ -387,7 +387,7 @@ class VulnerabilityMapper:
                 description=vuln_dict.get("description"),
                 severity=vuln_dict.get("severity"),
                 link=vuln_dict.get("dataSource"),
-                feed="grypedb",
+                feed="vulnerabilities",
                 feed_group=vuln_dict.get("namespace"),
                 cvss=cvss_objs,
             ),

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/grype/sha256:406413437f26223183d133ccc7186f24c827729e1b21adc7330dd43fcdc030b3.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/grype/sha256:406413437f26223183d133ccc7186f24c827729e1b21adc7330dd43fcdc030b3.json
@@ -44,7 +44,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
       "severity": "Negligible",
@@ -96,7 +96,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
       "severity": "Negligible",
@@ -141,7 +141,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2011-3389",
       "severity": "Medium",
@@ -187,7 +187,7 @@
         }
       ],
       "description": "The mintToken function of a smart contract implementation for APP, an Ethereum token, has an integer overflow that allows the owner of the contract to set the balance of an arbitrary user to any value.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "nvd",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-13661",
       "severity": "High",
@@ -239,7 +239,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2017-7246",
       "severity": "Negligible",
@@ -284,7 +284,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2007-6755",
       "severity": "Negligible",
@@ -336,7 +336,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
       "severity": "Negligible",
@@ -388,7 +388,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2020-15719",
       "severity": "Negligible",
@@ -440,7 +440,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2019-20838",
       "severity": "Negligible",
@@ -492,7 +492,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2020-13529",
       "severity": "Negligible",
@@ -537,7 +537,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2005-2541",
       "severity": "Negligible",
@@ -582,7 +582,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
       "severity": "Negligible",
@@ -634,7 +634,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010025",
       "severity": "Negligible",
@@ -680,7 +680,7 @@
         }
       ],
       "description": "xmldom is a pure JavaScript W3C standard-based (XML DOM Level 2 Core) DOMParser and XMLSerializer module. xmldom versions 0.4.0 and older do not correctly preserve system identifiers, FPIs or namespaces when repeatedly parsing and serializing maliciously crafted documents. This may lead to unexpected syntactic changes during XML processing in some downstream applications. This is fixed in version 0.5.0. As a workaround downstream applications can validate the input and reject the maliciously crafted documents.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "nvd",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21366",
       "severity": "Medium",
@@ -732,7 +732,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2020-13529",
       "severity": "Negligible",
@@ -777,7 +777,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2008-4108",
       "severity": "Negligible",
@@ -829,7 +829,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2017-11164",
       "severity": "Negligible",
@@ -881,7 +881,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2019-9893",
       "severity": "Negligible",
@@ -933,7 +933,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2019-9192",
       "severity": "Negligible",
@@ -985,7 +985,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010023",
       "severity": "Negligible",
@@ -1031,7 +1031,7 @@
         }
       ],
       "description": "aio-libs aiohttp-session contains a Session Fixation vulnerability in load_session function for RedisStorage (see: https://github.com/aio-libs/aiohttp-session/blob/master/aiohttp_session/redis_storage.py#L42) that can result in Session Hijacking. This attack appear to be exploitable via Any method that allows setting session cookies (?session=<>, or meta tags or script tags with Set-Cookie).",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "nvd",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-1000519",
       "severity": "Medium",
@@ -1076,7 +1076,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2010-4052",
       "severity": "Negligible",
@@ -1128,7 +1128,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2017-7245",
       "severity": "Negligible",
@@ -1180,7 +1180,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2020-13529",
       "severity": "Negligible",
@@ -1225,7 +1225,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2010-4756",
       "severity": "Negligible",
@@ -1270,7 +1270,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
       "severity": "Negligible",
@@ -1322,7 +1322,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2019-9923",
       "severity": "Negligible",
@@ -1367,7 +1367,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
       "severity": "Negligible",
@@ -1419,7 +1419,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
       "severity": "Negligible",
@@ -1464,7 +1464,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2010-0928",
       "severity": "Negligible",
@@ -1510,7 +1510,7 @@
         }
       ],
       "description": "The mintToken function of a smart contract implementation for APP, an Ethereum token, has an integer overflow that allows the owner of the contract to set the balance of an arbitrary user to any value.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "nvd",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-13661",
       "severity": "High",
@@ -1562,7 +1562,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2011-4116",
       "severity": "Negligible",
@@ -1614,7 +1614,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2020-27619",
       "severity": "Negligible",
@@ -1661,7 +1661,7 @@
         }
       ],
       "description": "A temp directory creation vulnerability exists in all versions of Guava, allowing an attacker with access to the machine to potentially access data in a temporary directory created by the Guava API com.google.common.io.Files.createTempDir(). By default, on unix-like systems, the created directory is world-readable (readable by an attacker with access to the system). The method in question has been marked @Deprecated in versions 30.0 and later and should not be used. For Android developers, we recommend choosing a temporary directory API provided by Android, such as context.getCacheDir(). For other Java developers, we recommend migrating to the Java 7 API java.nio.file.Files.createTempDirectory() which explicitly configures permissions of 700, or configuring the Java runtime's java.io.tmpdir system property to point to a location whose permissions are appropriately configured.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "nvd",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
       "severity": "Low",
@@ -1713,7 +1713,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2011-4116",
       "severity": "Negligible",
@@ -1758,7 +1758,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2010-4052",
       "severity": "Negligible",
@@ -1804,7 +1804,7 @@
         }
       ],
       "description": "aiohttp is an asynchronous HTTP client/server framework for asyncio and Python. In aiohttp before version 3.7.4 there is an open redirect vulnerability. A maliciously crafted link to an aiohttp-based web-server could redirect the browser to a different website. It is caused by a bug in the `aiohttp.web_middlewares.normalize_path_middleware` middleware. This security problem has been fixed in 3.7.4. Upgrade your dependency using pip as follows \"pip install aiohttp >= 3.7.4\". If upgrading is not an option for you, a workaround can be to avoid using `aiohttp.web_middlewares.normalize_path_middleware` in your applications.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "nvd",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21330",
       "severity": "Medium",
@@ -1856,7 +1856,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
       "severity": "Negligible",
@@ -1901,7 +1901,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2010-4051",
       "severity": "Negligible",
@@ -1946,7 +1946,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2004-0971",
       "severity": "Negligible",
@@ -1991,7 +1991,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2010-0928",
       "severity": "Negligible",
@@ -2043,7 +2043,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
       "severity": "Negligible",
@@ -2095,7 +2095,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2018-20796",
       "severity": "Negligible",
@@ -2147,7 +2147,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2017-17740",
       "severity": "Negligible",
@@ -2199,7 +2199,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2018-6829",
       "severity": "Negligible",
@@ -2251,7 +2251,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
       "severity": "Negligible",
@@ -2303,7 +2303,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010025",
       "severity": "Negligible",
@@ -2355,7 +2355,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
       "severity": "Negligible",
@@ -2407,7 +2407,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
       "severity": "Negligible",
@@ -2454,7 +2454,7 @@
         }
       ],
       "description": "Unbounded memory allocation in Google Guava 11.0 through 24.x before 24.1.1 allows remote attackers to conduct denial of service attacks against servers that depend on this library and deserialize attacker-provided data, because the AtomicDoubleArray class (when serialized with Java serialization) and the CompoundOrdering class (when serialized with GWT serialization) perform eager allocation without appropriate checks on what a client has sent and whether the data size is reasonable.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "nvd",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
       "severity": "Medium",
@@ -2485,7 +2485,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2021-3520",
       "severity": "Unknown",
@@ -2537,7 +2537,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
       "severity": "Negligible",
@@ -2582,7 +2582,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2013-7040",
       "severity": "Negligible",
@@ -2634,7 +2634,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
       "severity": "Negligible",
@@ -2686,7 +2686,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2020-13529",
       "severity": "Negligible",
@@ -2738,7 +2738,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
       "severity": "Negligible",
@@ -2790,7 +2790,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010022",
       "severity": "Negligible",
@@ -2836,7 +2836,7 @@
         }
       ],
       "description": "The ftpd gem 0.2.1 for Ruby allows remote attackers to execute arbitrary OS commands via shell metacharacters in a LIST or NLST command argument within FTP protocol traffic.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "nvd",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
       "severity": "Critical",
@@ -2888,7 +2888,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2019-9192",
       "severity": "Negligible",
@@ -2940,7 +2940,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010023",
       "severity": "Negligible",
@@ -2987,7 +2987,7 @@
         }
       ],
       "description": "Unbounded memory allocation in Google Guava 11.0 through 24.x before 24.1.1 allows remote attackers to conduct denial of service attacks against servers that depend on this library and deserialize attacker-provided data, because the AtomicDoubleArray class (when serialized with Java serialization) and the CompoundOrdering class (when serialized with GWT serialization) perform eager allocation without appropriate checks on what a client has sent and whether the data size is reasonable.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "nvd",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
       "severity": "Medium",
@@ -3039,7 +3039,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2017-14159",
       "severity": "Negligible",
@@ -3091,7 +3091,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2017-16231",
       "severity": "Negligible",
@@ -3136,7 +3136,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
       "severity": "Negligible",
@@ -3188,7 +3188,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2013-4235",
       "severity": "Negligible",
@@ -3242,7 +3242,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2021-2163",
       "severity": "Low",
@@ -3294,7 +3294,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010022",
       "severity": "Negligible",
@@ -3339,7 +3339,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2013-7040",
       "severity": "Negligible",
@@ -3391,7 +3391,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2019-18276",
       "severity": "Negligible",
@@ -3443,7 +3443,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2017-18018",
       "severity": "Negligible",
@@ -3495,7 +3495,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2020-35457",
       "severity": "Negligible",
@@ -3547,7 +3547,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2019-19882",
       "severity": "Negligible",
@@ -3599,7 +3599,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2021-20193",
       "severity": "Negligible",
@@ -3651,7 +3651,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2018-1000654",
       "severity": "Negligible",
@@ -3703,7 +3703,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
       "severity": "Negligible",
@@ -3748,7 +3748,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2010-4756",
       "severity": "Negligible",
@@ -3800,7 +3800,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2011-3374",
       "severity": "Negligible",
@@ -3852,7 +3852,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2011-3374",
       "severity": "Negligible",
@@ -3904,7 +3904,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
       "severity": "Negligible",
@@ -3949,7 +3949,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2015-3276",
       "severity": "Negligible",
@@ -3978,7 +3978,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2007-5686",
       "severity": "Negligible",
@@ -4030,7 +4030,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010024",
       "severity": "Negligible",
@@ -4082,7 +4082,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2017-15131",
       "severity": "Negligible",
@@ -4134,7 +4134,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010024",
       "severity": "Negligible",
@@ -4181,7 +4181,7 @@
         }
       ],
       "description": "A temp directory creation vulnerability exists in all versions of Guava, allowing an attacker with access to the machine to potentially access data in a temporary directory created by the Guava API com.google.common.io.Files.createTempDir(). By default, on unix-like systems, the created directory is world-readable (readable by an attacker with access to the system). The method in question has been marked @Deprecated in versions 30.0 and later and should not be used. For Android developers, we recommend choosing a temporary directory API provided by Android, such as context.getCacheDir(). For other Java developers, we recommend migrating to the Java 7 API java.nio.file.Files.createTempDirectory() which explicitly configures permissions of 700, or configuring the Java runtime's java.io.tmpdir system property to point to a location whose permissions are appropriately configured.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "nvd",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
       "severity": "Low",
@@ -4233,7 +4233,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2018-5709",
       "severity": "Negligible",
@@ -4262,7 +4262,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2007-5686",
       "severity": "Negligible",
@@ -4314,7 +4314,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2013-4235",
       "severity": "Negligible",
@@ -4366,7 +4366,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
       "severity": "Negligible",
@@ -4418,7 +4418,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
       "severity": "Negligible",
@@ -4463,7 +4463,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2012-0039",
       "severity": "Negligible",
@@ -4515,7 +4515,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2018-20796",
       "severity": "Negligible",
@@ -4567,7 +4567,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2020-27619",
       "severity": "Negligible",
@@ -4619,7 +4619,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
       "severity": "Negligible",
@@ -4671,7 +4671,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2019-19882",
       "severity": "Negligible",
@@ -4723,7 +4723,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
       "severity": "Negligible",
@@ -4768,7 +4768,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2010-4051",
       "severity": "Negligible",
@@ -4820,7 +4820,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
       "severity": "Negligible",
@@ -4872,7 +4872,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
       "severity": "Negligible",
@@ -4917,7 +4917,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "debian:10",
       "link": "https://security-tracker.debian.org/tracker/CVE-2007-6755",
       "severity": "Negligible",

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/grype/sha256:80a31c3ce2e99c3691c27ac3b1753163214494e9b2ca07bfdccf29a5cca2bfbe.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/grype/sha256:80a31c3ce2e99c3691c27ac3b1753163214494e9b2ca07bfdccf29a5cca2bfbe.json
@@ -39,7 +39,7 @@
         }
       ],
       "description": "Unbounded memory allocation in Google Guava 11.0 through 24.x before 24.1.1 allows remote attackers to conduct denial of service attacks against servers that depend on this library and deserialize attacker-provided data, because the AtomicDoubleArray class (when serialized with Java serialization) and the CompoundOrdering class (when serialized with GWT serialization) perform eager allocation without appropriate checks on what a client has sent and whether the data size is reasonable.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "nvd",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
       "severity": "Medium",
@@ -85,7 +85,7 @@
         }
       ],
       "description": "The mintToken function of a smart contract implementation for APP, an Ethereum token, has an integer overflow that allows the owner of the contract to set the balance of an arbitrary user to any value.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "nvd",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-13661",
       "severity": "High",
@@ -131,7 +131,7 @@
         }
       ],
       "description": "** DISPUTED ** An issue was discovered in pip (all versions) because it installs the version with the highest version number, even if the user had intended to obtain a private package from a private index. This only affects use of the --extra-index-url option, and exploitation requires that the package does not already exist in the public index (and thus the attacker can put the package there with an arbitrary version number). NOTE: it has been reported that this is intended functionality and the user is responsible for using --extra-index-url securely.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "nvd",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-20225",
       "severity": "High",
@@ -177,7 +177,7 @@
         }
       ],
       "description": "aiohttp is an asynchronous HTTP client/server framework for asyncio and Python. In aiohttp before version 3.7.4 there is an open redirect vulnerability. A maliciously crafted link to an aiohttp-based web-server could redirect the browser to a different website. It is caused by a bug in the `aiohttp.web_middlewares.normalize_path_middleware` middleware. This security problem has been fixed in 3.7.4. Upgrade your dependency using pip as follows \"pip install aiohttp >= 3.7.4\". If upgrading is not an option for you, a workaround can be to avoid using `aiohttp.web_middlewares.normalize_path_middleware` in your applications.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "nvd",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21330",
       "severity": "Medium",
@@ -223,7 +223,7 @@
         }
       ],
       "description": "xmldom is a pure JavaScript W3C standard-based (XML DOM Level 2 Core) DOMParser and XMLSerializer module. xmldom versions 0.4.0 and older do not correctly preserve system identifiers, FPIs or namespaces when repeatedly parsing and serializing maliciously crafted documents. This may lead to unexpected syntactic changes during XML processing in some downstream applications. This is fixed in version 0.5.0. As a workaround downstream applications can validate the input and reject the maliciously crafted documents.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "nvd",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21366",
       "severity": "Medium",
@@ -254,7 +254,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "alpine:3.12",
       "link": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-30139",
       "severity": "Medium",
@@ -301,7 +301,7 @@
         }
       ],
       "description": "Unbounded memory allocation in Google Guava 11.0 through 24.x before 24.1.1 allows remote attackers to conduct denial of service attacks against servers that depend on this library and deserialize attacker-provided data, because the AtomicDoubleArray class (when serialized with Java serialization) and the CompoundOrdering class (when serialized with GWT serialization) perform eager allocation without appropriate checks on what a client has sent and whether the data size is reasonable.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "nvd",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
       "severity": "Medium",
@@ -347,7 +347,7 @@
         }
       ],
       "description": "The mintToken function of a smart contract implementation for APP, an Ethereum token, has an integer overflow that allows the owner of the contract to set the balance of an arbitrary user to any value.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "nvd",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-13661",
       "severity": "High",
@@ -394,7 +394,7 @@
         }
       ],
       "description": "A temp directory creation vulnerability exists in all versions of Guava, allowing an attacker with access to the machine to potentially access data in a temporary directory created by the Guava API com.google.common.io.Files.createTempDir(). By default, on unix-like systems, the created directory is world-readable (readable by an attacker with access to the system). The method in question has been marked @Deprecated in versions 30.0 and later and should not be used. For Android developers, we recommend choosing a temporary directory API provided by Android, such as context.getCacheDir(). For other Java developers, we recommend migrating to the Java 7 API java.nio.file.Files.createTempDirectory() which explicitly configures permissions of 700, or configuring the Java runtime's java.io.tmpdir system property to point to a location whose permissions are appropriately configured.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "nvd",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
       "severity": "Low",
@@ -440,7 +440,7 @@
         }
       ],
       "description": "The ftpd gem 0.2.1 for Ruby allows remote attackers to execute arbitrary OS commands via shell metacharacters in a LIST or NLST command argument within FTP protocol traffic.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "nvd",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
       "severity": "Critical",
@@ -487,7 +487,7 @@
         }
       ],
       "description": "A temp directory creation vulnerability exists in all versions of Guava, allowing an attacker with access to the machine to potentially access data in a temporary directory created by the Guava API com.google.common.io.Files.createTempDir(). By default, on unix-like systems, the created directory is world-readable (readable by an attacker with access to the system). The method in question has been marked @Deprecated in versions 30.0 and later and should not be used. For Android developers, we recommend choosing a temporary directory API provided by Android, such as context.getCacheDir(). For other Java developers, we recommend migrating to the Java 7 API java.nio.file.Files.createTempDirectory() which explicitly configures permissions of 700, or configuring the Java runtime's java.io.tmpdir system property to point to a location whose permissions are appropriately configured.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "nvd",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
       "severity": "Low",
@@ -541,7 +541,7 @@
     "vulnerability": {
       "cvss": [],
       "description": null,
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "alpine:3.12",
       "link": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-28831",
       "severity": "Medium",
@@ -587,7 +587,7 @@
         }
       ],
       "description": "aio-libs aiohttp-session contains a Session Fixation vulnerability in load_session function for RedisStorage (see: https://github.com/aio-libs/aiohttp-session/blob/master/aiohttp_session/redis_storage.py#L42) that can result in Session Hijacking. This attack appear to be exploitable via Any method that allows setting session cookies (?session=<>, or meta tags or script tags with Set-Cookie).",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "nvd",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-1000519",
       "severity": "Medium",

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/grype/sha256:fe3ca35038008b0eac0fa4e686bd072c9430000ab7d7853001bde5f5b8ccf60c.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/grype/sha256:fe3ca35038008b0eac0fa4e686bd072c9430000ab7d7853001bde5f5b8ccf60c.json
@@ -39,7 +39,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "Race condition in the ssl3_read_bytes function in s3_pkt.c in OpenSSL through 1.0.1g, when SSL_MODE_RELEASE_BUFFERS is enabled, allows remote attackers to inject data across sessions or cause a denial of service (use-after-free and parsing error) via an SSL connection in a multithreaded environment.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2010-5298",
       "severity": "Medium",
@@ -85,7 +85,7 @@
         }
       ],
       "description": "The ftpd gem 0.2.1 for Ruby allows remote attackers to execute arbitrary OS commands via shell metacharacters in a LIST or NLST command argument within FTP protocol traffic.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "nvd",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
       "severity": "Critical",
@@ -132,7 +132,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "The dtls1_reassemble_fragment function in d1_both.c in OpenSSL before 0.9.8za, 1.0.0 before 1.0.0m, and 1.0.1 before 1.0.1h does not properly validate fragment lengths in DTLS ClientHello messages, which allows remote attackers to execute arbitrary code or cause a denial of service (buffer overflow and application crash) via a long non-initial fragment.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2014-0195",
       "severity": "High",
@@ -179,7 +179,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "The do_ssl3_write function in s3_pkt.c in OpenSSL 1.x through 1.0.1g, when SSL_MODE_RELEASE_BUFFERS is enabled, does not properly manage a buffer pointer during certain recursive calls, which allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) via vectors that trigger an alert condition.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2014-0198",
       "severity": "Medium",
@@ -226,7 +226,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "A denial of service flaw was found in the way OpenSSL handled certain DTLS ServerHello requests. A specially crafted DTLS handshake packet could cause a DTLS client using OpenSSL to crash.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2014-0221",
       "severity": "Medium",
@@ -280,7 +280,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "It was found that OpenSSL clients and servers could be forced, via a specially crafted handshake packet, to use weak keying material for communication. A man-in-the-middle attacker could use this flaw to decrypt and modify traffic between a client and a server.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2014-0224",
       "severity": "High",
@@ -327,7 +327,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "The ssl3_send_client_key_exchange function in s3_clnt.c in OpenSSL before 0.9.8za, 1.0.0 before 1.0.0m, and 1.0.1 before 1.0.1h, when an anonymous ECDH cipher suite is used, allows remote attackers to cause a denial of service (NULL pointer dereference and client crash) by triggering a NULL certificate value.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2014-3470",
       "severity": "Medium",
@@ -374,7 +374,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "A flaw was discovered in the way OpenSSL handled DTLS packets. A remote attacker could use this flaw to cause a DTLS server or client using OpenSSL to crash or use excessive amounts of memory.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2014-3505",
       "severity": "Medium",
@@ -421,7 +421,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "A flaw was discovered in the way OpenSSL handled DTLS packets. A remote attacker could use this flaw to cause a DTLS server or client using OpenSSL to crash or use excessive amounts of memory.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2014-3506",
       "severity": "Medium",
@@ -468,7 +468,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "A flaw was discovered in the way OpenSSL handled DTLS packets. A remote attacker could use this flaw to cause a DTLS server or client using OpenSSL to crash or use excessive amounts of memory.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2014-3507",
       "severity": "Medium",
@@ -515,7 +515,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "It was discovered that the OBJ_obj2txt() function could fail to properly NUL-terminate its output. This could possibly cause an application using OpenSSL functions to format fields of X.509 certificates to disclose portions of its memory.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2014-3508",
       "severity": "Medium",
@@ -562,7 +562,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "A race condition was found in the way OpenSSL handled ServerHello messages with an included Supported EC Point Format extension. A malicious server could possibly use this flaw to cause a multi-threaded TLS/SSL client using OpenSSL to write into freed memory, causing the client to crash or execute arbitrary code.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2014-3509",
       "severity": "Medium",
@@ -609,7 +609,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "A NULL pointer dereference flaw was found in the way OpenSSL performed a handshake when using the anonymous Diffie-Hellman (DH) key exchange. A malicious server could cause a DTLS client using OpenSSL to crash if that client had anonymous DH cipher suites enabled.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2014-3510",
       "severity": "Medium",
@@ -656,7 +656,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "A flaw was found in the way OpenSSL handled fragmented handshake packets. A man-in-the-middle attacker could use this flaw to force a TLS/SSL server using OpenSSL to use TLS 1.0, even if both the client and the server supported newer protocol versions.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2014-3511",
       "severity": "Medium",
@@ -703,7 +703,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "A memory leak flaw was found in the way OpenSSL parsed the DTLS Secure Real-time Transport Protocol (SRTP) extension data. A remote attacker could send multiple specially crafted handshake messages to exhaust all available memory of an SSL/TLS or DTLS server.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2014-3513",
       "severity": "High",
@@ -750,7 +750,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "A memory leak flaw was found in the way an OpenSSL handled failed session ticket integrity checks. A remote attacker could exhaust all available memory of an SSL/TLS or DTLS server by sending a large number of invalid session tickets to that server.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2014-3567",
       "severity": "Medium",
@@ -812,7 +812,7 @@
         }
       ],
       "description": "It was found that OpenSSL's BigNumber Squaring implementation could produce incorrect results under certain special conditions. This flaw could possibly affect certain OpenSSL library functionality, such as RSA blinding. Note that this issue occurred rarely and with a low probability, and there is currently no known way of exploiting it.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2014-3570",
       "severity": "Low",
@@ -859,7 +859,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "A NULL pointer dereference flaw was found in the DTLS implementation of OpenSSL. A remote attacker could send a specially crafted DTLS message, which would cause an OpenSSL server to crash.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2014-3571",
       "severity": "Medium",
@@ -906,7 +906,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "It was discovered that OpenSSL would perform an ECDH key exchange with a non-ephemeral key even when the ephemeral ECDH cipher suite was selected. A malicious server could make a TLS/SSL client using OpenSSL use a weaker key exchange method than the one requested by the user.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2014-3572",
       "severity": "Low",
@@ -958,7 +958,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "Libgcrypt before 1.6.3 and GnuPG before 1.4.19 does not implement ciphertext blinding for Elgamal decryption, which allows physically proximate attackers to obtain the server's private key by determining factors using crafted ciphertext and the fluctuations in the electromagnetic field during multiplication.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2014-3591",
       "severity": "Low",
@@ -1010,7 +1010,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "Libgcrypt before 1.6.3 and GnuPG before 1.4.19 does not implement ciphertext blinding for Elgamal decryption, which allows physically proximate attackers to obtain the server's private key by determining factors using crafted ciphertext and the fluctuations in the electromagnetic field during multiplication.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2014-3591",
       "severity": "Low",
@@ -1055,7 +1055,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "The posix_spawn_file_actions_addopen function in glibc before 2.20 does not copy its path argument in accordance with the POSIX specification, which allows context-dependent attackers to trigger use-after-free vulnerabilities.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2014-4043",
       "severity": "Low",
@@ -1100,7 +1100,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "The posix_spawn_file_actions_addopen function in glibc before 2.20 does not copy its path argument in accordance with the POSIX specification, which allows context-dependent attackers to trigger use-after-free vulnerabilities.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2014-4043",
       "severity": "Low",
@@ -1145,7 +1145,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "The do_uncompress function in g10/compress.c in GnuPG 1.x before 1.4.17 and 2.x before 2.0.24 allows context-dependent attackers to cause a denial of service (infinite loop) via malformed compressed packets, as demonstrated by an a3 01 5b ff byte sequence.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2014-4617",
       "severity": "Medium",
@@ -1190,7 +1190,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "Libgcrypt before 1.5.4, as used in GnuPG and other products, does not properly perform ciphertext normalization and ciphertext randomization, which makes it easier for physically proximate attackers to conduct key-extraction attacks by leveraging the ability to collect voltage data from exposed metal, a different vector than CVE-2013-4576.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2014-5270",
       "severity": "Medium",
@@ -1252,7 +1252,7 @@
         }
       ],
       "description": "An invalid-free flaw was found in the way OpenSSL handled certain DTLS handshake messages. A malicious DTLS client or server could send a specially crafted message to the peer, which could cause the application to crash or potentially result in arbitrary code execution.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2014-8176",
       "severity": "Medium",
@@ -1299,7 +1299,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "Multiple flaws were found in the way OpenSSL parsed X.509 certificates. An attacker could use these flaws to modify an X.509 certificate to produce a certificate with a different fingerprint without invalidating its signature, and possibly bypass fingerprint-based blacklisting in applications.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2014-8275",
       "severity": "Low",
@@ -1361,7 +1361,7 @@
         }
       ],
       "description": "It was discovered that OpenSSL would accept ephemeral RSA keys when using non-export RSA cipher suites. A malicious server could make a TLS/SSL client using OpenSSL use a weaker key exchange method.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2015-0204",
       "severity": "Medium",
@@ -1408,7 +1408,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "It was found that an OpenSSL server would, under certain conditions, accept Diffie-Hellman client certificates without the use of a private key. An attacker could use a user's client certificate to authenticate as that user, without needing the private key.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2015-0205",
       "severity": "Low",
@@ -1455,7 +1455,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "A memory leak flaw was found in the way the dtls1_buffer_record() function of OpenSSL parsed certain DTLS messages. A remote attacker could send multiple specially crafted DTLS messages to exhaust all available memory of a DTLS server.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2015-0206",
       "severity": "Medium",
@@ -1502,7 +1502,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "A use-after-free flaw was found in the way OpenSSL imported malformed Elliptic Curve private keys. A specially crafted key file could cause an application using OpenSSL to crash when imported.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2015-0209",
       "severity": "Low",
@@ -1547,7 +1547,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "A heap-based buffer overflow flaw was found in e2fsprogs. A specially crafted Ext2/3/4 file system could cause an application using the ext2fs library (for example, fsck) to crash or, possibly, execute arbitrary code.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2015-0247",
       "severity": "Medium",
@@ -1594,7 +1594,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "An invalid pointer use flaw was found in OpenSSL's ASN1_TYPE_cmp() function. A remote attacker could crash a TLS/SSL client or server using OpenSSL via a specially crafted X.509 certificate when the attacker-supplied certificate was verified by the application.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2015-0286",
       "severity": "Medium",
@@ -1641,7 +1641,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "An out-of-bounds write flaw was found in the way OpenSSL reused certain ASN.1 structures. A remote attacker could possibly use a specially crafted ASN.1 structure that, when parsed by an application, would cause that application to crash.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2015-0287",
       "severity": "Low",
@@ -1688,7 +1688,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "A NULL pointer dereference flaw was found in OpenSSL's X.509 certificate handling implementation. A specially crafted X.509 certificate could cause an application using OpenSSL to crash if the application attempted to convert the certificate to a certificate request.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2015-0288",
       "severity": "Low",
@@ -1735,7 +1735,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "A NULL pointer dereference was found in the way OpenSSL handled certain PKCS#7 inputs. An attacker able to make an application using OpenSSL verify, decrypt, or parse a specially crafted PKCS#7 input could cause that application to crash. TLS/SSL clients and servers using OpenSSL were not affected by this flaw.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2015-0289",
       "severity": "Low",
@@ -1782,7 +1782,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "An integer underflow flaw, leading to a buffer overflow, was found in the way OpenSSL decoded malformed Base64-encoded inputs. An attacker able to make an application using OpenSSL decode a specially crafted Base64-encoded input (such as a PEM file) could use this flaw to cause the application to crash. Note: this flaw is not exploitable via the TLS/SSL protocol because the data being transferred is not Base64-encoded.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2015-0292",
       "severity": "Medium",
@@ -1829,7 +1829,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "A denial of service flaw was found in the way OpenSSL handled SSLv2 handshake messages. A remote attacker could use this flaw to cause a TLS/SSL server using OpenSSL to exit on a failed assertion if it had both the SSLv2 protocol and EXPORT-grade cipher suites enabled.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2015-0293",
       "severity": "Medium",
@@ -1883,7 +1883,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "An out-of-bounds read flaw was found in the X509_cmp_time() function of OpenSSL, which is used to test the expiry dates of SSL/TLS certificates. An attacker could possibly use a specially crafted SSL/TLS certificate or CRL (Certificate Revocation List), which when parsed by an application would cause that application to crash.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2015-1789",
       "severity": "Medium",
@@ -1930,7 +1930,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "A NULL pointer dereference was found in the way OpenSSL handled certain PKCS#7 inputs. An attacker able to make an application using OpenSSL verify, decrypt, or parse a specially crafted PKCS#7 input could cause that application to crash. TLS/SSL clients and servers using OpenSSL were not affected by this flaw.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2015-1790",
       "severity": "Medium",
@@ -1977,7 +1977,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "A race condition was found in the session handling code of OpenSSL. This issue could possibly cause a multi-threaded TLS/SSL client using OpenSSL to double free session ticket data and crash.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2015-1791",
       "severity": "Low",
@@ -2024,7 +2024,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "A denial of service flaw was found in the way OpenSSL verified certain signed messages using CMS (Cryptographic Message Syntax). A remote attacker could cause an application using OpenSSL to use excessive amounts of memory by sending a specially crafted message for verification.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2015-1792",
       "severity": "Medium",
@@ -2069,7 +2069,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "The stringprep_utf8_to_ucs4 function in libin before 1.31, as used in jabberd2, allows context-dependent attackers to read system memory and possibly have other unspecified impact via invalid UTF-8 characters in a string, which triggers an out-of-bounds read.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2015-2059",
       "severity": "Low",
@@ -2123,7 +2123,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "A NULL pointer dereference flaw was found in the way OpenSSL verified signatures using the RSA PSS algorithm. A remote attacker could possibly use this flaw to crash a TLS/SSL client using OpenSSL, or a TLS/SSL server using OpenSSL if it enabled client authentication.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2015-3194",
       "severity": "Low",
@@ -2192,7 +2192,7 @@
         }
       ],
       "description": "A memory leak vulnerability was found in the way OpenSSL parsed PKCS#7 and CMS data. A remote attacker could use this flaw to cause an application that parses PKCS#7 or CMS data from untrusted sources to use an excessive amount of memory and possibly crash.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2015-3195",
       "severity": "Medium",
@@ -2239,7 +2239,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "A race condition flaw, leading to a double free, was found in the way OpenSSL handled pre-shared key (PSK) identify hints. A remote attacker could use this flaw to crash a multi-threaded SSL/TLS client using OpenSSL.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2015-3196",
       "severity": "Low",
@@ -2293,7 +2293,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "A flaw was found in the way malicious SSLv2 clients could negotiate SSLv2 ciphers that were disabled on the server. This could result in weak SSLv2 ciphers being used for SSLv2 connections, making them vulnerable to man-in-the-middle attacks.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2015-3197",
       "severity": "Low",
@@ -2340,7 +2340,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "A regression was found in the ssleay_rand_bytes() function in the versions of OpenSSL shipped with Red Hat Enterprise Linux 6 and 7. This regression could cause a multi-threaded application to crash.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2015-3216",
       "severity": "Low",
@@ -2437,7 +2437,7 @@
         }
       ],
       "description": "A flaw was found in the way the TLS protocol composes the Diffie-Hellman exchange (for both export and non-export grade cipher suites). An attacker could use this flaw to downgrade a DHE connection to use export-grade key sizes, which could then be broken by sufficient pre-computation. This can lead to a passive man-in-the-middle attack in which the attacker is able to decrypt all traffic.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2015-4000",
       "severity": "Medium",
@@ -2491,7 +2491,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "A flaw was found in the way TLS 1.2 could use the MD5 hash function for signing ServerKeyExchange and Client Authentication packets during a TLS handshake. A man-in-the-middle attacker able to force a TLS connection to use the MD5 hash function could use this flaw to conduct collision attacks to impersonate a TLS server or an authenticated TLS client.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2015-7575",
       "severity": "Medium",
@@ -2545,7 +2545,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "A side-channel attack was found that makes use of cache-bank conflicts on the Intel Sandy-Bridge microarchitecture. An attacker who has the ability to control code in a thread running on the same hyper-threaded core as the victim's thread that is performing decryption, could use this flaw to recover RSA private keys.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2016-0702",
       "severity": "Low",
@@ -2599,7 +2599,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "It was discovered that the SSLv2 servers using OpenSSL accepted SSLv2 connection handshakes that indicated non-zero clear key length for non-export cipher suites. An attacker could use this flaw to decrypt recorded SSLv2 sessions with the server by using it as a decryption oracle.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2016-0703",
       "severity": "Medium",
@@ -2653,7 +2653,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "It was discovered that the SSLv2 protocol implementation in OpenSSL did not properly implement the Bleichenbacher protection for export cipher suites. An attacker could use a SSLv2 server using OpenSSL as a Bleichenbacher oracle.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2016-0704",
       "severity": "Medium",
@@ -2707,7 +2707,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "A double-free flaw was found in the way OpenSSL parsed certain malformed DSA (Digital Signature Algorithm) private keys. An attacker could create specially crafted DSA private keys that, when processed by an application compiled against OpenSSL, could cause the application to crash.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2016-0705",
       "severity": "Low",
@@ -2761,7 +2761,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "An integer overflow flaw, leading to a NULL pointer dereference or a heap-based memory corruption, was found in the way some BIGNUM functions of OpenSSL were implemented. Applications that use these functions with large untrusted input could crash or, potentially, execute arbitrary code.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2016-0797",
       "severity": "Low",
@@ -2815,7 +2815,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "Several flaws were found in the way BIO_*printf functions were implemented in OpenSSL. Applications which passed large amounts of untrusted data through these functions could crash or potentially execute code with the permissions of the user running such an application.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2016-0799",
       "severity": "Low",
@@ -2869,7 +2869,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "A padding oracle flaw was found in the Secure Sockets Layer version 2.0 (SSLv2) protocol. An attacker could potentially use this flaw to decrypt RSA-encrypted cipher text from a connection using a newer SSL/TLS protocol version, allowing them to decrypt such connections. This cross-protocol attack is publicly referred to as DROWN.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2016-0800",
       "severity": "High",
@@ -2931,7 +2931,7 @@
         }
       ],
       "description": "A vulnerability was found in vim in how certain modeline options were treated. An attacker could craft a file that, when opened in vim with modelines enabled, could execute arbitrary commands with privileges of the user running vim.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2016-1248",
       "severity": "Medium",
@@ -3000,7 +3000,7 @@
         }
       ],
       "description": "An integer overflow flaw, leading to a buffer overflow, was found in the way the EVP_EncodeUpdate() function of OpenSSL parsed very large amounts of input data. A remote attacker could use this flaw to crash an application using OpenSSL or, possibly, execute arbitrary code with the permissions of the user running that application.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2016-2105",
       "severity": "Medium",
@@ -3069,7 +3069,7 @@
         }
       ],
       "description": "An integer overflow flaw, leading to a buffer overflow, was found in the way the EVP_EncryptUpdate() function of OpenSSL parsed very large amounts of input data. A remote attacker could use this flaw to crash an application using OpenSSL or, possibly, execute arbitrary code with the permissions of the user running that application.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2016-2106",
       "severity": "Medium",
@@ -3123,7 +3123,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "It was discovered that OpenSSL leaked timing information when decrypting TLS/SSL and DTLS protocol encrypted records when the connection used the AES CBC cipher suite and the server supported AES-NI. A remote attacker could possibly use this flaw to retrieve plain text from encrypted packets by using a TLS/SSL or DTLS server as a padding oracle.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2016-2107",
       "severity": "Medium",
@@ -3192,7 +3192,7 @@
         }
       ],
       "description": "A flaw was found in the way OpenSSL encoded certain ASN.1 data structures. An attacker could use this flaw to create a specially crafted certificate which, when verified or re-encoded by OpenSSL, could cause it to crash, or execute arbitrary code using the permissions of the user running an application compiled against the OpenSSL library.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2016-2108",
       "severity": "High",
@@ -3261,7 +3261,7 @@
         }
       ],
       "description": "A denial of service flaw was found in the way OpenSSL parsed certain ASN.1-encoded data from BIO (OpenSSL's I/O abstraction) inputs. An application using OpenSSL that accepts untrusted ASN.1 BIO input could be forced to allocate an excessive amount of data.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2016-2109",
       "severity": "Low",
@@ -3330,7 +3330,7 @@
         }
       ],
       "description": "Multiple integer overflow flaws were found in the way OpenSSL performed pointer arithmetic. A remote attacker could possibly use these flaws to cause a TLS/SSL server or client using OpenSSL to crash.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2016-2177",
       "severity": "Low",
@@ -3399,7 +3399,7 @@
         }
       ],
       "description": "It was discovered that OpenSSL did not always use constant time operations when computing Digital Signature Algorithm (DSA) signatures. A local attacker could possibly use this flaw to obtain a private DSA key belonging to another user or service running on the same system.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2016-2178",
       "severity": "Medium",
@@ -3468,7 +3468,7 @@
         }
       ],
       "description": "It was discovered that the Datagram TLS (DTLS) implementation could fail to release memory in certain cases. A malicious DTLS client could cause a DTLS server using OpenSSL to consume an excessive amount of memory and, possibly, exit unexpectedly after exhausting all available memory.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2016-2179",
       "severity": "Medium",
@@ -3530,7 +3530,7 @@
         }
       ],
       "description": "An out of bounds read flaw was found in the way OpenSSL formatted Public Key Infrastructure Time-Stamp Protocol data for printing. An attacker could possibly cause an application using OpenSSL to crash if it printed time stamp data from the attacker.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2016-2180",
       "severity": "Low",
@@ -3599,7 +3599,7 @@
         }
       ],
       "description": "A flaw was found in the Datagram TLS (DTLS) replay protection implementation in OpenSSL. A remote attacker could possibly use this flaw to make a DTLS server using OpenSSL to reject further packets sent from a DTLS client over an established DTLS connection.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2016-2181",
       "severity": "Medium",
@@ -3668,7 +3668,7 @@
         }
       ],
       "description": "An out of bounds write flaw was discovered in the OpenSSL BN_bn2dec() function. An attacker able to make an application using OpenSSL to process a large BIGNUM could cause the application to crash or, possibly, execute arbitrary code.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2016-2182",
       "severity": "Medium",
@@ -3722,7 +3722,7 @@
     "vulnerability": {
       "cvss": [],
       "description": "Several flaws were found in the way BIO_*printf functions were implemented in OpenSSL. Applications which passed large amounts of untrusted data through these functions could crash or potentially execute code with the permissions of the user running such an application.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2016-2842",
       "severity": "Low",
@@ -3784,7 +3784,7 @@
         }
       ],
       "description": "An integer underflow flaw leading to a buffer over-read was found in the way OpenSSL parsed TLS session tickets. A remote attacker could use this flaw to crash a TLS server using OpenSSL if it used SHA-512 as HMAC for session tickets.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2016-6302",
       "severity": "Medium",
@@ -3846,7 +3846,7 @@
         }
       ],
       "description": "A memory leak flaw was found in the way OpenSSL handled TLS status request extension data during session renegotiation. A remote attacker could cause a TLS server using OpenSSL to consume an excessive amount of memory and, possibly, exit unexpectedly after exhausting all available memory, if it enabled OCSP stapling support.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2016-6304",
       "severity": "High",
@@ -3915,7 +3915,7 @@
         }
       ],
       "description": "Multiple out of bounds read flaws were found in the way OpenSSL handled certain TLS/SSL protocol handshake messages. A remote attacker could possibly use these flaws to crash a TLS/SSL server or client using OpenSSL.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2016-6306",
       "severity": "Low",
@@ -3977,7 +3977,7 @@
         }
       ],
       "description": "A timing attack flaw was found in OpenSSL that could allow a malicious user with local access to recover ECDSA P-256 private keys.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2016-7056",
       "severity": "Medium",
@@ -4053,7 +4053,7 @@
         }
       ],
       "description": "A denial of service flaw was found in the way the TLS/SSL protocol defined processing of ALERT packets during a connection handshake. A remote attacker could use this flaw to make a TLS/SSL server consume an excessive amount of CPU and fail to accept connections from other clients.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2016-8610",
       "severity": "Medium",
@@ -4122,7 +4122,7 @@
         }
       ],
       "description": "An integer underflow leading to an out of bounds read flaw was found in OpenSSL. A remote attacker could possibly use this flaw to crash a 32-bit TLS/SSL server or client using OpenSSL if it used the RC4-MD5 cipher suite.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2017-3731",
       "severity": "Medium",
@@ -4198,7 +4198,7 @@
         }
       ],
       "description": "While parsing an IPAddressFamily extension in an X.509 certificate, it is possible to do a one-byte overread. This would result in an incorrect text display of the certificate. This bug has been present since 2006 and is present in all versions of OpenSSL before 1.0.2m and 1.1.0g.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2017-3735",
       "severity": "Low",
@@ -4267,7 +4267,7 @@
         }
       ],
       "description": "There is a carry propagating bug in the x86_64 Montgomery squaring procedure in OpenSSL before 1.0.2m and 1.1.0 before 1.1.0g. No EC algorithms are affected. Analysis suggests that attacks against RSA and DSA as a result of this defect would be very difficult to perform and are not believed likely. Attacks against DH are considered just feasible (although very difficult) because most of the work necessary to deduce information about a private key may be performed offline. The amount of resources required for such an attack would be very significant and likely only accessible to a limited number of attackers. An attacker would additionally need online access to an unpatched system using the target private key in a scenario with persistent DH parameters and a private key that is shared between multiple clients. This only affects processors that support the BMI1, BMI2 and ADX extensions like Intel Broadwell (5th generation) and later or AMD Ryzen.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2017-3736",
       "severity": "Medium",
@@ -4329,7 +4329,7 @@
         }
       ],
       "description": "OpenSSL 1.0.2 (starting from version 1.0.2b) introduced an \"error state\" mechanism. The intent was that if a fatal error occurred during a handshake then OpenSSL would move into the error state and would immediately fail if you attempted to continue the handshake. This works as designed for the explicit handshake functions (SSL_do_handshake(), SSL_accept() and SSL_connect()), however due to a bug it does not work correctly if SSL_read() or SSL_write() is called directly. In that scenario, if the handshake fails then a fatal error will be returned in the initial function call. If SSL_read()/SSL_write() is subsequently called by the application for the same SSL object then it will succeed and the data is passed without being decrypted/encrypted directly from the SSL/TLS record layer. In order to exploit this issue an application bug would have to be present that resulted in a call to SSL_read()/SSL_write() being issued after having already received a fatal error. OpenSSL version 1.0.2b-1.0.2m are affected. Fixed in OpenSSL 1.0.2n. OpenSSL 1.1.0 is not affected.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2017-3737",
       "severity": "Medium",
@@ -4391,7 +4391,7 @@
         }
       ],
       "description": "There is an overflow bug in the AVX2 Montgomery multiplication procedure used in exponentiation with 1024-bit moduli. No EC algorithms are affected. Analysis suggests that attacks against RSA and DSA as a result of this defect would be very difficult to perform and are not believed likely. Attacks against DH1024 are considered just feasible, because most of the work necessary to deduce information about a private key may be performed offline. The amount of resources required for such an attack would be significant. However, for an attack on TLS to be meaningful, the server would have to share the DH1024 private key among multiple clients, which is no longer an option since CVE-2016-0701. This only affects processors that support the AVX2 but not ADX extensions like Intel Haswell (4th generation). Note: The impact from this issue is similar to CVE-2017-3736, CVE-2017-3732 and CVE-2015-3193. OpenSSL version 1.0.2-1.0.2m and 1.1.0-1.1.0g are affected. Fixed in OpenSSL 1.0.2n. Due to the low severity of this issue we are not issuing a new release of OpenSSL 1.1.0 at this time. The fix will be included in OpenSSL 1.1.0h when it becomes available. The fix is also available in commit e502cc86d in the OpenSSL git repository.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2017-3738",
       "severity": "Low",
@@ -4474,7 +4474,7 @@
         }
       ],
       "description": "Libgcrypt before 1.7.10 and 1.8.x before 1.8.3 allows a memory-cache side-channel attack on ECDSA signatures that can be mitigated through the use of blinding during the signing process in the _gcry_ecc_ecdsa_sign function in cipher/ecc-ecdsa.c, aka the Return Of the Hidden Number Problem or ROHNP. To discover an ECDSA key, the attacker needs access to either the local machine or a different virtual machine on the same physical host.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2018-0495",
       "severity": "Medium",
@@ -4550,7 +4550,7 @@
         }
       ],
       "description": "During key agreement in a TLS handshake using a DH(E) based ciphersuite a malicious server can send a very large prime value to the client. This will cause the client to spend an unreasonably long period of time generating a key for this prime resulting in a hang until the client has finished. This could be exploited in a Denial Of Service attack. Fixed in OpenSSL 1.1.0i-dev (Affected 1.1.0-1.1.0h). Fixed in OpenSSL 1.0.2p-dev (Affected 1.0.2-1.0.2o).",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2018-0732",
       "severity": "Medium",
@@ -4626,7 +4626,7 @@
         }
       ],
       "description": "The OpenSSL DSA signature algorithm has been shown to be vulnerable to a timing side channel attack. An attacker could use variations in the signing algorithm to recover the private key. Fixed in OpenSSL 1.1.1a (Affected 1.1.1). Fixed in OpenSSL 1.1.0j (Affected 1.1.0-1.1.0i). Fixed in OpenSSL 1.0.2q (Affected 1.0.2-1.0.2p).",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2018-0734",
       "severity": "Low",
@@ -4695,7 +4695,7 @@
         }
       ],
       "description": "The OpenSSL ECDSA signature algorithm has been shown to be vulnerable to a timing side channel attack. An attacker could use variations in the signing algorithm to recover the private key. Fixed in OpenSSL 1.1.0j (Affected 1.1.0-1.1.0i). Fixed in OpenSSL 1.1.1a (Affected 1.1.1).",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2018-0735",
       "severity": "Low",
@@ -4764,7 +4764,7 @@
         }
       ],
       "description": "OpenSSL RSA key generation was found to be vulnerable to cache side-channel attacks. An attacker with sufficient access to mount cache timing attacks during the RSA key generation process could recover parts of the private key.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2018-0737",
       "severity": "Low",
@@ -4847,7 +4847,7 @@
         }
       ],
       "description": "Constructed ASN.1 types with a recursive definition (such as can be found in PKCS7) could eventually exceed the stack given malicious input with excessive recursion. This could result in a Denial Of Service attack. There are no such structures used within SSL/TLS that come from untrusted sources so this is considered safe. Fixed in OpenSSL 1.1.0h (Affected 1.1.0-1.1.0g). Fixed in OpenSSL 1.0.2o (Affected 1.0.2b-1.0.2n).",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2018-0739",
       "severity": "Medium",
@@ -4893,7 +4893,7 @@
         }
       ],
       "description": "aio-libs aiohttp-session contains a Session Fixation vulnerability in load_session function for RedisStorage (see: https://github.com/aio-libs/aiohttp-session/blob/master/aiohttp_session/redis_storage.py#L42) that can result in Session Hijacking. This attack appear to be exploitable via Any method that allows setting session cookies (?session=<>, or meta tags or script tags with Set-Cookie).",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "nvd",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-1000519",
       "severity": "Medium",
@@ -4940,7 +4940,7 @@
         }
       ],
       "description": "Unbounded memory allocation in Google Guava 11.0 through 24.x before 24.1.1 allows remote attackers to conduct denial of service attacks against servers that depend on this library and deserialize attacker-provided data, because the AtomicDoubleArray class (when serialized with Java serialization) and the CompoundOrdering class (when serialized with GWT serialization) perform eager allocation without appropriate checks on what a client has sent and whether the data size is reasonable.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "nvd",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
       "severity": "Medium",
@@ -4987,7 +4987,7 @@
         }
       ],
       "description": "Unbounded memory allocation in Google Guava 11.0 through 24.x before 24.1.1 allows remote attackers to conduct denial of service attacks against servers that depend on this library and deserialize attacker-provided data, because the AtomicDoubleArray class (when serialized with Java serialization) and the CompoundOrdering class (when serialized with GWT serialization) perform eager allocation without appropriate checks on what a client has sent and whether the data size is reasonable.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "nvd",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
       "severity": "Medium",
@@ -5033,7 +5033,7 @@
         }
       ],
       "description": "The mintToken function of a smart contract implementation for APP, an Ethereum token, has an integer overflow that allows the owner of the contract to set the balance of an arbitrary user to any value.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "nvd",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-13661",
       "severity": "High",
@@ -5079,7 +5079,7 @@
         }
       ],
       "description": "The mintToken function of a smart contract implementation for APP, an Ethereum token, has an integer overflow that allows the owner of the contract to set the balance of an arbitrary user to any value.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "nvd",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-13661",
       "severity": "High",
@@ -5155,7 +5155,7 @@
         }
       ],
       "description": "A microprocessor side-channel vulnerability was found on SMT (e.g, Hyper-Threading) architectures. An attacker running a malicious process on the same core of the processor as the victim process can extract certain secret information.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2018-5407",
       "severity": "Medium",
@@ -5217,7 +5217,7 @@
         }
       ],
       "description": "It was found that the `:source!` command was not restricted by the sandbox mode. If modeline was explicitly enabled, opening a specially crafted text file in vim could result in arbitrary command execution.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2019-12735",
       "severity": "High",
@@ -5279,7 +5279,7 @@
         }
       ],
       "description": "A flaw was found in dbus. The implementation of DBUS_COOKIE_SHA1 is susceptible to a symbolic link attack. A malicious client with write access to its own home directory could manipulate a ~/.dbus-keyrings symlink to cause the DBusServer to read and write in unintended locations resulting in an authentication bypass. The highest threat from this vulnerability is to data confidentiality and integrity as well as system availability.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2019-12749",
       "severity": "High",
@@ -5341,7 +5341,7 @@
         }
       ],
       "description": "A flaw was found in dbus. The implementation of DBUS_COOKIE_SHA1 is susceptible to a symbolic link attack. A malicious client with write access to its own home directory could manipulate a ~/.dbus-keyrings symlink to cause the DBusServer to read and write in unintended locations resulting in an authentication bypass. The highest threat from this vulnerability is to data confidentiality and integrity as well as system availability.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2019-12749",
       "severity": "High",
@@ -5417,7 +5417,7 @@
         }
       ],
       "description": "If an application encounters a fatal protocol error and then calls SSL_shutdown() twice (once to send a close_notify, and once to receive one) then OpenSSL can respond differently to the calling application if a 0 byte record is received with invalid padding compared to if a 0 byte record is received with an invalid MAC. If the application then behaves differently based on that in a way that is detectable to the remote peer, then this amounts to a padding oracle that could be used to decrypt data. In order for this to be exploitable \"non-stitched\" ciphersuites must be in use. Stitched ciphersuites are optimised implementations of certain commonly used ciphersuites. Also the application must call SSL_shutdown() twice even if a protocol error has occurred (applications should not do this but some do anyway). Fixed in OpenSSL 1.0.2r (Affected 1.0.2-1.0.2q).",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2019-1559",
       "severity": "Medium",
@@ -5486,7 +5486,7 @@
         }
       ],
       "description": "In Lib/tarfile.py in Python through 3.8.3, an attacker is able to craft a TAR archive leading to an infinite loop when opened by tarfile.open, because _proc_pax lacks header validation.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2019-20907",
       "severity": "Medium",
@@ -5555,7 +5555,7 @@
         }
       ],
       "description": "In Lib/tarfile.py in Python through 3.8.3, an attacker is able to craft a TAR archive leading to an infinite loop when opened by tarfile.open, because _proc_pax lacks header validation.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2019-20907",
       "severity": "Medium",
@@ -5617,7 +5617,7 @@
         }
       ],
       "description": "An uncontrolled resource consumption vulnerability was discovered in D-Bus. The DBusServer leaks file descriptors when a message exceeds the per-message file descriptor limit. This flaw allows a local attacker with access to the D-Bus system bus or another system service's private AF_UNIX socket, to make the system service reach its file descriptor limit, denying service to subsequent D-Bus clients. As a result, the system may become unusable for other users, and some services may stop working. The highest threat from this vulnerability is to system availability.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2020-12049",
       "severity": "High",
@@ -5679,7 +5679,7 @@
         }
       ],
       "description": "An uncontrolled resource consumption vulnerability was discovered in D-Bus. The DBusServer leaks file descriptors when a message exceeds the per-message file descriptor limit. This flaw allows a local attacker with access to the D-Bus system bus or another system service's private AF_UNIX socket, to make the system service reach its file descriptor limit, denying service to subsequent D-Bus clients. As a result, the system may become unusable for other users, and some services may stop working. The highest threat from this vulnerability is to system availability.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2020-12049",
       "severity": "High",
@@ -5741,7 +5741,7 @@
         }
       ],
       "description": "A null pointer dereference flaw was found in openssl. A remote attacker, able to control the arguments of the GENERAL_NAME_cmp function, could cause the application, compiled with openssl to crash resulting in a denial of service. The highest threat from this vulnerability is to system availability.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2020-1971",
       "severity": "High",
@@ -5803,7 +5803,7 @@
         }
       ],
       "description": "A flaw was found in the way NSS handled CCS (ChangeCipherSpec) messages in TLS 1.3. This flaw allows a remote attacker to send multiple CCS messages, causing a denial of service for servers compiled with the NSS library. The highest threat from this vulnerability is to system availability.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2020-25648",
       "severity": "Medium",
@@ -5865,7 +5865,7 @@
         }
       ],
       "description": "A flaw was found in the way NSS handled CCS (ChangeCipherSpec) messages in TLS 1.3. This flaw allows a remote attacker to send multiple CCS messages, causing a denial of service for servers compiled with the NSS library. The highest threat from this vulnerability is to system availability.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2020-25648",
       "severity": "Medium",
@@ -5927,7 +5927,7 @@
         }
       ],
       "description": "A flaw was found in the way NSS handled CCS (ChangeCipherSpec) messages in TLS 1.3. This flaw allows a remote attacker to send multiple CCS messages, causing a denial of service for servers compiled with the NSS library. The highest threat from this vulnerability is to system availability.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2020-25648",
       "severity": "Medium",
@@ -5989,7 +5989,7 @@
         }
       ],
       "description": "A NULL pointer dereference flaw was found in the OpenLDAP server, during a request for renaming RDNs. This flaw allows a remote, unauthenticated attacker to crash the slapd process by sending a specially crafted request, causing a denial of service. The highest threat from this vulnerability is to system availability.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2020-25692",
       "severity": "Medium",
@@ -6051,7 +6051,7 @@
         }
       ],
       "description": "A flaw was found in curl. Overwriting local files is possible when using a certain combination of command line options. Requesting content from a malicious server could lead to overwriting local files with compromised files leading to unknown effects. The highest threat from this vulnerability is to file integrity.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2020-8177",
       "severity": "Medium",
@@ -6113,7 +6113,7 @@
         }
       ],
       "description": "A flaw was found in curl. Overwriting local files is possible when using a certain combination of command line options. Requesting content from a malicious server could lead to overwriting local files with compromised files leading to unknown effects. The highest threat from this vulnerability is to file integrity.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2020-8177",
       "severity": "Medium",
@@ -6160,7 +6160,7 @@
         }
       ],
       "description": "A temp directory creation vulnerability exists in all versions of Guava, allowing an attacker with access to the machine to potentially access data in a temporary directory created by the Guava API com.google.common.io.Files.createTempDir(). By default, on unix-like systems, the created directory is world-readable (readable by an attacker with access to the system). The method in question has been marked @Deprecated in versions 30.0 and later and should not be used. For Android developers, we recommend choosing a temporary directory API provided by Android, such as context.getCacheDir(). For other Java developers, we recommend migrating to the Java 7 API java.nio.file.Files.createTempDirectory() which explicitly configures permissions of 700, or configuring the Java runtime's java.io.tmpdir system property to point to a location whose permissions are appropriately configured.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "nvd",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
       "severity": "Low",
@@ -6207,7 +6207,7 @@
         }
       ],
       "description": "A temp directory creation vulnerability exists in all versions of Guava, allowing an attacker with access to the machine to potentially access data in a temporary directory created by the Guava API com.google.common.io.Files.createTempDir(). By default, on unix-like systems, the created directory is world-readable (readable by an attacker with access to the system). The method in question has been marked @Deprecated in versions 30.0 and later and should not be used. For Android developers, we recommend choosing a temporary directory API provided by Android, such as context.getCacheDir(). For other Java developers, we recommend migrating to the Java 7 API java.nio.file.Files.createTempDirectory() which explicitly configures permissions of 700, or configuring the Java runtime's java.io.tmpdir system property to point to a location whose permissions are appropriately configured.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "nvd",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
       "severity": "Low",
@@ -6253,7 +6253,7 @@
         }
       ],
       "description": "aiohttp is an asynchronous HTTP client/server framework for asyncio and Python. In aiohttp before version 3.7.4 there is an open redirect vulnerability. A maliciously crafted link to an aiohttp-based web-server could redirect the browser to a different website. It is caused by a bug in the `aiohttp.web_middlewares.normalize_path_middleware` middleware. This security problem has been fixed in 3.7.4. Upgrade your dependency using pip as follows \"pip install aiohttp >= 3.7.4\". If upgrading is not an option for you, a workaround can be to avoid using `aiohttp.web_middlewares.normalize_path_middleware` in your applications.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "nvd",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21330",
       "severity": "Medium",
@@ -6299,7 +6299,7 @@
         }
       ],
       "description": "xmldom is a pure JavaScript W3C standard-based (XML DOM Level 2 Core) DOMParser and XMLSerializer module. xmldom versions 0.4.0 and older do not correctly preserve system identifiers, FPIs or namespaces when repeatedly parsing and serializing maliciously crafted documents. This may lead to unexpected syntactic changes during XML processing in some downstream applications. This is fixed in version 0.5.0. As a workaround downstream applications can validate the input and reject the maliciously crafted documents.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "nvd",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21366",
       "severity": "Medium",
@@ -6345,7 +6345,7 @@
         }
       ],
       "description": "xmldom is a pure JavaScript W3C standard-based (XML DOM Level 2 Core) DOMParser and XMLSerializer module. xmldom versions 0.4.0 and older do not correctly preserve system identifiers, FPIs or namespaces when repeatedly parsing and serializing maliciously crafted documents. This may lead to unexpected syntactic changes during XML processing in some downstream applications. This is fixed in version 0.5.0. As a workaround downstream applications can validate the input and reject the maliciously crafted documents.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "nvd",
       "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21366",
       "severity": "Medium",
@@ -6412,7 +6412,7 @@
         }
       ],
       "description": "Calls to EVP_CipherUpdate, EVP_EncryptUpdate and EVP_DecryptUpdate may overflow the output length argument in some cases where the input length is close to the maximum permissible length for an integer on the platform. In such cases the return value from the function call will be 1 (indicating success), but the output length value will be negative. This could cause applications to behave incorrectly or crash.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2021-23840",
       "severity": "Medium",
@@ -6486,7 +6486,7 @@
         }
       ],
       "description": "The OpenSSL public API function X509_issuer_and_serial_hash() attempts to create a unique hash value based on the issuer and serial number data contained within an X509 certificate. However it fails to correctly handle any errors that may occur while parsing the issuer field (which might occur if the issuer field is maliciously constructed). This may subsequently result in a NULL pointer deref and a crash leading to a potential denial of service attack.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2021-23841",
       "severity": "Medium",
@@ -6548,7 +6548,7 @@
         }
       ],
       "description": "An issue was discovered in GNOME GLib before 2.66.6 and 2.67.x before 2.67.3. The function g_bytes_new has an integer overflow on 64-bit platforms due to an implicit cast from 64 bits to 32 bits. The overflow could potentially lead to memory corruption.",
-      "feed": "grypedb",
+      "feed": "vulnerabilities",
       "feed_group": "rhel:7",
       "link": "https://access.redhat.com/security/cve/CVE-2021-27219",
       "severity": "High",


### PR DESCRIPTION
This PR renames the grypedb feed to vulnerabilities in the vulnerability report.
I originally had this change in https://github.com/anchore/anchore-engine/pull/1188, but forgot to reproduce it in https://github.com/anchore/anchore-engine/pull/1192.
