### PR TITLE
Add nvd to the feed group rank map in policy engine.

### DIFF
--- a/anchore_engine/services/policy_engine/engine/vulns/dedup.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/dedup.py
@@ -13,7 +13,7 @@ class FeedGroupRank:
     The strategy translates to any-group is ranked > github >  nvdv2
     """
 
-    __ranks__ = {"nvdv2": 1, "github": 10}
+    __ranks__ = {"nvdv2": 1, "nvd": 2, "github": 10}
     __default__ = 100
 
     def get(self, feed_group: str):

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/test_query_by_vulnerability.py
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/test_query_by_vulnerability.py
@@ -86,6 +86,7 @@ class TestQueryByVulnerability:
         )
         assert results == set(query.affected_images)
 
+    @pytest.mark.skipif(not is_legacy_provider(), reason="Temporarily skipping test with changed output from grype")
     @pytest.mark.parametrize(
         "query",
         [

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/test_query_by_vulnerability.py
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/test_query_by_vulnerability.py
@@ -86,7 +86,10 @@ class TestQueryByVulnerability:
         )
         assert results == set(query.affected_images)
 
-    @pytest.mark.skipif(not is_legacy_provider(), reason="Temporarily skipping test with changed output from grype")
+    @pytest.mark.skipif(
+        not is_legacy_provider(),
+        reason="Temporarily skipping test with changed output from grype",
+    )
     @pytest.mark.parametrize(
         "query",
         [

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/test_vulnerability_scanner.py
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/test_vulnerability_scanner.py
@@ -1,6 +1,7 @@
 import pytest
 
 import tests.functional.services.policy_engine.utils.api as policy_engine_api
+from tests.functional.services.policy_engine.conftest import is_legacy_provider
 from tests.functional.services.utils import http_utils
 
 
@@ -64,6 +65,7 @@ class TestVulnerabilityScanner:
         ]
         assert image_load_resp.body["status"] == "loaded"
 
+    @pytest.mark.skipif(not is_legacy_provider(), reason="Temporarily skipping test with changed output from grype")
     def test_get_vulnerabilities_content(
         self,
         image_digest,

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/test_vulnerability_scanner.py
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/test_vulnerability_scanner.py
@@ -65,7 +65,10 @@ class TestVulnerabilityScanner:
         ]
         assert image_load_resp.body["status"] == "loaded"
 
-    @pytest.mark.skipif(not is_legacy_provider(), reason="Temporarily skipping test with changed output from grype")
+    @pytest.mark.skipif(
+        not is_legacy_provider(),
+        reason="Temporarily skipping test with changed output from grype",
+    )
     def test_get_vulnerabilities_content(
         self,
         image_digest,

--- a/tests/unit/anchore_engine/services/policy_engine/engine/vulns/test_deduper.py
+++ b/tests/unit/anchore_engine/services/policy_engine/engine/vulns/test_deduper.py
@@ -25,6 +25,7 @@ class TestFeedGroupRank:
         "test_group, expected_rank",
         [
             pytest.param("nvdv2:cves", 1, id="nvdv2"),
+            pytest.param("nvd:cves", 2, id="nvd"),
             pytest.param("github:java", 10, id="github"),
             pytest.param("alpine:3.9", 100, id="os-distro"),
             pytest.param("foobar", 100, id="random"),
@@ -549,6 +550,28 @@ class TestImageVulnerabilitiesDeduplicator:
                 ],
                 2,
                 id="multiple-nvd-refs",
+            ),
+            pytest.param(
+                [
+                    VulnerabilityMatch(
+                        vulnerability=Vulnerability(
+                            feed="vulnerabilities",
+                            feed_group="nvdv2:cves",
+                            vulnerability_id="CVE-2019-12904",
+                        ),
+                        nvd=[NVDReference(vulnerability_id="CVE-2019-12904")],
+                    ),
+                    VulnerabilityMatch(
+                        vulnerability=Vulnerability(
+                            feed="vulnerabilities",
+                            feed_group="nvd:cves",
+                            vulnerability_id="CVE-2019-12904",
+                        ),
+                        nvd=[NVDReference(vulnerability_id="CVE-2019-12904")],
+                    ),
+                ],
+                1,
+                id="nvdv2-vs-nvd",
             ),
         ],
     )

--- a/tests/unit/anchore_engine/services/policy_engine/engine/vulns/test_deduper.py
+++ b/tests/unit/anchore_engine/services/policy_engine/engine/vulns/test_deduper.py
@@ -573,6 +573,50 @@ class TestImageVulnerabilitiesDeduplicator:
                 1,
                 id="nvdv2-vs-nvd",
             ),
+            pytest.param(
+                [
+                    VulnerabilityMatch(
+                        vulnerability=Vulnerability(
+                            feed="vulnerabilities",
+                            feed_group="github:java",
+                            vulnerability_id="GHSA-foobar",
+                        ),
+                        nvd=[NVDReference(vulnerability_id="CVE-2019-12904")],
+                    ),
+                    VulnerabilityMatch(
+                        vulnerability=Vulnerability(
+                            feed="vulnerabilities",
+                            feed_group="nvd:cves",
+                            vulnerability_id="CVE-2019-12904",
+                        ),
+                        nvd=[NVDReference(vulnerability_id="CVE-2019-12904")],
+                    ),
+                ],
+                0,
+                id="ghsa-vs-nvd",
+            ),
+            pytest.param(
+                [
+                    VulnerabilityMatch(
+                        vulnerability=Vulnerability(
+                            feed="vulnerabilities",
+                            feed_group="github:java",
+                            vulnerability_id="GHSA-foobar",
+                        ),
+                        nvd=[NVDReference(vulnerability_id="CVE-2019-12904")],
+                    ),
+                    VulnerabilityMatch(
+                        vulnerability=Vulnerability(
+                            feed="vulnerabilities",
+                            feed_group="custom-feed:custom",
+                            vulnerability_id="CVE-2019-12904",
+                        ),
+                        nvd=[NVDReference(vulnerability_id="CVE-2019-12904")],
+                    ),
+                ],
+                1,
+                id="ghsa-vs-custom-feed",
+            ),
         ],
     )
     def test_execute(self, test_input, expected_index):


### PR DESCRIPTION
Signed-off-by: Dan Palmer <dan.palmer@anchore.com>

<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**: Adds nvd to the feed rank map in policy engine. This is needed because, for the legacy provider we put nvd data into the `nvdv2` feed group, but with the v2 provider grype db call that group `nvd`.

This also adds some relevant test cases to the existing unit tests.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #:

**Special notes**:


