### PR TITLE
Fix fixed_artifact issues

### DIFF
--- a/anchore_engine/db/entities/policy_engine.py
+++ b/anchore_engine/db/entities/policy_engine.py
@@ -3042,7 +3042,12 @@ class ImagePackageVulnerability(Base):
         """
         if not fixed_in:
             fixed_in = self.fixed_artifact()
-        return fixed_in and fixed_in.vendor_no_advisory
+
+        return (
+            fixed_in.vendor_no_advisory
+            if fixed_in and isinstance(fixed_in, FixedArtifact)
+            else False
+        )
 
     @classmethod
     def from_pair(cls, package_obj, vuln_obj):

--- a/anchore_engine/services/policy_engine/engine/vulns/providers.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/providers.py
@@ -439,7 +439,7 @@ class LegacyProvider(VulnerabilitiesProvider):
                     nvd_refs = []
 
                 advisories = []
-                if fixed_artifact.fix_metadata:
+                if fixed_artifact and fixed_artifact.fix_metadata:
                     vendor_advisories = fixed_artifact.fix_metadata.get(
                         "VendorAdvisorySummary", []
                     )


### PR DESCRIPTION
PR makes 2 changes:

1. Adds safe navigator to fixed_artifact reference in providers. Resolves error where fixed_artifact is none
2. Ensures that fix_has_no_advisory returns a bool. If fixed_artifact was none in that function, it would return none instead of False