### PR TITLE
Do not block on linting; get other CI feedback too

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,7 +302,6 @@ workflows:
             - unit_tests_38
       - build:
           requires:
-            - lint_38
             - unit_tests_38
       - container_tests:
           name: test_container_dev
@@ -367,7 +366,6 @@ workflows:
       - build:
           filters: *filter_nightly
           requires:
-            - lint_38
             - unit_tests_38
       - container_tests:
           name: test_container_nightly
@@ -502,12 +500,10 @@ workflows:
           tox_env: "py38"
           filters: *filter_rebuild_tags
           requires:
-            - lint_38
             - unit_tests_38
       - build:
           filters: *filter_rebuild_tags
           requires:
-            - lint_38
             - unit_tests_38
       - container_tests:
           name: test_container_rebuild


### PR DESCRIPTION
During a team discussion with @dspalmer99, @nightfurys, @Vijay-P, & @zburstein on 2021-09-03, we agreed to run the full set of tests in CI even if a PR fails linting so that we don't delay the feedback from unit/integration/functional tests. Those tests may fail for reasons that are unlikely to be the same as the linter findings.

The `lint` step will still execute immediately and fail the overall CI job, but the other jobs will not wait on the linting to pass before starting.

You can see the dependency graph by checking the [Circle CI checks on this PR](https://app.circleci.com/pipelines/github/anchore/anchore-engine/3838/workflows/f167e025-4403-463b-ab1a-5e027f97bae9).

To marginally speed up the CI pipeline, we may want to do the same with the unit test job. Chaining the jobs conserves resources by skipping subsequent steps once a job fails, but delays the green light when all tests will pass and also prevents us from seeing all test failures.