### PR TITLE
Feed index rename

### DIFF
--- a/anchore_engine/db/entities/catalog.py
+++ b/anchore_engine/db/entities/catalog.py
@@ -21,16 +21,16 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import relationship
 
-from anchore_engine.util.time import datetime_to_rfc3339
-
-from .common import (
+from anchore_engine.db.entities.common import (
     Base,
     StringJSON,
     UtilMixin,
     anchore_now,
     anchore_now_datetime,
     anchore_uuid,
+    truncate_index_name,
 )
+from anchore_engine.util.time import datetime_to_rfc3339
 
 
 class Anchore(Base, UtilMixin):
@@ -148,14 +148,14 @@ class Event(Base, UtilMixin):
     timestamp = Column(DateTime)
 
     __table_args__ = (
-        Index("ix_timestamp", timestamp.desc()),
-        Index("ix_resource_user_id", resource_user_id),
-        Index("ix_resource_type", resource_type),
-        Index("ix_resource_id", resource_id),
-        Index("ix_source_servicename", source_servicename),
-        Index("ix_source_hostid", source_hostid),
-        Index("ix_level", level),
-        Index("ix_type", type),
+        Index(truncate_index_name("ix_timestamp"), timestamp.desc()),
+        Index(truncate_index_name("ix_resource_user_id"), resource_user_id),
+        Index(truncate_index_name("ix_resource_type"), resource_type),
+        Index(truncate_index_name("ix_resource_id"), resource_id),
+        Index(truncate_index_name("ix_source_servicename"), source_servicename),
+        Index(truncate_index_name("ix_source_hostid"), source_hostid),
+        Index(truncate_index_name("ix_level"), level),
+        Index(truncate_index_name("ix_type"), type),
     )
 
     def __repr__(self):
@@ -767,7 +767,10 @@ class ImageImportOperation(Base, UtilMixin):
     )
     contents = relationship("ImageImportContent", back_populates="operation")
 
-    __table_args__ = (Index("ix_image_imports_account", account), {})
+    __table_args__ = (
+        Index(truncate_index_name("ix_image_imports_account"), account),
+        {},
+    )
 
     def to_json(self):
         j = super().to_json()

--- a/anchore_engine/db/entities/identity.py
+++ b/anchore_engine/db/entities/identity.py
@@ -3,10 +3,16 @@ import time
 
 from authlib.integrations.sqla_oauth2.client_mixin import OAuth2ClientMixin
 from authlib.integrations.sqla_oauth2.tokens_mixins import TokenMixin
-from sqlalchemy import Boolean, Column, Enum, ForeignKey, Integer, String, Text, Index
+from sqlalchemy import Boolean, Column, Enum, ForeignKey, Index, Integer, String, Text
 from sqlalchemy.orm import relationship
 
-from anchore_engine.db.entities.common import Base, UtilMixin, anchore_now, anchore_uuid
+from anchore_engine.db.entities.common import (
+    Base,
+    UtilMixin,
+    anchore_now,
+    anchore_uuid,
+    truncate_index_name,
+)
 
 
 class AccountTypes(enum.Enum):
@@ -99,8 +105,8 @@ class AccountUser(Base, UtilMixin):
     )
 
     __table_args__ = (
-        Index("ix_account_users_account_name", account_name),
-        Index("ix_account_users_uuid", uuid, unique=True),
+        Index(truncate_index_name("ix_account_users_account_name"), account_name),
+        Index(truncate_index_name("ix_account_users_uuid"), uuid, unique=True),
     )
 
     def to_dict(self):
@@ -167,7 +173,10 @@ class OAuth2Token(Base, UtilMixin, TokenMixin):
     issued_at = Column(Integer, nullable=False, default=lambda: int(time.time()))
     expires_in = Column(Integer, nullable=False, default=0)
 
-    __table_args__ = (Index("ix_oauth2_tokens_refresh_token", refresh_token), {})
+    __table_args__ = (
+        Index(truncate_index_name("ix_oauth2_tokens_refresh_token"), refresh_token),
+        {},
+    )
 
     def get_scope(self):
         return self.scope

--- a/anchore_engine/db/entities/policy_engine.py
+++ b/anchore_engine/db/entities/policy_engine.py
@@ -31,7 +31,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import joinedload, relationship, synonym
 
 from anchore_engine.common.models.policy_engine import CVSS, NVDReference
-from anchore_engine.db.entities.common import anchore_now_datetime
+from anchore_engine.db.entities.common import anchore_now_datetime, truncate_index_name
 from anchore_engine.util.apk import compare_versions as apkg_compare_versions
 from anchore_engine.util.deb import compare_versions as dpkg_compare_versions
 from anchore_engine.util.langpack import compare_versions as langpack_compare_versions
@@ -167,7 +167,9 @@ class GrypeDBFeedMetadata(Base):
     groups = Column(JSONB, default=[])
 
     __table_args__ = (
-        Index("ix_grype_db_feed_metadata_db_checksum", db_checksum),
+        Index(
+            truncate_index_name("ix_grype_db_feed_metadata_db_checksum"), db_checksum
+        ),
         {},
     )
 
@@ -865,7 +867,9 @@ class NvdV2Metadata(Base):
     )
 
     __table_args__ = (
-        Index("ix_feed_data_nvdv2_vulnerabilities_severity", severity),
+        Index(
+            truncate_index_name("ix_feed_data_nvdv2_vulnerabilities_severity"), severity
+        ),
         {},
     )
 
@@ -1114,7 +1118,10 @@ class VulnDBMetadata(Base):
     )
 
     __table_args__ = (
-        Index("ix_feed_data_vulndb_vulnerabilities_severity", severity),
+        Index(
+            truncate_index_name("ix_feed_data_vulndb_vulnerabilities_severity"),
+            severity,
+        ),
         {},
     )
 
@@ -1733,9 +1740,13 @@ class CpeVulnerability(Base):
                 NvdMetadata.severity,
             ),
         ),
-        Index("ix_feed_data_cpe_vulnerabilities_name_version", name, version),
         Index(
-            "ix_feed_data_cpe_vulnerabilities_fk",
+            truncate_index_name("ix_feed_data_cpe_vulnerabilities_name_version"),
+            name,
+            version,
+        ),
+        Index(
+            truncate_index_name("ix_feed_data_cpe_vulnerabilities_fk"),
             vulnerability_id,
             namespace_name,
             severity,
@@ -1805,9 +1816,15 @@ class CpeV2Vulnerability(Base):
             columns=(vulnerability_id, namespace_name),
             refcolumns=(NvdV2Metadata.name, NvdV2Metadata.namespace_name),
         ),
-        Index("ix_feed_data_cpev2_vulnerabilities_name_version", product, version),
         Index(
-            "ix_feed_data_cpev2_vulnerabilities_fk", vulnerability_id, namespace_name
+            truncate_index_name("ix_feed_data_cpev2_vulnerabilities_name_version"),
+            product,
+            version,
+        ),
+        Index(
+            truncate_index_name("ix_feed_data_cpev2_vulnerabilities_fk"),
+            vulnerability_id,
+            namespace_name,
         ),
         {},
     )
@@ -1910,8 +1927,16 @@ class VulnDBCpe(Base):
             columns=(vulnerability_id, namespace_name),
             refcolumns=(VulnDBMetadata.name, VulnDBMetadata.namespace_name),
         ),
-        Index("ix_feed_data_vulndb_affected_cpes_product_version", product, version),
-        Index("ix_feed_data_vulndb_affected_cpes_fk", vulnerability_id, namespace_name),
+        Index(
+            truncate_index_name("ix_feed_data_vulndb_affected_cpes_product_version"),
+            product,
+            version,
+        ),
+        Index(
+            truncate_index_name("ix_feed_data_vulndb_affected_cpes_fk"),
+            vulnerability_id,
+            namespace_name,
+        ),
         {},
     )
 
@@ -2447,7 +2472,7 @@ class ImageCpe(Base):
             columns=(image_id, image_user_id),
             refcolumns=("images.id", "images.user_id"),
         ),
-        Index("ix_image_cpe_user_img", image_id, image_user_id),
+        Index(truncate_index_name("ix_image_cpe_user_img"), image_id, image_user_id),
         {},
     )
 
@@ -3402,8 +3427,14 @@ class ImageVulnerabilitiesReport(Base, StorageInterface):
     )
 
     __table_args__ = (
-        Index("ix_image_vulnerabilities_reports_report_key", report_key),
-        Index("ix_image_vulnerabilities_reports_generated_at", generated_at),
+        Index(
+            truncate_index_name("ix_image_vulnerabilities_reports_report_key"),
+            report_key,
+        ),
+        Index(
+            truncate_index_name("ix_image_vulnerabilities_reports_generated_at"),
+            generated_at,
+        ),
     )
 
 


### PR DESCRIPTION
This PR adds new common db utility to truncate index names in a reproducible way that matches sqlalchemy's default naming convention but is FIPS compliant. All uses of sqlalchemy.Index were updated to use new truncate_index_name function.

Sources used to verify approach:
https://docs.sqlalchemy.org/en/14/core/constraints.html#the-default-naming-convention
https://docs.sqlalchemy.org/en/14/core/metadata.html#sqlalchemy.schema.MetaData.params.naming_convention

Query used to check index names:

```
SELECT
    tablename,
    indexname
FROM
    pg_indexes
WHERE indexname LIKE 'ix_%'
ORDER BY
    tablename,
    indexname;
```