### PR TITLE
Fix return in kb mapper function

### DIFF
--- a/anchore_engine/services/policy_engine/engine/vulns/mappers.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/mappers.py
@@ -116,9 +116,9 @@ class KBMapper(PackageMapper):
             "name": record.get("sourcepkg"),
             "version": record.get("version"),
             "type": self.grype_type,
-            "cpes": record.get("cpes", []),
             "locations": [{"path": "registry"}],
         }
+        return artifact
 
 
 class LinuxDistroPackageMapper(PackageMapper):

--- a/tests/unit/anchore_engine/services/policy_engine/engine/vulns/test_mappers.py
+++ b/tests/unit/anchore_engine/services/policy_engine/engine/vulns/test_mappers.py
@@ -221,6 +221,27 @@ class TestImageContentAPIToGrypeSbom:
                 },
                 id="apkg-with-source",
             ),
+            pytest.param(
+                ENGINE_PACKAGE_MAPPERS.get("kb"),
+                {
+                    "cpes": None,
+                    "license": "Unknown",
+                    "licenses": ["Unknown"],
+                    "origin": "Microsoft",
+                    "package": "935509",
+                    "size": "0",
+                    "sourcepkg": "10855",
+                    "type": "kb",
+                    "version": "935509",
+                },
+                {
+                    "name": "10855",
+                    "version": "935509",
+                    "type": "msrc-kb",
+                    "locations": [{"path": "registry"}],
+                },
+                id="microsoft-kb",
+            ),
         ],
     )
     def test_mappers(self, mapper, test_input, expected):


### PR DESCRIPTION
https://github.com/anchore/anchore-engine/pull/1229 updated the mapper functionality to account for sbom generation using image content API response. It introduced a bug - a missing return statement in kb mapper which resulted in a very empty sbom. This PR adds the return statement and adds a unit test that was missed in the previous PR

