### PR TITLE
Updates grype-to-engine image vulnerabilities mapper

### DIFF
--- a/anchore_engine/services/policy_engine/api/controllers/synchronous_operations.py
+++ b/anchore_engine/services/policy_engine/api/controllers/synchronous_operations.py
@@ -21,7 +21,6 @@ from anchore_engine import apis, utils
 from anchore_engine.apis.authorization import INTERNAL_SERVICE_ALLOWED, get_authorizer
 from anchore_engine.apis.context import ApiRequestContextProxy
 from anchore_engine.clients.services import catalog, internal_client_for
-from anchore_engine.clients.services.common import get_service_endpoint
 from anchore_engine.common.helpers import make_response_error
 
 # API models
@@ -92,24 +91,6 @@ vulnerabilities_cache_enabled = (
     os.getenv("ANCHORE_POLICY_ENGINE_VULNERABILITIES_CACHE_ENABLED", "true").lower()
     == "true"
 )
-
-
-def get_api_endpoint():
-    try:
-        return get_service_endpoint("apiext").strip("/")
-    except:
-        log.warn(
-            "Could not find valid apiext endpoint for links so will use policy engine endpoint instead"
-        )
-        try:
-            return get_service_endpoint("policy_engine").strip("/")
-        except:
-            log.warn(
-                "No policy engine endpoint found either, using default but invalid url"
-            )
-            return "http://<valid endpoint not found>"
-
-    return ""
 
 
 @authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)

--- a/anchore_engine/services/policy_engine/engine/vulns/providers.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/providers.py
@@ -8,7 +8,6 @@ from typing import Dict, List, Optional
 from marshmallow.exceptions import ValidationError
 from sqlalchemy import asc, func, orm
 
-from anchore_engine.clients.services.common import get_service_endpoint
 from anchore_engine.common.helpers import make_response_error
 from anchore_engine.common.models.policy_engine import Advisory, Artifact
 from anchore_engine.common.models.policy_engine import (
@@ -88,6 +87,7 @@ from anchore_engine.services.policy_engine.engine.vulns.stores import (
     ImageVulnerabilitiesStore,
     Status,
 )
+from anchore_engine.services.policy_engine.engine.vulns.utils import get_api_endpoint
 from anchore_engine.subsys import logger, metrics
 from anchore_engine.utils import timer
 
@@ -500,7 +500,7 @@ class LegacyProvider(VulnerabilitiesProvider):
                 if not all_cpe_matches:
                     all_cpe_matches = []
 
-                api_endpoint = self._get_api_endpoint()
+                api_endpoint = get_api_endpoint()
 
                 for image_cpe, vulnerability_cpe in all_cpe_matches:
                     link = vulnerability_cpe.parent.link
@@ -627,7 +627,7 @@ class LegacyProvider(VulnerabilitiesProvider):
 
         logger.spew("Vuln query 1 timing: {}".format(time.time() - t1))
 
-        api_endpoint = self._get_api_endpoint()
+        api_endpoint = get_api_endpoint()
 
         if not namespace or ("nvdv2:cves" in namespace):
             dedupped_return_hash = {}
@@ -937,25 +937,6 @@ class LegacyProvider(VulnerabilitiesProvider):
             advisory_cache[phash] = img_pkg_vuln.fix_has_no_advisory()
 
         return advisory_cache.get(phash)
-
-    @staticmethod
-    def _get_api_endpoint():
-        """
-        Utility function for fetching the url to external api
-        """
-        try:
-            return get_service_endpoint("apiext").strip("/")
-        except:
-            logger.warn(
-                "Could not find valid apiext endpoint for links so will use policy engine endpoint instead"
-            )
-            try:
-                return get_service_endpoint("policy_engine").strip("/")
-            except:
-                logger.warn(
-                    "No policy engine endpoint found either, using default but invalid url"
-                )
-                return "http://<valid endpoint not found>"
 
     def get_sync_util_provider(
         self, sync_configs: Dict[str, SyncConfig]

--- a/anchore_engine/services/policy_engine/engine/vulns/scanners.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/scanners.py
@@ -36,7 +36,7 @@ from anchore_engine.utils import timer
 
 from .cpe_matchers import DistroEnabledCpeMatcher, NonOSCpeMatcher
 from .dedup import get_image_vulnerabilities_deduper
-from .mappers import image_content_to_grype_sbom, to_engine_vulnerabilities
+from .mappers import grype_to_engine_image_vulnerabilities, image_content_to_grype_sbom
 
 # debug option for saving image sbom, defaults to not saving
 SAVE_SBOM_TO_FILE = (
@@ -284,7 +284,7 @@ class GrypeScanner:
 
         # transform grype response to engine vulnerabilities and dedup
         try:
-            results = to_engine_vulnerabilities(grype_response)
+            results = grype_to_engine_image_vulnerabilities(grype_response)
             report.results = get_image_vulnerabilities_deduper().execute(results)
             report.metadata.generated_by = self._get_report_generated_by(grype_response)
         except Exception:

--- a/anchore_engine/services/policy_engine/engine/vulns/utils.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/utils.py
@@ -1,0 +1,21 @@
+from anchore_engine.clients.services.common import get_service_endpoint
+from anchore_engine.subsys import logger as log
+
+
+def get_api_endpoint():
+    """
+    Utility function for fetching the url to external api
+    """
+    try:
+        return get_service_endpoint("apiext").strip("/")
+    except:
+        log.warn(
+            "Could not find valid apiext endpoint for links so will use policy engine endpoint instead"
+        )
+        try:
+            return get_service_endpoint("policy_engine").strip("/")
+        except:
+            log.warn(
+                "No policy engine endpoint found either, using default but invalid url"
+            )
+            return "http://<valid endpoint not found>"


### PR DESCRIPTION
- Build url for vulnerability if grype doesn't return any and point it to the query vulnerabilities API.
- Transform third party vulnerability identifier into CVE identifier when possible