### PR TITLE
Catalog API for returning all or multiple types of image content

### DIFF
--- a/anchore_engine/clients/services/catalog.py
+++ b/anchore_engine/clients/services/catalog.py
@@ -118,6 +118,21 @@ class CatalogClient(InternalServiceClient):
             path_params={"image_digest": image_digest, "content_type": content_type},
         )
 
+    def get_image_content_multiple_types(
+        self, image_digest, content_types=None, allow_analyzing_state=False
+    ):
+        return self.call_api(
+            http.anchy_get,
+            "images/{image_digest}/content",
+            path_params={"image_digest": image_digest},
+            query_params={
+                "content_types": ",".join(content_types)
+                if content_types and isinstance(content_types, list)
+                else None,
+                "allow_analyzing_state": allow_analyzing_state,
+            },
+        )
+
     def get_image_by_id(self, imageId):
         return self.call_api(
             http.anchy_get, "images", query_params={"imageId": imageId}

--- a/anchore_engine/services/catalog/image_content/get_image_content.py
+++ b/anchore_engine/services/catalog/image_content/get_image_content.py
@@ -1,9 +1,11 @@
 import base64
 import json
+from typing import Dict, List
 
 import anchore_engine
 from anchore_engine import db, utils
 from anchore_engine.apis.exceptions import BadRequest, ResourceNotFound
+from anchore_engine.common import image_content_types
 from anchore_engine.common.helpers import make_anchore_exception
 from anchore_engine.db import db_catalog_image
 from anchore_engine.services.apiext.api import helpers
@@ -162,3 +164,76 @@ class ImageDockerfileContentGetter(ImageContentGetter):
         return helpers.make_image_content_response(
             self.content_type, image_content_data[self.content_type]
         )
+
+
+class MultipleContentTypesGetter(ImageContentGetter):
+    """
+    Image content getter extension for returning multiple or all content types (not metadata such as dockerfile and manfiest)
+    and associated content. Does not raise an error if the requested content type can't be found unlike the parent class
+    """
+
+    __normalize_to_user_format_on_load__ = False
+    __verify_content_type__ = False
+
+    def __init__(self, account_id: str, content_types: List[str], image_digest: str):
+        super(MultipleContentTypesGetter, self).__init__(
+            account_id=account_id, content_type=None, image_digest=image_digest
+        )
+        if content_types and isinstance(content_types, list):
+            self.content_types = [item.lower() for item in content_types]
+
+    def _is_content_type_match(self, content_type: str) -> bool:
+        """
+        Checks if the input content type is a supported content-type and is one of the requested content types.
+        If the keyword `all` is present in the requested content types, the function returns True as long as the input
+        is a supported content type
+        """
+        if not content_type or content_type not in image_content_types:
+            # not a supported content type, return False
+            return False
+        elif "all" in self.content_types:
+            # all content types requested, return True since it's a support type
+            return True
+        else:
+            return content_type.lower() in self.content_types
+
+    def hydrate_additional_data(
+        self, image_content_data: Dict, image_report
+    ) -> Dict[str, List[Dict]]:
+        """
+        Expects the image_content_data dictionary with key-value pairs where each key is content type and value is a
+        list of packages.
+
+        For an input like below
+        {
+          "java": {
+            "identifier": {package}
+          },
+          "os": [
+            "identifier": {package}
+          ]
+        }
+
+        Output looks something like this
+        {
+          "java": [
+            {package}
+          ],
+          "os": [
+            {package}
+          ]
+        }
+        """
+        results = {}
+
+        if not image_content_data or not self.content_types:
+            return results
+
+        # gather content for requested types, 'all' is a shortcut to retrieve everything
+        results = {
+            c_type: helpers.make_image_content_response(c_type, packages)
+            for c_type, packages in image_content_data.items()
+            if self._is_content_type_match(c_type)
+        }
+
+        return results

--- a/anchore_engine/services/catalog/swagger/swagger.yaml
+++ b/anchore_engine/services/catalog/swagger/swagger.yaml
@@ -352,6 +352,41 @@ paths:
           schema:
             type: object
       x-swagger-router-controller: "anchore_engine.services.catalog.api.controllers.default_controller"
+  /images/{image_digest}/content:
+    get:
+      tags:
+        - "catalog"
+      summary: "Get image content for one or more content types"
+      description: ""
+      operationId: "get_image_content_multiple_types"
+      parameters:
+        - name: 'image_digest'
+          in: path
+          type: string
+          description: "Digest of image to retrieve content"
+          required: true
+        - name: 'content_types'
+          in: query
+          type: array
+          items:
+            type: string
+          collectionFormat: csv
+          required: false
+          description: "Image content types to retrieve. If left blank, all content types will be returned"
+        - name: 'allow_analyzing_state'
+          in: query
+          type: boolean
+          description: "Flag to retrieve content for images in analyzing state. Default is set to false, the API error out for images in analyzing state"
+          required: false
+          default: false
+      produces:
+        - "application/json"
+      responses:
+        200:
+          description: "success"
+          schema:
+            type: object
+      x-swagger-router-controller: "anchore_engine.services.catalog.api.controllers.default_controller"
   /registry_lookup:
     get:
       tags:

--- a/tests/unit/anchore_engine/services/catalog/test_image_content_getter.py
+++ b/tests/unit/anchore_engine/services/catalog/test_image_content_getter.py
@@ -1,0 +1,36 @@
+import pytest
+
+from anchore_engine.services.catalog.image_content.get_image_content import (
+    MultipleContentTypesGetter,
+)
+from anchore_engine.subsys.object_store import manager
+
+
+class TestMultipleContentTypesGetter:
+    @pytest.fixture
+    def initialize_storage_manager(self):
+        manager.manager_singleton = {manager.DEFAULT_OBJECT_STORE_MANAGER_ID: "bar"}
+
+    @pytest.mark.parametrize(
+        "request_types, content_type, expected",
+        [
+            pytest.param([], "", False, id="blank-blank"),
+            pytest.param(None, None, False, id="none-none"),
+            pytest.param([], None, False, id="blank-none"),
+            pytest.param(None, "", False, id="none-blank"),
+            pytest.param(["all"], "manifest", False, id="all-manifest"),
+            pytest.param(["all"], "dockerfile", False, id="all-dockerfile"),
+            pytest.param(["all"], "binary", True, id="all-supported"),
+            pytest.param(["java"], "npm", False, id="supported-not-match"),
+            pytest.param(["gem"], "gem", True, id="supported-match"),
+        ],
+    )
+    def test_is_content_type_match(
+        self, request_types, content_type, expected, initialize_storage_manager
+    ):
+        assert (
+            MultipleContentTypesGetter(
+                account_id="foo", content_types=request_types, image_digest=""
+            )._is_content_type_match(content_type)
+            == expected
+        )


### PR DESCRIPTION
Internal aka catalog API for returning all or multiple types of content for an image.

There is a similar API in place but it returns content for a single type per request. This is a convenience API to avoid multiple round trips and repetitive processing in catalog. It returns content for multiple types or all types depending on the query params. The implementation is an extension of the existing API.

This is another PR in the series of changes for streamlining the input to ops that operate on image content such as vulnerabilities matching. There is some basic unit test coverage, more functional tests already in the pipeline will also exercise this functionality (cc @zburstein)