### PR TITLE
Set default provider to grype when incorrect config

### DIFF
--- a/anchore_engine/services/policy_engine/engine/vulns/providers.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/providers.py
@@ -1635,7 +1635,7 @@ def set_provider():
             "No implementation found for configured provider %s. Falling back to default",
             provider_name,
         )
-        provider_class = LegacyProvider
+        provider_class = GrypeProvider
 
     PROVIDER = provider_class()
     logger.info("Initialized vulnerabilities provider: %s", PROVIDER.get_config_name())

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -46,3 +46,14 @@ def bundle():
             return json.load(f)
 
     return find
+
+
+@pytest.fixture(autouse=True)
+def set_legacy_provider(monkeysession):
+    def _provider_name(section):
+        return "legacy"
+
+    monkeysession.setattr(
+        "anchore_engine.services.policy_engine.engine.vulns.providers.get_provider_name",
+        _provider_name,
+    )


### PR DESCRIPTION
Sets the fdefault provider to grype when config is neither legacy or grype. Also changes the integration tests to continue to default to legacy because they are not designed for functionality with grype. 