### PR TITLE
Added active criteria in determining if grypedb being synced is new

### DIFF
--- a/anchore_engine/services/policy_engine/engine/feeds/feeds.py
+++ b/anchore_engine/services/policy_engine/engine/feeds/feeds.py
@@ -1071,8 +1071,10 @@ class GrypeDBFeed(LogContextMixin, DataFeed):
             # Check that the data that we downloaded matches the checksum provided
             checksum = record.metadata["checksum"]
             GrypeDBFile.verify_integrity(record.data, checksum)
-            # If there aren't any other database files with the same checksum, then this is a new database file.
-            matches = self._get_db_metadata_records(db, checksum)
+
+            # If there aren't any other active database files with the same checksum, then treat this as a new one
+            matches = self._get_db_metadata_records(db, checksum, True)
+
             if len(matches) == 0:
                 # Cache the file to temporary storage
                 with GrypeDBStorage() as grypedb_file:


### PR DESCRIPTION
We currently store 2 grype db meta records in the db at max. This is done so the old one is preserved as a fallback in the event that the new sync fails. The grypedb sync was failing when attempting to sync a grypedb that was in the GrypeDBFeedMetadata, but not the active record. This was because the logic used to determine if the grypedb currently being synced was new or not was not using the active criteria in determining if it was present. This change resolves that. There is a potentially more performant fix here that switches to the db already on the system rather than reprocessing it, but in the interest of time for upcoming release this resolves the issue


