### PR TITLE
Fix broken policy engine tests for grype provider

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,0 +1,25 @@
+import pytest
+
+from tests.functional.services.api.images import (
+    add_image,
+    delete_image_by_id,
+    get_image_id,
+    wait_for_image_to_analyze,
+)
+from tests.functional.services.utils.http_utils import get_api_conf
+
+
+@pytest.fixture(scope="package")
+def add_image_with_teardown_package_scope(request):
+    def _add_image_with_teardown(tag, api_conf=get_api_conf):
+        # add image
+        add_resp = add_image(tag, api_conf)
+        image_id = get_image_id(add_resp)
+        wait_for_image_to_analyze(image_id, api_conf)
+
+        # add teardown
+        request.addfinalizer(lambda: delete_image_by_id(image_id, api_conf))
+
+        return add_resp
+
+    return _add_image_with_teardown

--- a/tests/functional/services/api/images/__init__.py
+++ b/tests/functional/services/api/images/__init__.py
@@ -1,7 +1,13 @@
 import time
 
 from tests.functional import get_logger
-from tests.functional.services.utils.http_utils import RequestFailedError, http_get
+from tests.functional.services.utils.http_utils import (
+    RequestFailedError,
+    get_api_conf,
+    http_del,
+    http_get,
+    http_post,
+)
 
 WAIT_TIMEOUT_SEC = 60 * 5
 
@@ -65,3 +71,26 @@ def wait_for_image_to_analyze(image_id, api_conf: callable):
                 int(time.time() - start_time_sec)
             )
         )
+
+
+def add_image(tag, api_conf=get_api_conf):
+    add_image_resp = http_post(["images"], {"tag": tag}, config=api_conf)
+    if add_image_resp.code != 200:
+        raise RequestFailedError(
+            add_image_resp.url, add_image_resp.code, add_image_resp.body
+        )
+
+    return add_image_resp
+
+
+def delete_image_by_id(image_id, api_conf=get_api_conf):
+    delete_image_resp = http_del(
+        ["images", "by_id", image_id], query={"force": True}, config=api_conf
+    )
+
+    if delete_image_resp.code != 200:
+        raise RequestFailedError(
+            delete_image_resp.url, delete_image_resp.code, delete_image_resp.body
+        )
+
+    return delete_image_resp

--- a/tests/functional/services/api/repositories/test_post.py
+++ b/tests/functional/services/api/repositories/test_post.py
@@ -10,7 +10,7 @@ class TestRepositoriesAPIGetReturns200:
         resp = http_post(
             ["repositories"],
             None,
-            query={"repository": "docker.io/alpine"},
+            query={"repository": "docker.io/anchore/repo-watcher-testing"},
             config=api_conf,
         )
         assert resp == APIResponse(200)

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/conftest.py
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/conftest.py
@@ -52,6 +52,20 @@ ANALYSIS_FILES: Sequence[AnalysisFile] = [
 ]
 
 IMAGE_DIGEST_ID_MAP: Dict[str, str] = {}
+IMAGE_DIGEST_MAP = {
+    "sha256:80a31c3ce2e99c3691c27ac3b1753163214494e9b2ca07bfdccf29a5cca2bfbe": {
+        "tag": "anchore/test_images:vulnerabilities-alpine-f5e8952",
+        "image_id": "8d4db62fbc412dd3a19f55bdf3d15bed65a7cdf9a3cf00630da685af565e2d25",
+    },
+    "sha256:406413437f26223183d133ccc7186f24c827729e1b21adc7330dd43fcdc030b3": {
+        "tag": "anchore/test_images:vulnerabilities-debian-f5e8952",
+        "image_id": "cbe22359b63443e715091e24efbcdeaa6bb3fb96c6fffeb5a1e85caaffc83565",
+    },
+    "sha256:fe3ca35038008b0eac0fa4e686bd072c9430000ab7d7853001bde5f5b8ccf60c": {
+        "tag": "anchore/test_images:vulnerabilities-centos-f5e8952",
+        "image_id": "08b3583ff5e85fb755be57d2ae9b14e3b5e4d406a5de55246b2ca84b2035f5da",
+    },
+}
 
 
 @pytest.fixture(scope="package")
@@ -59,6 +73,10 @@ def add_catalog_documents(request) -> None:
     """
     Adds analyzer manifests to catalog. Deletes existing manifests and images if they exist.
     """
+    # Do not load up any catalog documents if legacy test
+    if not is_legacy_provider():
+        return
+
     for analysis_file in ANALYSIS_FILES:
         file_path = path.join(ANALYSIS_FILES_DIR, analysis_file.filename)
         with open(file_path, "r") as f:
@@ -182,7 +200,10 @@ def _setup_vuln_data():
     """
     with session_scope() as db:
         all_records = []
-        files_to_seed = CATALOG_FILES.copy()
+
+        files_to_seed = []
+        if is_legacy_provider():
+            files_to_seed += CATALOG_FILES
 
         # If legacy provider, add vuln data to be seeded to files
         # if grype provider, ensure the grypedb is synced
@@ -214,3 +235,32 @@ def setup_vuln_data(
     teardown_and_recreate_tables(tablenames)
     _setup_vuln_data()
     request.addfinalizer(lambda: teardown_and_recreate_tables(tablenames))
+
+
+@pytest.fixture(scope="package")
+def setup_image(ingress_image, add_image_with_teardown_package_scope):
+    """
+    This fixture is used to get the image being tested into the correct analyzed state to test vulnerabilities
+    If its the legacy provider, uses the old method of ingressing image directly into the policy engine
+    If grype, uses the api to add and analyze the image
+    """
+
+    def _setup_image(image_digest):
+        if is_legacy_provider():
+            return ingress_image(image_digest)
+        else:
+            return add_image_with_teardown_package_scope(
+                IMAGE_DIGEST_MAP[image_digest]["tag"]
+            )
+
+    return _setup_image
+
+
+@pytest.fixture(scope="package")
+def setup_all_images(ingress_image, setup_image):
+    if is_legacy_provider():
+        for analysis_file in ANALYSIS_FILES:
+            ingress_image(analysis_file.image_digest)
+    else:
+        for tag in IMAGE_DIGEST_MAP.keys():
+            setup_image(tag)

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/grype/sha256:406413437f26223183d133ccc7186f24c827729e1b21adc7330dd43fcdc030b3.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/grype/sha256:406413437f26223183d133ccc7186f24c827729e1b21adc7330dd43fcdc030b3.json
@@ -4,1915 +4,6 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "libudev1",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 6.2,
-            "exploitability_score": 1.9,
-            "impact_score": 10.0,
-            "vector": "AV:L/AC:H/Au:N/C:C/I:C/A:C",
-            "version": "2.0"
-          },
-          {
-            "base_score": 6.7,
-            "exploitability_score": 0.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13776",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2020-13776"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-13776"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libpython2.7-minimal",
-      "pkg_type": "dpkg",
-      "version": "2.7.16-2+deb10u1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 6.8,
-            "exploitability_score": 8.6,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 8.8,
-            "exploitability_score": 2.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-17522",
-        "severity": "High",
-        "vulnerability_id": "CVE-2017-17522"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-17522"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libgnutls30",
-      "pkg_type": "dpkg",
-      "version": "3.6.7-4+deb10u6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2011-3389",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2011-3389"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2011-3389",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2011-3389"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [
-        "cpe:2.3:a:*:app:1:*:*:*:*:*:*:*"
-      ],
-      "location": "/sandbox/target/original-my-app-1.jar",
-      "name": "my-app",
-      "pkg_type": "java",
-      "version": "1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 5.0,
-          "exploitability_score": 10.0,
-          "impact_score": 2.9,
-          "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
-          "version": "2.0"
-        },
-        {
-          "base_score": 7.5,
-          "exploitability_score": 3.9,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
-          "version": "3.0"
-        }
-      ],
-      "description": "The mintToken function of a smart contract implementation for APP, an Ethereum token, has an integer overflow that allows the owner of the contract to set the balance of an arbitrary user to any value.",
-      "feed": "vulnerabilities",
-      "feed_group": "nvd",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-13661",
-      "severity": "High",
-      "vulnerability_id": "CVE-2018-13661"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libpcre3",
-      "pkg_type": "dpkg",
-      "version": "2:8.39-12"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 6.8,
-            "exploitability_score": 8.6,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.8,
-            "exploitability_score": 1.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-7246",
-        "severity": "High",
-        "vulnerability_id": "CVE-2017-7246"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-7246",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-7246"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl",
-      "pkg_type": "dpkg",
-      "version": "1.1.1d-0+deb10u6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.8,
-            "exploitability_score": 8.6,
-            "impact_score": 4.9,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2007-6755",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2007-6755"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2007-6755",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2007-6755"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libnss-systemd",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 6.2,
-            "exploitability_score": 1.9,
-            "impact_score": 10.0,
-            "vector": "AV:L/AC:H/Au:N/C:C/I:C/A:C",
-            "version": "2.0"
-          },
-          {
-            "base_score": 6.7,
-            "exploitability_score": 0.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13776",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2020-13776"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-13776"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libldap-common",
-      "pkg_type": "dpkg",
-      "version": "2.4.47+dfsg-3+deb10u6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.0,
-            "exploitability_score": 4.9,
-            "impact_score": 4.9,
-            "vector": "AV:N/AC:H/Au:N/C:P/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 4.2,
-            "exploitability_score": 1.6,
-            "impact_score": 2.5,
-            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-15719",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2020-15719"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-15719",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-15719"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libpcre3",
-      "pkg_type": "dpkg",
-      "version": "2:8.39-12"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-20838",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-20838"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20838",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-20838"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "systemd",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 2.9,
-            "exploitability_score": 5.5,
-            "impact_score": 2.9,
-            "vector": "AV:A/AC:M/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 6.1,
-            "exploitability_score": 1.6,
-            "impact_score": 4.0,
-            "vector": "CVSS:3.1/AV:A/AC:H/PR:N/UI:N/S:C/C:N/I:N/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13529",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2020-13529"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13529",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-13529"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "tar",
-      "pkg_type": "dpkg",
-      "version": "1.30+dfsg-6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 10.0,
-            "exploitability_score": 10.0,
-            "impact_score": 10.0,
-            "vector": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2005-2541",
-        "severity": "High",
-        "vulnerability_id": "CVE-2005-2541"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2005-2541",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2005-2541"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "systemd",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 3.3,
-            "exploitability_score": 3.4,
-            "impact_score": 4.9,
-            "vector": "AV:L/AC:M/Au:N/C:P/I:P/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-4392",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2013-4392"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2013-4392"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc6",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.3,
-            "exploitability_score": 3.9,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010025",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2019-1010025"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010025",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-1010025"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [
-        "cpe:2.3:a:*:xmldom:0.4.0:*:*:*:*:*:*:*"
-      ],
-      "location": "/sandbox/node_modules/xmldom/package.json",
-      "name": "xmldom",
-      "pkg_type": "npm",
-      "version": "0.4.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 4.3,
-          "exploitability_score": 8.6,
-          "impact_score": 2.9,
-          "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-          "version": "2.0"
-        },
-        {
-          "base_score": 4.3,
-          "exploitability_score": 2.8,
-          "impact_score": 1.4,
-          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
-          "version": "3.1"
-        }
-      ],
-      "description": "xmldom is a pure JavaScript W3C standard-based (XML DOM Level 2 Core) DOMParser and XMLSerializer module. xmldom versions 0.4.0 and older do not correctly preserve system identifiers, FPIs or namespaces when repeatedly parsing and serializing maliciously crafted documents. This may lead to unexpected syntactic changes during XML processing in some downstream applications. This is fixed in version 0.5.0. As a workaround downstream applications can validate the input and reject the maliciously crafted documents.",
-      "feed": "vulnerabilities",
-      "feed_group": "nvd",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21366",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2021-21366"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libsystemd0",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 2.9,
-            "exploitability_score": 5.5,
-            "impact_score": 2.9,
-            "vector": "AV:A/AC:M/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 6.1,
-            "exploitability_score": 1.6,
-            "impact_score": 4.0,
-            "vector": "CVSS:3.1/AV:A/AC:H/PR:N/UI:N/S:C/C:N/I:N/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13529",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2020-13529"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13529",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-13529"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "python",
-      "pkg_type": "dpkg",
-      "version": "2.7.16-1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.2,
-            "exploitability_score": 3.9,
-            "impact_score": 10.0,
-            "vector": "AV:L/AC:L/Au:N/C:C/I:C/A:C",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2008-4108",
-        "severity": "High",
-        "vulnerability_id": "CVE-2008-4108"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2008-4108",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2008-4108"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libpcre3",
-      "pkg_type": "dpkg",
-      "version": "2:8.39-12"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.8,
-            "exploitability_score": 10.0,
-            "impact_score": 6.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:C",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-11164",
-        "severity": "High",
-        "vulnerability_id": "CVE-2017-11164"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-11164",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-11164"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libseccomp2",
-      "pkg_type": "dpkg",
-      "version": "2.3.3-4"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.5,
-            "exploitability_score": 10.0,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 9.8,
-            "exploitability_score": 3.9,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9893",
-        "severity": "Critical",
-        "vulnerability_id": "CVE-2019-9893"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9893",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-9893"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc-bin",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9192",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-9192"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9192",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-9192"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc-bin",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 6.8,
-            "exploitability_score": 8.6,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 8.8,
-            "exploitability_score": 2.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010023",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-1010023"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010023",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-1010023"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [
-        "cpe:2.3:a:*:aiohttp:3.7.3:*:*:*:*:*:*:*"
-      ],
-      "location": "/usr/local/lib/python3.7/dist-packages/aiohttp",
-      "name": "aiohttp",
-      "pkg_type": "python",
-      "version": "3.7.3"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 4.3,
-          "exploitability_score": 8.6,
-          "impact_score": 2.9,
-          "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-          "version": "2.0"
-        },
-        {
-          "base_score": 6.5,
-          "exploitability_score": 2.8,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:N",
-          "version": "3.0"
-        }
-      ],
-      "description": "aio-libs aiohttp-session contains a Session Fixation vulnerability in load_session function for RedisStorage (see: https://github.com/aio-libs/aiohttp-session/blob/master/aiohttp_session/redis_storage.py#L42) that can result in Session Hijacking. This attack appear to be exploitable via Any method that allows setting session cookies (?session=<>, or meta tags or script tags with Set-Cookie).",
-      "feed": "vulnerabilities",
-      "feed_group": "nvd",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-1000519",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2018-1000519"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc6",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-4052",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2010-4052"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4052",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2010-4052"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libpcre3",
-      "pkg_type": "dpkg",
-      "version": "2:8.39-12"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 6.8,
-            "exploitability_score": 8.6,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.8,
-            "exploitability_score": 1.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-7245",
-        "severity": "High",
-        "vulnerability_id": "CVE-2017-7245"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-7245",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-7245"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libnss-systemd",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 2.9,
-            "exploitability_score": 5.5,
-            "impact_score": 2.9,
-            "vector": "AV:A/AC:M/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 6.1,
-            "exploitability_score": 1.6,
-            "impact_score": 4.0,
-            "vector": "CVSS:3.1/AV:A/AC:H/PR:N/UI:N/S:C/C:N/I:N/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13529",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2020-13529"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13529",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-13529"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc6",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.0,
-            "exploitability_score": 8.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:S/C:N/I:N/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-4756",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2010-4756"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4756",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2010-4756"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libnss-systemd",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 3.3,
-            "exploitability_score": 3.4,
-            "impact_score": 4.9,
-            "vector": "AV:L/AC:M/Au:N/C:P/I:P/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-4392",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2013-4392"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2013-4392"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "tar",
-      "pkg_type": "dpkg",
-      "version": "1.30+dfsg-6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9923",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-9923"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9923",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-9923"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libudev1",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 3.3,
-            "exploitability_score": 3.4,
-            "impact_score": 4.9,
-            "vector": "AV:L/AC:M/Au:N/C:P/I:P/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-4392",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2013-4392"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2013-4392"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "python3.7-minimal",
-      "pkg_type": "dpkg",
-      "version": "3.7.3-2+deb10u3"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9674",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-9674"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-9674"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl",
-      "pkg_type": "dpkg",
-      "version": "1.1.1d-0+deb10u6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.0,
-            "exploitability_score": 1.9,
-            "impact_score": 6.9,
-            "vector": "AV:L/AC:H/Au:N/C:C/I:N/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-0928",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2010-0928"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2010-0928",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2010-0928"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [
-        "cpe:2.3:a:*:app:1:*:*:*:*:*:*:*"
-      ],
-      "location": "/sandbox/target/my-app-1.jar",
-      "name": "my-app",
-      "pkg_type": "java",
-      "version": "1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 5.0,
-          "exploitability_score": 10.0,
-          "impact_score": 2.9,
-          "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
-          "version": "2.0"
-        },
-        {
-          "base_score": 7.5,
-          "exploitability_score": 3.9,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
-          "version": "3.0"
-        }
-      ],
-      "description": "The mintToken function of a smart contract implementation for APP, an Ethereum token, has an integer overflow that allows the owner of the contract to set the balance of an arbitrary user to any value.",
-      "feed": "vulnerabilities",
-      "feed_group": "nvd",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-13661",
-      "severity": "High",
-      "vulnerability_id": "CVE-2018-13661"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "perl",
-      "pkg_type": "dpkg",
-      "version": "5.28.1-6+deb10u1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2011-4116",
-        "severity": "High",
-        "vulnerability_id": "CVE-2011-4116"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2011-4116",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2011-4116"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libpython3.7-minimal",
-      "pkg_type": "dpkg",
-      "version": "3.7.3-2+deb10u3"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.5,
-            "exploitability_score": 10.0,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 9.8,
-            "exploitability_score": 3.9,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-27619",
-        "severity": "Critical",
-        "vulnerability_id": "CVE-2020-27619"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-27619",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-27619"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [
-        "cpe:2.3:a:*:guava:23.0:*:*:*:*:*:*:*",
-        "cpe:2.3:a:google:guava:23.0:*:*:*:*:*:*:*"
-      ],
-      "location": "/sandbox/target/original-my-app-1.jar:guava",
-      "name": "guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 2.1,
-          "exploitability_score": 3.9,
-          "impact_score": 2.9,
-          "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
-          "version": "2.0"
-        },
-        {
-          "base_score": 3.3,
-          "exploitability_score": 1.8,
-          "impact_score": 1.4,
-          "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
-          "version": "3.1"
-        }
-      ],
-      "description": "A temp directory creation vulnerability exists in all versions of Guava, allowing an attacker with access to the machine to potentially access data in a temporary directory created by the Guava API com.google.common.io.Files.createTempDir(). By default, on unix-like systems, the created directory is world-readable (readable by an attacker with access to the system). The method in question has been marked @Deprecated in versions 30.0 and later and should not be used. For Android developers, we recommend choosing a temporary directory API provided by Android, such as context.getCacheDir(). For other Java developers, we recommend migrating to the Java 7 API java.nio.file.Files.createTempDirectory() which explicitly configures permissions of 700, or configuring the Java runtime's java.io.tmpdir system property to point to a location whose permissions are appropriately configured.",
-      "feed": "vulnerabilities",
-      "feed_group": "nvd",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2020-8908"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "perl-base",
-      "pkg_type": "dpkg",
-      "version": "5.28.1-6+deb10u1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2011-4116",
-        "severity": "High",
-        "vulnerability_id": "CVE-2011-4116"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2011-4116",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2011-4116"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc-bin",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-4052",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2010-4052"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4052",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2010-4052"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [
-        "cpe:2.3:a:*:aiohttp:3.7.3:*:*:*:*:*:*:*"
-      ],
-      "location": "/usr/local/lib/python3.7/dist-packages/aiohttp",
-      "name": "aiohttp",
-      "pkg_type": "python",
-      "version": "3.7.3"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 5.8,
-          "exploitability_score": 8.6,
-          "impact_score": 4.9,
-          "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:N",
-          "version": "2.0"
-        },
-        {
-          "base_score": 6.1,
-          "exploitability_score": 2.8,
-          "impact_score": 2.7,
-          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
-          "version": "3.1"
-        }
-      ],
-      "description": "aiohttp is an asynchronous HTTP client/server framework for asyncio and Python. In aiohttp before version 3.7.4 there is an open redirect vulnerability. A maliciously crafted link to an aiohttp-based web-server could redirect the browser to a different website. It is caused by a bug in the `aiohttp.web_middlewares.normalize_path_middleware` middleware. This security problem has been fixed in 3.7.4. Upgrade your dependency using pip as follows \"pip install aiohttp >= 3.7.4\". If upgrading is not an option for you, a workaround can be to avoid using `aiohttp.web_middlewares.normalize_path_middleware` in your applications.",
-      "feed": "vulnerabilities",
-      "feed_group": "nvd",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21330",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2021-21330"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libsystemd0",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 2.4,
-            "exploitability_score": 0.9,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-20386",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2019-20386"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-20386"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc6",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-4051",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2010-4051"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4051",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2010-4051"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
       "name": "libgssapi-krb5-2",
       "pkg_type": "dpkg",
       "version": "1.17-3+deb10u1"
@@ -1924,7 +15,7 @@
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
+      "detected_at": "2021-09-24T18:59:14Z"
     },
     "nvd": [
       {
@@ -1958,6 +49,109 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
+      "name": "tar",
+      "pkg_type": "dpkg",
+      "version": "1.30+dfsg-6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 10.0,
+            "exploitability_score": 10.0,
+            "impact_score": 10.0,
+            "vector": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2005-2541",
+        "severity": "High",
+        "vulnerability_id": "CVE-2005-2541"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2005-2541",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2005-2541"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "login",
+      "pkg_type": "dpkg",
+      "version": "1:4.5-1.1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2007-5686",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2007-5686"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "passwd",
+      "pkg_type": "dpkg",
+      "version": "1:4.5-1.1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2007-5686",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2007-5686"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
       "name": "libssl1.1",
       "pkg_type": "dpkg",
       "version": "1.1.1d-0+deb10u6"
@@ -1969,7 +163,142 @@
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.8,
+            "exploitability_score": 8.6,
+            "impact_score": 4.9,
+            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:N",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2007-6755",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2007-6755"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2007-6755",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2007-6755"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "openssl",
+      "pkg_type": "dpkg",
+      "version": "1.1.1d-0+deb10u6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.8,
+            "exploitability_score": 8.6,
+            "impact_score": 4.9,
+            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:N",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2007-6755",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2007-6755"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2007-6755",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2007-6755"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "python",
+      "pkg_type": "dpkg",
+      "version": "2.7.16-1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 7.2,
+            "exploitability_score": 3.9,
+            "impact_score": 10.0,
+            "vector": "AV:L/AC:L/Au:N/C:C/I:C/A:C",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2008-4108",
+        "severity": "High",
+        "vulnerability_id": "CVE-2008-4108"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2008-4108",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2008-4108"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libssl1.1",
+      "pkg_type": "dpkg",
+      "version": "1.1.1d-0+deb10u6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
     },
     "nvd": [
       {
@@ -2003,9 +332,9 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "python2.7-minimal",
+      "name": "openssl",
       "pkg_type": "dpkg",
-      "version": "2.7.16-2+deb10u1"
+      "version": "1.1.1d-0+deb10u6"
     },
     "fix": {
       "advisories": [],
@@ -2014,1690 +343,23 @@
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
+      "detected_at": "2021-09-24T18:59:14Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 6.8,
-            "exploitability_score": 8.6,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 8.8,
-            "exploitability_score": 2.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-17522",
-        "severity": "High",
-        "vulnerability_id": "CVE-2017-17522"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-17522"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc6",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-20796",
-        "severity": "High",
-        "vulnerability_id": "CVE-2018-20796"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2018-20796",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2018-20796"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libldap-common",
-      "pkg_type": "dpkg",
-      "version": "2.4.47+dfsg-3+deb10u6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-17740",
-        "severity": "High",
-        "vulnerability_id": "CVE-2017-17740"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17740",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-17740"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libgcrypt20",
-      "pkg_type": "dpkg",
-      "version": "1.8.4-5"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-6829",
-        "severity": "High",
-        "vulnerability_id": "CVE-2018-6829"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2018-6829",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2018-6829"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "systemd",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 2.4,
-            "exploitability_score": 0.9,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-20386",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2019-20386"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-20386"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc-bin",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.3,
-            "exploitability_score": 3.9,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010025",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2019-1010025"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010025",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-1010025"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libpython2.7-minimal",
-      "pkg_type": "dpkg",
-      "version": "2.7.16-2+deb10u1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9674",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-9674"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-9674"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libnss-systemd",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 2.4,
-            "exploitability_score": 0.9,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-20386",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2019-20386"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-20386"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [
-        "cpe:2.3:a:*:guava:23.0:*:*:*:*:*:*:*",
-        "cpe:2.3:a:google:guava:23.0:*:*:*:*:*:*:*"
-      ],
-      "location": "/sandbox/target/original-my-app-1.jar:guava",
-      "name": "guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 4.3,
-          "exploitability_score": 8.6,
-          "impact_score": 2.9,
-          "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
-          "version": "2.0"
-        },
-        {
-          "base_score": 5.9,
-          "exploitability_score": 2.2,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
-          "version": "3.1"
-        }
-      ],
-      "description": "Unbounded memory allocation in Google Guava 11.0 through 24.x before 24.1.1 allows remote attackers to conduct denial of service attacks against servers that depend on this library and deserialize attacker-provided data, because the AtomicDoubleArray class (when serialized with Java serialization) and the CompoundOrdering class (when serialized with GWT serialization) perform eager allocation without appropriate checks on what a client has sent and whether the data size is reasonable.",
-      "feed": "vulnerabilities",
-      "feed_group": "nvd",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2018-10237"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "liblz4-1",
-      "pkg_type": "dpkg",
-      "version": "1.8.3-1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-06-08T20:34:56Z",
-      "versions": [
-        "1.8.3-1+deb10u1"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2021-3520",
-      "severity": "Unknown",
-      "vulnerability_id": "CVE-2021-3520"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "python3.7-minimal",
-      "pkg_type": "dpkg",
-      "version": "3.7.3-2+deb10u3"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 6.8,
-            "exploitability_score": 8.6,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 8.8,
-            "exploitability_score": 2.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-17522",
-        "severity": "High",
-        "vulnerability_id": "CVE-2017-17522"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-17522"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "python2.7-minimal",
-      "pkg_type": "dpkg",
-      "version": "2.7.16-2+deb10u1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-7040",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2013-7040"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-7040",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2013-7040"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libpython3.7-minimal",
-      "pkg_type": "dpkg",
-      "version": "3.7.3-2+deb10u3"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 6.1,
-            "exploitability_score": 2.8,
-            "impact_score": 2.7,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-18348",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2019-18348"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-18348"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libudev1",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 2.9,
-            "exploitability_score": 5.5,
-            "impact_score": 2.9,
-            "vector": "AV:A/AC:M/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 6.1,
-            "exploitability_score": 1.6,
-            "impact_score": 4.0,
-            "vector": "CVSS:3.1/AV:A/AC:H/PR:N/UI:N/S:C/C:N/I:N/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13529",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2020-13529"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13529",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-13529"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "python2.7-minimal",
-      "pkg_type": "dpkg",
-      "version": "2.7.16-2+deb10u1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 6.1,
-            "exploitability_score": 2.8,
-            "impact_score": 2.7,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-18348",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2019-18348"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-18348"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc-bin",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.5,
-            "exploitability_score": 10.0,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 9.8,
-            "exploitability_score": 3.9,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010022",
-        "severity": "Critical",
-        "vulnerability_id": "CVE-2019-1010022"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010022",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-1010022"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [
-        "cpe:2.3:a:*:ftpd:0.2.1:*:*:*:*:*:*:*"
-      ],
-      "location": "/var/lib/gems/2.5.0/specifications/ftpd-0.2.1.gemspec",
-      "name": "ftpd",
-      "pkg_type": "gem",
-      "version": "0.2.1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 10.0,
-          "exploitability_score": 10.0,
-          "impact_score": 10.0,
-          "vector": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
-          "version": "2.0"
-        },
-        {
-          "base_score": 9.8,
-          "exploitability_score": 3.9,
-          "impact_score": 5.9,
-          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-          "version": "3.1"
-        }
-      ],
-      "description": "The ftpd gem 0.2.1 for Ruby allows remote attackers to execute arbitrary OS commands via shell metacharacters in a LIST or NLST command argument within FTP protocol traffic.",
-      "feed": "vulnerabilities",
-      "feed_group": "nvd",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
-      "severity": "Critical",
-      "vulnerability_id": "CVE-2013-2512"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc6",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9192",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-9192"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9192",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-9192"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc6",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 6.8,
-            "exploitability_score": 8.6,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 8.8,
-            "exploitability_score": 2.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010023",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-1010023"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010023",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-1010023"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [
-        "cpe:2.3:a:*:guava:23.0:*:*:*:*:*:*:*",
-        "cpe:2.3:a:google:guava:23.0:*:*:*:*:*:*:*"
-      ],
-      "location": "/sandbox/target/my-app-1.jar:guava",
-      "name": "guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 4.3,
-          "exploitability_score": 8.6,
-          "impact_score": 2.9,
-          "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
-          "version": "2.0"
-        },
-        {
-          "base_score": 5.9,
-          "exploitability_score": 2.2,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
-          "version": "3.1"
-        }
-      ],
-      "description": "Unbounded memory allocation in Google Guava 11.0 through 24.x before 24.1.1 allows remote attackers to conduct denial of service attacks against servers that depend on this library and deserialize attacker-provided data, because the AtomicDoubleArray class (when serialized with Java serialization) and the CompoundOrdering class (when serialized with GWT serialization) perform eager allocation without appropriate checks on what a client has sent and whether the data size is reasonable.",
-      "feed": "vulnerabilities",
-      "feed_group": "nvd",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2018-10237"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libldap-common",
-      "pkg_type": "dpkg",
-      "version": "2.4.47+dfsg-3+deb10u6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 1.9,
-            "exploitability_score": 3.4,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:M/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 4.7,
-            "exploitability_score": 1.0,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-14159",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2017-14159"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-14159",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-14159"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libpcre3",
-      "pkg_type": "dpkg",
-      "version": "2:8.39-12"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.5,
-            "exploitability_score": 1.8,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-16231",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2017-16231"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-16231",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-16231"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libsystemd0",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 3.3,
-            "exploitability_score": 3.4,
-            "impact_score": 4.9,
-            "vector": "AV:L/AC:M/Au:N/C:P/I:P/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-4392",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2013-4392"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2013-4392"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "passwd",
-      "pkg_type": "dpkg",
-      "version": "1:4.5-1.1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 3.3,
-            "exploitability_score": 3.4,
-            "impact_score": 4.9,
-            "vector": "AV:L/AC:M/Au:N/C:N/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 4.7,
-            "exploitability_score": 1.0,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:H/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-4235",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2013-4235"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4235",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2013-4235"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openjdk-11-jre-headless",
-      "pkg_type": "dpkg",
-      "version": "11.0.9.1+1-1~deb10u2"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-06-08T20:34:56Z",
-      "versions": [
-        "11.0.11+9-1~deb10u1"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 2.6,
-            "exploitability_score": 4.9,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:H/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.3,
-            "exploitability_score": 1.6,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:H/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-2163",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2021-2163"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2021-2163",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2021-2163"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc6",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.5,
-            "exploitability_score": 10.0,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 9.8,
-            "exploitability_score": 3.9,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010022",
-        "severity": "Critical",
-        "vulnerability_id": "CVE-2019-1010022"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010022",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-1010022"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libpython2.7-minimal",
-      "pkg_type": "dpkg",
-      "version": "2.7.16-2+deb10u1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-7040",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2013-7040"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2013-7040",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2013-7040"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "bash",
-      "pkg_type": "dpkg",
-      "version": "5.0-4"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.2,
-            "exploitability_score": 3.9,
-            "impact_score": 10.0,
-            "vector": "AV:L/AC:L/Au:N/C:C/I:C/A:C",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.8,
-            "exploitability_score": 1.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-18276",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-18276"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18276",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-18276"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "coreutils",
-      "pkg_type": "dpkg",
-      "version": "8.30-3"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 1.9,
-            "exploitability_score": 3.4,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:M/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 4.7,
-            "exploitability_score": 1.0,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:H/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-18018",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2017-18018"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-18018",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-18018"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libglib2.0-0",
-      "pkg_type": "dpkg",
-      "version": "2.58.3-2+deb10u2"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.6,
-            "exploitability_score": 3.9,
-            "impact_score": 6.4,
-            "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.8,
-            "exploitability_score": 1.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-35457",
-        "severity": "High",
-        "vulnerability_id": "CVE-2020-35457"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-35457",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-35457"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "login",
-      "pkg_type": "dpkg",
-      "version": "1:4.5-1.1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 6.9,
-            "exploitability_score": 3.4,
-            "impact_score": 10.0,
-            "vector": "AV:L/AC:M/Au:N/C:C/I:C/A:C",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.8,
-            "exploitability_score": 1.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-19882",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-19882"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-19882",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-19882"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "tar",
-      "pkg_type": "dpkg",
-      "version": "1.30+dfsg-6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.5,
-            "exploitability_score": 1.8,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-20193",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2021-20193"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2021-20193",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2021-20193"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libtasn1-6",
-      "pkg_type": "dpkg",
-      "version": "4.13-3"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.1,
-            "exploitability_score": 8.6,
-            "impact_score": 6.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:C",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.5,
-            "exploitability_score": 1.8,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-1000654",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2018-1000654"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2018-1000654",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2018-1000654"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libsystemd0",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 6.2,
+            "base_score": 4.0,
             "exploitability_score": 1.9,
-            "impact_score": 10.0,
-            "vector": "AV:L/AC:H/Au:N/C:C/I:C/A:C",
+            "impact_score": 6.9,
+            "vector": "AV:L/AC:H/Au:N/C:C/I:N/A:N",
             "version": "2.0"
-          },
-          {
-            "base_score": 6.7,
-            "exploitability_score": 0.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H",
-            "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13776",
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-0928",
         "severity": "Medium",
-        "vulnerability_id": "CVE-2020-13776"
+        "vulnerability_id": "CVE-2010-0928"
       }
     ],
     "vulnerability": {
@@ -3705,9 +367,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-0928",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-13776"
+      "vulnerability_id": "CVE-2010-0928"
     }
   },
   {
@@ -3726,7 +388,232 @@
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-4051",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2010-4051"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4051",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2010-4051"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libc6",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-4051",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2010-4051"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4051",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2010-4051"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libc-bin",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-4052",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2010-4052"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4052",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2010-4052"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libc6",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-4052",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2010-4052"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4052",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2010-4052"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libc-bin",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.0,
+            "exploitability_score": 8.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:S/C:N/I:N/A:P",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-4756",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2010-4756"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4756",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2010-4756"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libc6",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
     },
     "nvd": [
       {
@@ -3771,7 +658,7 @@
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
+      "detected_at": "2021-09-24T18:59:14Z"
     },
     "nvd": [
       {
@@ -3823,7 +710,7 @@
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
+      "detected_at": "2021-09-24T18:59:14Z"
     },
     "nvd": [
       {
@@ -3864,9 +751,9 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "libpython3.7-minimal",
+      "name": "libgnutls30",
       "pkg_type": "dpkg",
-      "version": "3.7.3-2+deb10u3"
+      "version": "3.6.7-4+deb10u6"
     },
     "fix": {
       "advisories": [],
@@ -3875,7 +762,156 @@
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:P/I:N/A:N",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2011-3389",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2011-3389"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2011-3389",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2011-3389"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "perl",
+      "pkg_type": "dpkg",
+      "version": "5.28.1-6+deb10u1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2011-4116",
+        "severity": "High",
+        "vulnerability_id": "CVE-2011-4116"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2011-4116",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2011-4116"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "perl-base",
+      "pkg_type": "dpkg",
+      "version": "5.28.1-6+deb10u1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2011-4116",
+        "severity": "High",
+        "vulnerability_id": "CVE-2011-4116"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2011-4116",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2011-4116"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libglib2.0-0",
+      "pkg_type": "dpkg",
+      "version": "2.58.3-2+deb10u2"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
     },
     "nvd": [
       {
@@ -3886,64 +922,12 @@
             "impact_score": 2.9,
             "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
             "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9674",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-9674"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-9674"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libldap-common",
-      "pkg_type": "dpkg",
-      "version": "2.4.47+dfsg-3+deb10u6"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-3276",
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2012-0039",
         "severity": "Medium",
-        "vulnerability_id": "CVE-2015-3276"
+        "vulnerability_id": "CVE-2012-0039"
       }
     ],
     "vulnerability": {
@@ -3951,207 +935,21 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2015-3276",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2012-0039",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2015-3276"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "passwd",
-      "pkg_type": "dpkg",
-      "version": "1:4.5-1.1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2007-5686",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2007-5686"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc-bin",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.3,
-            "exploitability_score": 3.9,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010024",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2019-1010024"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010024",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-1010024"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "xdg-user-dirs",
-      "pkg_type": "dpkg",
-      "version": "0.17-2"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.6,
-            "exploitability_score": 3.9,
-            "impact_score": 6.4,
-            "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.8,
-            "exploitability_score": 1.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-15131",
-        "severity": "High",
-        "vulnerability_id": "CVE-2017-15131"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-15131",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-15131"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libc6",
-      "pkg_type": "dpkg",
-      "version": "2.28-10"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.3,
-            "exploitability_score": 3.9,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010024",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2019-1010024"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010024",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-1010024"
+      "vulnerability_id": "CVE-2012-0039"
     }
   },
   {
     "artifact": {
       "cpe": null,
       "cpes": [
-        "cpe:2.3:a:*:guava:23.0:*:*:*:*:*:*:*",
-        "cpe:2.3:a:google:guava:23.0:*:*:*:*:*:*:*"
+        "cpe:2.3:a:*:ftpd:0.2.1:*:*:*:*:*:*:*"
       ],
-      "location": "/sandbox/target/my-app-1.jar:guava",
-      "name": "guava",
-      "pkg_type": "java",
-      "version": "23.0"
+      "location": "/var/lib/gems/2.5.0/specifications/ftpd-0.2.1.gemspec",
+      "name": "ftpd",
+      "pkg_type": "gem",
+      "version": "0.2.1"
     },
     "fix": {
       "advisories": [],
@@ -4160,84 +958,32 @@
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
+      "detected_at": "2021-09-24T18:59:14Z"
     },
     "nvd": [],
     "vulnerability": {
       "cvss": [
         {
-          "base_score": 2.1,
-          "exploitability_score": 3.9,
-          "impact_score": 2.9,
-          "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
+          "base_score": 10.0,
+          "exploitability_score": 10.0,
+          "impact_score": 10.0,
+          "vector": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
           "version": "2.0"
         },
         {
-          "base_score": 3.3,
-          "exploitability_score": 1.8,
-          "impact_score": 1.4,
-          "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
+          "base_score": 9.8,
+          "exploitability_score": 3.9,
+          "impact_score": 5.9,
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
           "version": "3.1"
         }
       ],
-      "description": "A temp directory creation vulnerability exists in all versions of Guava, allowing an attacker with access to the machine to potentially access data in a temporary directory created by the Guava API com.google.common.io.Files.createTempDir(). By default, on unix-like systems, the created directory is world-readable (readable by an attacker with access to the system). The method in question has been marked @Deprecated in versions 30.0 and later and should not be used. For Android developers, we recommend choosing a temporary directory API provided by Android, such as context.getCacheDir(). For other Java developers, we recommend migrating to the Java 7 API java.nio.file.Files.createTempDirectory() which explicitly configures permissions of 700, or configuring the Java runtime's java.io.tmpdir system property to point to a location whose permissions are appropriately configured.",
+      "description": "The ftpd gem 0.2.1 for Ruby allows remote attackers to execute arbitrary OS commands via shell metacharacters in a LIST or NLST command argument within FTP protocol traffic.",
       "feed": "vulnerabilities",
       "feed_group": "nvd",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2020-8908"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "libgssapi-krb5-2",
-      "pkg_type": "dpkg",
-      "version": "1.17-3+deb10u1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-5709",
-        "severity": "High",
-        "vulnerability_id": "CVE-2018-5709"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2018-5709",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2018-5709"
+      "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-2512",
+      "severity": "Critical",
+      "vulnerability_id": "CVE-2013-2512"
     }
   },
   {
@@ -4256,36 +1002,7 @@
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2007-5686",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2007-5686"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "login",
-      "pkg_type": "dpkg",
-      "version": "1:4.5-1.1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
+      "detected_at": "2021-09-24T18:59:14Z"
     },
     "nvd": [
       {
@@ -4326,9 +1043,9 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "python2.7-minimal",
+      "name": "passwd",
       "pkg_type": "dpkg",
-      "version": "2.7.16-2+deb10u1"
+      "version": "1:4.5-1.1"
     },
     "fix": {
       "advisories": [],
@@ -4337,30 +1054,30 @@
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
+      "detected_at": "2021-09-24T18:59:14Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "base_score": 3.3,
+            "exploitability_score": 3.4,
+            "impact_score": 4.9,
+            "vector": "AV:L/AC:M/Au:N/C:N/I:P/A:P",
             "version": "2.0"
           },
           {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
+            "base_score": 4.7,
+            "exploitability_score": 1.0,
             "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:H/A:N",
             "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9674",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-9674"
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-4235",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2013-4235"
       }
     ],
     "vulnerability": {
@@ -4368,9 +1085,144 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4235",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-9674"
+      "vulnerability_id": "CVE-2013-4235"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libnss-systemd",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 3.3,
+            "exploitability_score": 3.4,
+            "impact_score": 4.9,
+            "vector": "AV:L/AC:M/Au:N/C:P/I:P/A:N",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-4392",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2013-4392"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2013-4392"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libsystemd0",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 3.3,
+            "exploitability_score": 3.4,
+            "impact_score": 4.9,
+            "vector": "AV:L/AC:M/Au:N/C:P/I:P/A:N",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-4392",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2013-4392"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2013-4392"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libudev1",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 3.3,
+            "exploitability_score": 3.4,
+            "impact_score": 4.9,
+            "vector": "AV:L/AC:M/Au:N/C:P/I:P/A:N",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-4392",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2013-4392"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2013-4392"
     }
   },
   {
@@ -4389,30 +1241,23 @@
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
+      "detected_at": "2021-09-24T18:59:14Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 6.2,
-            "exploitability_score": 1.9,
-            "impact_score": 10.0,
-            "vector": "AV:L/AC:H/Au:N/C:C/I:C/A:C",
+            "base_score": 3.3,
+            "exploitability_score": 3.4,
+            "impact_score": 4.9,
+            "vector": "AV:L/AC:M/Au:N/C:P/I:P/A:N",
             "version": "2.0"
-          },
-          {
-            "base_score": 6.7,
-            "exploitability_score": 0.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H",
-            "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13776",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2020-13776"
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-4392",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2013-4392"
       }
     ],
     "vulnerability": {
@@ -4420,9 +1265,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-4392",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2020-13776"
+      "vulnerability_id": "CVE-2013-4392"
     }
   },
   {
@@ -4430,9 +1275,9 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "libglib2.0-0",
+      "name": "libpython2.7-minimal",
       "pkg_type": "dpkg",
-      "version": "2.58.3-2+deb10u2"
+      "version": "2.7.16-2+deb10u1"
     },
     "fix": {
       "advisories": [],
@@ -4441,7 +1286,558 @@
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-7040",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2013-7040"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-7040",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2013-7040"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "python2.7-minimal",
+      "pkg_type": "dpkg",
+      "version": "2.7.16-2+deb10u1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2013-7040",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2013-7040"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2013-7040",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2013-7040"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libldap-common",
+      "pkg_type": "dpkg",
+      "version": "2.4.47+dfsg-3+deb10u6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-3276",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2015-3276"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2015-3276",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2015-3276"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libpcre3",
+      "pkg_type": "dpkg",
+      "version": "2:8.39-12"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 7.8,
+            "exploitability_score": 10.0,
+            "impact_score": 6.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:C",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-11164",
+        "severity": "High",
+        "vulnerability_id": "CVE-2017-11164"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-11164",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-11164"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libldap-common",
+      "pkg_type": "dpkg",
+      "version": "2.4.47+dfsg-3+deb10u6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 1.9,
+            "exploitability_score": 3.4,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:M/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 4.7,
+            "exploitability_score": 1.0,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-14159",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2017-14159"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-14159",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-14159"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "xdg-user-dirs",
+      "pkg_type": "dpkg",
+      "version": "0.17-2"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.6,
+            "exploitability_score": 3.9,
+            "impact_score": 6.4,
+            "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.8,
+            "exploitability_score": 1.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-15131",
+        "severity": "High",
+        "vulnerability_id": "CVE-2017-15131"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-15131",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-15131"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libpcre3",
+      "pkg_type": "dpkg",
+      "version": "2:8.39-12"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 5.5,
+            "exploitability_score": 1.8,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-16231",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2017-16231"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-16231",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-16231"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libpython2.7-minimal",
+      "pkg_type": "dpkg",
+      "version": "2.7.16-2+deb10u1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 6.8,
+            "exploitability_score": 8.6,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 8.8,
+            "exploitability_score": 2.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-17522",
+        "severity": "High",
+        "vulnerability_id": "CVE-2017-17522"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-17522"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libpython3.7-minimal",
+      "pkg_type": "dpkg",
+      "version": "3.7.3-2+deb10u3"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 6.8,
+            "exploitability_score": 8.6,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 8.8,
+            "exploitability_score": 2.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-17522",
+        "severity": "High",
+        "vulnerability_id": "CVE-2017-17522"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-17522"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "python2.7-minimal",
+      "pkg_type": "dpkg",
+      "version": "2.7.16-2+deb10u1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 6.8,
+            "exploitability_score": 8.6,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 8.8,
+            "exploitability_score": 2.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-17522",
+        "severity": "High",
+        "vulnerability_id": "CVE-2017-17522"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-17522"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "python3.7-minimal",
+      "pkg_type": "dpkg",
+      "version": "3.7.3-2+deb10u3"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 6.8,
+            "exploitability_score": 8.6,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 8.8,
+            "exploitability_score": 2.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-17522",
+        "severity": "High",
+        "vulnerability_id": "CVE-2017-17522"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-17522"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libldap-common",
+      "pkg_type": "dpkg",
+      "version": "2.4.47+dfsg-3+deb10u6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
     },
     "nvd": [
       {
@@ -4452,12 +1848,19 @@
             "impact_score": 2.9,
             "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
             "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.0"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2012-0039",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2012-0039"
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-17740",
+        "severity": "High",
+        "vulnerability_id": "CVE-2017-17740"
       }
     ],
     "vulnerability": {
@@ -4465,9 +1868,217 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2012-0039",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17740",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2012-0039"
+      "vulnerability_id": "CVE-2017-17740"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "coreutils",
+      "pkg_type": "dpkg",
+      "version": "8.30-3"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 1.9,
+            "exploitability_score": 3.4,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:M/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 4.7,
+            "exploitability_score": 1.0,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:H/A:N",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-18018",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2017-18018"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-18018",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-18018"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libpcre3",
+      "pkg_type": "dpkg",
+      "version": "2:8.39-12"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 6.8,
+            "exploitability_score": 8.6,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.8,
+            "exploitability_score": 1.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-7245",
+        "severity": "High",
+        "vulnerability_id": "CVE-2017-7245"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-7245",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-7245"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libpcre3",
+      "pkg_type": "dpkg",
+      "version": "2:8.39-12"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 6.8,
+            "exploitability_score": 8.6,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.8,
+            "exploitability_score": 1.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-7246",
+        "severity": "High",
+        "vulnerability_id": "CVE-2017-7246"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2017-7246",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2017-7246"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libtasn1-6",
+      "pkg_type": "dpkg",
+      "version": "4.13-3"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 7.1,
+            "exploitability_score": 8.6,
+            "impact_score": 6.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:C",
+            "version": "2.0"
+          },
+          {
+            "base_score": 5.5,
+            "exploitability_score": 1.8,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-1000654",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2018-1000654"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2018-1000654",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2018-1000654"
     }
   },
   {
@@ -4486,7 +2097,7 @@
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
+      "detected_at": "2021-09-24T18:59:14Z"
     },
     "nvd": [
       {
@@ -4527,6 +2138,786 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
+      "name": "libc6",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-20796",
+        "severity": "High",
+        "vulnerability_id": "CVE-2018-20796"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2018-20796",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2018-20796"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libgssapi-krb5-2",
+      "pkg_type": "dpkg",
+      "version": "1.17-3+deb10u1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-5709",
+        "severity": "High",
+        "vulnerability_id": "CVE-2018-5709"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2018-5709",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2018-5709"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libgcrypt20",
+      "pkg_type": "dpkg",
+      "version": "1.8.4-5"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-6829",
+        "severity": "High",
+        "vulnerability_id": "CVE-2018-6829"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2018-6829",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2018-6829"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libc-bin",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 7.5,
+            "exploitability_score": 10.0,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 9.8,
+            "exploitability_score": 3.9,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010022",
+        "severity": "Critical",
+        "vulnerability_id": "CVE-2019-1010022"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010022",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-1010022"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libc6",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 7.5,
+            "exploitability_score": 10.0,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 9.8,
+            "exploitability_score": 3.9,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010022",
+        "severity": "Critical",
+        "vulnerability_id": "CVE-2019-1010022"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010022",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-1010022"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libc-bin",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 6.8,
+            "exploitability_score": 8.6,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 8.8,
+            "exploitability_score": 2.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010023",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-1010023"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010023",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-1010023"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libc6",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 6.8,
+            "exploitability_score": 8.6,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 8.8,
+            "exploitability_score": 2.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010023",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-1010023"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010023",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-1010023"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libc-bin",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 5.3,
+            "exploitability_score": 3.9,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010024",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2019-1010024"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010024",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-1010024"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libc6",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 5.3,
+            "exploitability_score": 3.9,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010024",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2019-1010024"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010024",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-1010024"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libc-bin",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 5.3,
+            "exploitability_score": 3.9,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010025",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2019-1010025"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010025",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-1010025"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libc6",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 5.3,
+            "exploitability_score": 3.9,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1010025",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2019-1010025"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-1010025",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-1010025"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "bash",
+      "pkg_type": "dpkg",
+      "version": "5.0-4"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 7.2,
+            "exploitability_score": 3.9,
+            "impact_score": 10.0,
+            "vector": "AV:L/AC:L/Au:N/C:C/I:C/A:C",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.8,
+            "exploitability_score": 1.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-18276",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-18276"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18276",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-18276"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libpython2.7-minimal",
+      "pkg_type": "dpkg",
+      "version": "2.7.16-2+deb10u1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 6.1,
+            "exploitability_score": 2.8,
+            "impact_score": 2.7,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-18348",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2019-18348"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-18348"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libpython3.7-minimal",
+      "pkg_type": "dpkg",
+      "version": "3.7.3-2+deb10u3"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 6.1,
+            "exploitability_score": 2.8,
+            "impact_score": 2.7,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-18348",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2019-18348"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-18348"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "python2.7-minimal",
+      "pkg_type": "dpkg",
+      "version": "2.7.16-2+deb10u1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 6.1,
+            "exploitability_score": 2.8,
+            "impact_score": 2.7,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-18348",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2019-18348"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-18348"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
       "name": "python3.7-minimal",
       "pkg_type": "dpkg",
       "version": "3.7.3-2+deb10u3"
@@ -4538,7 +2929,1307 @@
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 6.1,
+            "exploitability_score": 2.8,
+            "impact_score": 2.7,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-18348",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2019-18348"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-18348"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "login",
+      "pkg_type": "dpkg",
+      "version": "1:4.5-1.1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 6.9,
+            "exploitability_score": 3.4,
+            "impact_score": 10.0,
+            "vector": "AV:L/AC:M/Au:N/C:C/I:C/A:C",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.8,
+            "exploitability_score": 1.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-19882",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-19882"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-19882",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-19882"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "passwd",
+      "pkg_type": "dpkg",
+      "version": "1:4.5-1.1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 6.9,
+            "exploitability_score": 3.4,
+            "impact_score": 10.0,
+            "vector": "AV:L/AC:M/Au:N/C:C/I:C/A:C",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.8,
+            "exploitability_score": 1.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-19882",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-19882"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-19882",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-19882"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libnss-systemd",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 2.4,
+            "exploitability_score": 0.9,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-20386",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2019-20386"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-20386"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libsystemd0",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 2.4,
+            "exploitability_score": 0.9,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-20386",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2019-20386"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-20386"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libudev1",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 2.4,
+            "exploitability_score": 0.9,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-20386",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2019-20386"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-20386"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "systemd",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 2.4,
+            "exploitability_score": 0.9,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-20386",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2019-20386"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-20386"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libpcre3",
+      "pkg_type": "dpkg",
+      "version": "2:8.39-12"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-20838",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-20838"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20838",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-20838"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libc-bin",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9192",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-9192"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9192",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-9192"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libc6",
+      "pkg_type": "dpkg",
+      "version": "2.28-10"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9192",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-9192"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9192",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-9192"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libpython2.7-minimal",
+      "pkg_type": "dpkg",
+      "version": "2.7.16-2+deb10u1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9674",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-9674"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-9674"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libpython3.7-minimal",
+      "pkg_type": "dpkg",
+      "version": "3.7.3-2+deb10u3"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9674",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-9674"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-9674"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "python2.7-minimal",
+      "pkg_type": "dpkg",
+      "version": "2.7.16-2+deb10u1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9674",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-9674"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-9674"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "python3.7-minimal",
+      "pkg_type": "dpkg",
+      "version": "3.7.3-2+deb10u3"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9674",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-9674"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9674",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-9674"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libseccomp2",
+      "pkg_type": "dpkg",
+      "version": "2.3.3-4"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 7.5,
+            "exploitability_score": 10.0,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 9.8,
+            "exploitability_score": 3.9,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9893",
+        "severity": "Critical",
+        "vulnerability_id": "CVE-2019-9893"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9893",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-9893"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "tar",
+      "pkg_type": "dpkg",
+      "version": "1.30+dfsg-6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.0"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-9923",
+        "severity": "High",
+        "vulnerability_id": "CVE-2019-9923"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2019-9923",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2019-9923"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libnss-systemd",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 2.9,
+            "exploitability_score": 5.5,
+            "impact_score": 2.9,
+            "vector": "AV:A/AC:M/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 6.1,
+            "exploitability_score": 1.6,
+            "impact_score": 4.0,
+            "vector": "CVSS:3.1/AV:A/AC:H/PR:N/UI:N/S:C/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13529",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2020-13529"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13529",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2020-13529"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libsystemd0",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 2.9,
+            "exploitability_score": 5.5,
+            "impact_score": 2.9,
+            "vector": "AV:A/AC:M/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 6.1,
+            "exploitability_score": 1.6,
+            "impact_score": 4.0,
+            "vector": "CVSS:3.1/AV:A/AC:H/PR:N/UI:N/S:C/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13529",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2020-13529"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13529",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2020-13529"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libudev1",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 2.9,
+            "exploitability_score": 5.5,
+            "impact_score": 2.9,
+            "vector": "AV:A/AC:M/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 6.1,
+            "exploitability_score": 1.6,
+            "impact_score": 4.0,
+            "vector": "CVSS:3.1/AV:A/AC:H/PR:N/UI:N/S:C/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13529",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2020-13529"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13529",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2020-13529"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "systemd",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 2.9,
+            "exploitability_score": 5.5,
+            "impact_score": 2.9,
+            "vector": "AV:A/AC:M/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 6.1,
+            "exploitability_score": 1.6,
+            "impact_score": 4.0,
+            "vector": "CVSS:3.1/AV:A/AC:H/PR:N/UI:N/S:C/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13529",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2020-13529"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13529",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2020-13529"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libnss-systemd",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 6.2,
+            "exploitability_score": 1.9,
+            "impact_score": 10.0,
+            "vector": "AV:L/AC:H/Au:N/C:C/I:C/A:C",
+            "version": "2.0"
+          },
+          {
+            "base_score": 6.7,
+            "exploitability_score": 0.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13776",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2020-13776"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2020-13776"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libsystemd0",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 6.2,
+            "exploitability_score": 1.9,
+            "impact_score": 10.0,
+            "vector": "AV:L/AC:H/Au:N/C:C/I:C/A:C",
+            "version": "2.0"
+          },
+          {
+            "base_score": 6.7,
+            "exploitability_score": 0.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13776",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2020-13776"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2020-13776"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libudev1",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 6.2,
+            "exploitability_score": 1.9,
+            "impact_score": 10.0,
+            "vector": "AV:L/AC:H/Au:N/C:C/I:C/A:C",
+            "version": "2.0"
+          },
+          {
+            "base_score": 6.7,
+            "exploitability_score": 0.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13776",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2020-13776"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2020-13776"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "systemd",
+      "pkg_type": "dpkg",
+      "version": "241-7~deb10u7"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 6.2,
+            "exploitability_score": 1.9,
+            "impact_score": 10.0,
+            "vector": "AV:L/AC:H/Au:N/C:C/I:C/A:C",
+            "version": "2.0"
+          },
+          {
+            "base_score": 6.7,
+            "exploitability_score": 0.8,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13776",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2020-13776"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-13776",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2020-13776"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libldap-common",
+      "pkg_type": "dpkg",
+      "version": "2.4.47+dfsg-3+deb10u6"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.0,
+            "exploitability_score": 4.9,
+            "impact_score": 4.9,
+            "vector": "AV:N/AC:H/Au:N/C:P/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 4.2,
+            "exploitability_score": 1.6,
+            "impact_score": 2.5,
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-15719",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2020-15719"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-15719",
+      "severity": "Negligible",
+      "vulnerability_id": "CVE-2020-15719"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "libpython3.7-minimal",
+      "pkg_type": "dpkg",
+      "version": "3.7.3-2+deb10u3"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": null,
+      "versions": [],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
     },
     "nvd": [
       {
@@ -4590,30 +4281,30 @@
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
+      "detected_at": "2021-09-24T18:59:14Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+            "base_score": 7.5,
+            "exploitability_score": 10.0,
+            "impact_score": 6.4,
+            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
             "version": "2.0"
           },
           {
-            "base_score": 6.1,
-            "exploitability_score": 2.8,
-            "impact_score": 2.7,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+            "base_score": 9.8,
+            "exploitability_score": 3.9,
+            "impact_score": 5.9,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
             "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-18348",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2019-18348"
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-27619",
+        "severity": "Critical",
+        "vulnerability_id": "CVE-2020-27619"
       }
     ],
     "vulnerability": {
@@ -4621,9 +4312,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-27619",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-18348"
+      "vulnerability_id": "CVE-2020-27619"
     }
   },
   {
@@ -4631,9 +4322,9 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "passwd",
+      "name": "libglib2.0-0",
       "pkg_type": "dpkg",
-      "version": "1:4.5-1.1"
+      "version": "2.58.3-2+deb10u2"
     },
     "fix": {
       "advisories": [],
@@ -4642,16 +4333,16 @@
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
+      "detected_at": "2021-09-24T18:59:14Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 6.9,
-            "exploitability_score": 3.4,
-            "impact_score": 10.0,
-            "vector": "AV:L/AC:M/Au:N/C:C/I:C/A:C",
+            "base_score": 4.6,
+            "exploitability_score": 3.9,
+            "impact_score": 6.4,
+            "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
             "version": "2.0"
           },
           {
@@ -4663,9 +4354,9 @@
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-19882",
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-35457",
         "severity": "High",
-        "vulnerability_id": "CVE-2019-19882"
+        "vulnerability_id": "CVE-2020-35457"
       }
     ],
     "vulnerability": {
@@ -4673,9 +4364,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-19882",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2020-35457",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-19882"
+      "vulnerability_id": "CVE-2020-35457"
     }
   },
   {
@@ -4683,9 +4374,9 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "libpython3.7-minimal",
+      "name": "tar",
       "pkg_type": "dpkg",
-      "version": "3.7.3-2+deb10u3"
+      "version": "1.30+dfsg-6"
     },
     "fix": {
       "advisories": [],
@@ -4694,30 +4385,30 @@
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
+      "detected_at": "2021-09-24T18:59:14Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 6.8,
+            "base_score": 4.3,
             "exploitability_score": 8.6,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
             "version": "2.0"
           },
           {
-            "base_score": 8.8,
-            "exploitability_score": 2.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
-            "version": "3.0"
+            "base_score": 5.5,
+            "exploitability_score": 1.8,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
+            "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-17522",
-        "severity": "High",
-        "vulnerability_id": "CVE-2017-17522"
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-20193",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2021-20193"
       }
     ],
     "vulnerability": {
@@ -4725,9 +4416,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2017-17522",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2021-20193",
       "severity": "Negligible",
-      "vulnerability_id": "CVE-2017-17522"
+      "vulnerability_id": "CVE-2021-20193"
     }
   },
   {
@@ -4735,34 +4426,43 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "libc-bin",
+      "name": "openjdk-11-jre-headless",
       "pkg_type": "dpkg",
-      "version": "2.28-10"
+      "version": "11.0.9.1+1-1~deb10u2"
     },
     "fix": {
       "advisories": [],
-      "observed_at": null,
-      "versions": [],
+      "observed_at": "2021-09-24T18:59:14Z",
+      "versions": [
+        "11.0.11+9-1~deb10u1"
+      ],
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
+      "detected_at": "2021-09-24T18:59:14Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
+            "base_score": 2.6,
+            "exploitability_score": 4.9,
             "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "vector": "AV:N/AC:H/Au:N/C:N/I:P/A:N",
             "version": "2.0"
+          },
+          {
+            "base_score": 5.3,
+            "exploitability_score": 1.6,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:H/A:N",
+            "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-4051",
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-2163",
         "severity": "Medium",
-        "vulnerability_id": "CVE-2010-4051"
+        "vulnerability_id": "CVE-2021-2163"
       }
     ],
     "vulnerability": {
@@ -4770,9 +4470,9 @@
       "description": null,
       "feed": "vulnerabilities",
       "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2010-4051",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2010-4051"
+      "link": "https://security-tracker.debian.org/tracker/CVE-2021-2163",
+      "severity": "Low",
+      "vulnerability_id": "CVE-2021-2163"
     }
   },
   {
@@ -4780,18 +4480,159 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "libpython2.7-minimal",
+      "name": "liblz4-1",
       "pkg_type": "dpkg",
-      "version": "2.7.16-2+deb10u1"
+      "version": "1.8.3-1"
     },
     "fix": {
       "advisories": [],
-      "observed_at": null,
-      "versions": [],
+      "observed_at": "2021-09-24T18:59:14Z",
+      "versions": [
+        "1.8.3-1+deb10u1"
+      ],
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "debian:10",
+      "link": "https://security-tracker.debian.org/tracker/CVE-2021-3520",
+      "severity": "Unknown",
+      "vulnerability_id": "CVE-2021-3520"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/sandbox/target/my-app-1.jar:guava",
+      "name": "guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-09-24T18:59:14Z",
+      "versions": [
+        "30.0-jre"
+      ],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 3.3,
+            "exploitability_score": 1.8,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2020-8908"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": "Information Disclosure in Guava",
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/sandbox/target/original-my-app-1.jar:guava",
+      "name": "guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-09-24T18:59:14Z",
+      "versions": [
+        "30.0-jre"
+      ],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 3.3,
+            "exploitability_score": 1.8,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2020-8908"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": "Information Disclosure in Guava",
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/sandbox/node_modules/xmldom/package.json",
+      "name": "xmldom",
+      "pkg_type": "npm",
+      "version": "0.4.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-09-24T18:59:14Z",
+      "versions": [
+        "0.5.0"
+      ],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
     },
     "nvd": [
       {
@@ -4804,98 +4645,156 @@
             "version": "2.0"
           },
           {
-            "base_score": 6.1,
+            "base_score": 4.3,
             "exploitability_score": 2.8,
-            "impact_score": 2.7,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
             "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-18348",
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21366",
         "severity": "Medium",
-        "vulnerability_id": "CVE-2019-18348"
+        "vulnerability_id": "CVE-2021-21366"
       }
     ],
     "vulnerability": {
       "cvss": [],
-      "description": null,
+      "description": "Misinterpretation of malicious XML input",
       "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-18348",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-18348"
+      "feed_group": "github:npm",
+      "link": "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv",
+      "severity": "Low",
+      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv"
     }
   },
   {
     "artifact": {
       "cpe": null,
       "cpes": [],
-      "location": "pkgdb",
-      "name": "libudev1",
-      "pkg_type": "dpkg",
-      "version": "241-7~deb10u6"
+      "location": "/sandbox/target/my-app-1.jar:guava",
+      "name": "guava",
+      "pkg_type": "java",
+      "version": "23.0"
     },
     "fix": {
       "advisories": [],
-      "observed_at": null,
-      "versions": [],
+      "observed_at": "2021-09-24T18:59:14Z",
+      "versions": [
+        "24.1.1-jre"
+      ],
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
+      "detected_at": "2021-09-24T18:59:14Z"
     },
     "nvd": [
       {
         "cvss": [
           {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
             "impact_score": 2.9,
-            "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:P",
+            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
             "version": "2.0"
           },
           {
-            "base_score": 2.4,
-            "exploitability_score": 0.9,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+            "base_score": 5.9,
+            "exploitability_score": 2.2,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
             "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-20386",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2019-20386"
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2018-10237"
       }
     ],
     "vulnerability": {
       "cvss": [],
-      "description": null,
+      "description": "Denial of Service in Google Guava",
       "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2019-20386",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2019-20386"
+      "feed_group": "github:java",
+      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
     }
   },
   {
     "artifact": {
       "cpe": null,
       "cpes": [],
-      "location": "pkgdb",
-      "name": "libssl1.1",
-      "pkg_type": "dpkg",
-      "version": "1.1.1d-0+deb10u6"
+      "location": "/sandbox/target/original-my-app-1.jar:guava",
+      "name": "guava",
+      "pkg_type": "java",
+      "version": "23.0"
     },
     "fix": {
       "advisories": [],
-      "observed_at": null,
-      "versions": [],
+      "observed_at": "2021-09-24T18:59:14Z",
+      "versions": [
+        "24.1.1-jre"
+      ],
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-06-08T20:34:56Z"
+      "detected_at": "2021-09-24T18:59:14Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 5.9,
+            "exploitability_score": 2.2,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2018-10237"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": "Denial of Service in Google Guava",
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/usr/local/lib/python3.7/dist-packages/aiohttp",
+      "name": "aiohttp",
+      "pkg_type": "python",
+      "version": "3.7.3"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-09-24T18:59:14Z",
+      "versions": [
+        "3.7.4"
+      ],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-24T18:59:14Z"
     },
     "nvd": [
       {
@@ -4906,22 +4805,29 @@
             "impact_score": 4.9,
             "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:N",
             "version": "2.0"
+          },
+          {
+            "base_score": 6.1,
+            "exploitability_score": 2.8,
+            "impact_score": 2.7,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+            "version": "3.1"
           }
         ],
         "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2007-6755",
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21330",
         "severity": "Medium",
-        "vulnerability_id": "CVE-2007-6755"
+        "vulnerability_id": "CVE-2021-21330"
       }
     ],
     "vulnerability": {
       "cvss": [],
-      "description": null,
+      "description": "Open redirect vulnerability in `aiohttp` (`normalize_path_middleware` middleware)",
       "feed": "vulnerabilities",
-      "feed_group": "debian:10",
-      "link": "https://security-tracker.debian.org/tracker/CVE-2007-6755",
-      "severity": "Negligible",
-      "vulnerability_id": "CVE-2007-6755"
+      "feed_group": "github:python",
+      "link": "https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
+      "severity": "Low",
+      "vulnerability_id": "GHSA-v6wp-4m6f-gcjg"
     }
   }
 ]

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/grype/sha256:80a31c3ce2e99c3691c27ac3b1753163214494e9b2ca07bfdccf29a5cca2bfbe.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/grype/sha256:80a31c3ce2e99c3691c27ac3b1753163214494e9b2ca07bfdccf29a5cca2bfbe.json
@@ -3,408 +3,6 @@
     "artifact": {
       "cpe": null,
       "cpes": [
-        "cpe:2.3:a:*:guava:23.0:*:*:*:*:*:*:*",
-        "cpe:2.3:a:google:guava:23.0:*:*:*:*:*:*:*"
-      ],
-      "location": "/sandbox/target/original-my-app-1.jar:guava",
-      "name": "guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:16:01Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 4.3,
-          "exploitability_score": 8.6,
-          "impact_score": 2.9,
-          "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
-          "version": "2.0"
-        },
-        {
-          "base_score": 5.9,
-          "exploitability_score": 2.2,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
-          "version": "3.1"
-        }
-      ],
-      "description": "Unbounded memory allocation in Google Guava 11.0 through 24.x before 24.1.1 allows remote attackers to conduct denial of service attacks against servers that depend on this library and deserialize attacker-provided data, because the AtomicDoubleArray class (when serialized with Java serialization) and the CompoundOrdering class (when serialized with GWT serialization) perform eager allocation without appropriate checks on what a client has sent and whether the data size is reasonable.",
-      "feed": "vulnerabilities",
-      "feed_group": "nvd",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2018-10237"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [
-        "cpe:2.3:a:*:app:1:*:*:*:*:*:*:*"
-      ],
-      "location": "/sandbox/target/original-my-app-1.jar",
-      "name": "my-app",
-      "pkg_type": "java",
-      "version": "1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:16:01Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 5.0,
-          "exploitability_score": 10.0,
-          "impact_score": 2.9,
-          "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
-          "version": "2.0"
-        },
-        {
-          "base_score": 7.5,
-          "exploitability_score": 3.9,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
-          "version": "3.0"
-        }
-      ],
-      "description": "The mintToken function of a smart contract implementation for APP, an Ethereum token, has an integer overflow that allows the owner of the contract to set the balance of an arbitrary user to any value.",
-      "feed": "vulnerabilities",
-      "feed_group": "nvd",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-13661",
-      "severity": "High",
-      "vulnerability_id": "CVE-2018-13661"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [
-        "cpe:2.3:a:*:pip:20.2.3:*:*:*:*:*:*:*"
-      ],
-      "location": "/usr/lib/python3.8/site-packages/pip",
-      "name": "pip",
-      "pkg_type": "python",
-      "version": "20.2.3"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:16:01Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 6.8,
-          "exploitability_score": 8.6,
-          "impact_score": 6.4,
-          "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
-          "version": "2.0"
-        },
-        {
-          "base_score": 7.8,
-          "exploitability_score": 1.8,
-          "impact_score": 5.9,
-          "vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
-          "version": "3.1"
-        }
-      ],
-      "description": "** DISPUTED ** An issue was discovered in pip (all versions) because it installs the version with the highest version number, even if the user had intended to obtain a private package from a private index. This only affects use of the --extra-index-url option, and exploitation requires that the package does not already exist in the public index (and thus the attacker can put the package there with an arbitrary version number). NOTE: it has been reported that this is intended functionality and the user is responsible for using --extra-index-url securely.",
-      "feed": "vulnerabilities",
-      "feed_group": "nvd",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-20225",
-      "severity": "High",
-      "vulnerability_id": "CVE-2018-20225"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [
-        "cpe:2.3:a:*:aiohttp:3.7.3:*:*:*:*:*:*:*"
-      ],
-      "location": "/usr/lib/python3.8/site-packages/aiohttp",
-      "name": "aiohttp",
-      "pkg_type": "python",
-      "version": "3.7.3"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:16:01Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 5.8,
-          "exploitability_score": 8.6,
-          "impact_score": 4.9,
-          "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:N",
-          "version": "2.0"
-        },
-        {
-          "base_score": 6.1,
-          "exploitability_score": 2.8,
-          "impact_score": 2.7,
-          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
-          "version": "3.1"
-        }
-      ],
-      "description": "aiohttp is an asynchronous HTTP client/server framework for asyncio and Python. In aiohttp before version 3.7.4 there is an open redirect vulnerability. A maliciously crafted link to an aiohttp-based web-server could redirect the browser to a different website. It is caused by a bug in the `aiohttp.web_middlewares.normalize_path_middleware` middleware. This security problem has been fixed in 3.7.4. Upgrade your dependency using pip as follows \"pip install aiohttp >= 3.7.4\". If upgrading is not an option for you, a workaround can be to avoid using `aiohttp.web_middlewares.normalize_path_middleware` in your applications.",
-      "feed": "vulnerabilities",
-      "feed_group": "nvd",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21330",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2021-21330"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [
-        "cpe:2.3:a:*:xmldom:0.4.0:*:*:*:*:*:*:*"
-      ],
-      "location": "/sandbox/node_modules/xmldom/package.json",
-      "name": "xmldom",
-      "pkg_type": "npm",
-      "version": "0.4.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:16:01Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 4.3,
-          "exploitability_score": 8.6,
-          "impact_score": 2.9,
-          "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-          "version": "2.0"
-        },
-        {
-          "base_score": 4.3,
-          "exploitability_score": 2.8,
-          "impact_score": 1.4,
-          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
-          "version": "3.1"
-        }
-      ],
-      "description": "xmldom is a pure JavaScript W3C standard-based (XML DOM Level 2 Core) DOMParser and XMLSerializer module. xmldom versions 0.4.0 and older do not correctly preserve system identifiers, FPIs or namespaces when repeatedly parsing and serializing maliciously crafted documents. This may lead to unexpected syntactic changes during XML processing in some downstream applications. This is fixed in version 0.5.0. As a workaround downstream applications can validate the input and reject the maliciously crafted documents.",
-      "feed": "vulnerabilities",
-      "feed_group": "nvd",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21366",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2021-21366"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "apk-tools",
-      "pkg_type": "APKG",
-      "version": "2.10.5-r1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-06-08T20:16:01Z",
-      "versions": [
-        "2.10.6-r0"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:16:01Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [],
-      "description": null,
-      "feed": "vulnerabilities",
-      "feed_group": "alpine:3.12",
-      "link": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-30139",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2021-30139"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [
-        "cpe:2.3:a:*:guava:23.0:*:*:*:*:*:*:*",
-        "cpe:2.3:a:google:guava:23.0:*:*:*:*:*:*:*"
-      ],
-      "location": "/sandbox/target/my-app-1.jar:guava",
-      "name": "guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:16:01Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 4.3,
-          "exploitability_score": 8.6,
-          "impact_score": 2.9,
-          "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
-          "version": "2.0"
-        },
-        {
-          "base_score": 5.9,
-          "exploitability_score": 2.2,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
-          "version": "3.1"
-        }
-      ],
-      "description": "Unbounded memory allocation in Google Guava 11.0 through 24.x before 24.1.1 allows remote attackers to conduct denial of service attacks against servers that depend on this library and deserialize attacker-provided data, because the AtomicDoubleArray class (when serialized with Java serialization) and the CompoundOrdering class (when serialized with GWT serialization) perform eager allocation without appropriate checks on what a client has sent and whether the data size is reasonable.",
-      "feed": "vulnerabilities",
-      "feed_group": "nvd",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2018-10237"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [
-        "cpe:2.3:a:*:app:1:*:*:*:*:*:*:*"
-      ],
-      "location": "/sandbox/target/my-app-1.jar",
-      "name": "my-app",
-      "pkg_type": "java",
-      "version": "1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:16:01Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 5.0,
-          "exploitability_score": 10.0,
-          "impact_score": 2.9,
-          "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
-          "version": "2.0"
-        },
-        {
-          "base_score": 7.5,
-          "exploitability_score": 3.9,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
-          "version": "3.0"
-        }
-      ],
-      "description": "The mintToken function of a smart contract implementation for APP, an Ethereum token, has an integer overflow that allows the owner of the contract to set the balance of an arbitrary user to any value.",
-      "feed": "vulnerabilities",
-      "feed_group": "nvd",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-13661",
-      "severity": "High",
-      "vulnerability_id": "CVE-2018-13661"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [
-        "cpe:2.3:a:*:guava:23.0:*:*:*:*:*:*:*",
-        "cpe:2.3:a:google:guava:23.0:*:*:*:*:*:*:*"
-      ],
-      "location": "/sandbox/target/my-app-1.jar:guava",
-      "name": "guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:16:01Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 2.1,
-          "exploitability_score": 3.9,
-          "impact_score": 2.9,
-          "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
-          "version": "2.0"
-        },
-        {
-          "base_score": 3.3,
-          "exploitability_score": 1.8,
-          "impact_score": 1.4,
-          "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
-          "version": "3.1"
-        }
-      ],
-      "description": "A temp directory creation vulnerability exists in all versions of Guava, allowing an attacker with access to the machine to potentially access data in a temporary directory created by the Guava API com.google.common.io.Files.createTempDir(). By default, on unix-like systems, the created directory is world-readable (readable by an attacker with access to the system). The method in question has been marked @Deprecated in versions 30.0 and later and should not be used. For Android developers, we recommend choosing a temporary directory API provided by Android, such as context.getCacheDir(). For other Java developers, we recommend migrating to the Java 7 API java.nio.file.Files.createTempDirectory() which explicitly configures permissions of 700, or configuring the Java runtime's java.io.tmpdir system property to point to a location whose permissions are appropriately configured.",
-      "feed": "vulnerabilities",
-      "feed_group": "nvd",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2020-8908"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [
         "cpe:2.3:a:*:ftpd:0.2.1:*:*:*:*:*:*:*"
       ],
       "location": "/usr/lib/ruby/gems/2.7.0/specifications/ftpd-0.2.1.gemspec",
@@ -419,7 +17,7 @@
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-06-08T20:16:01Z"
+      "detected_at": "2021-09-28T17:53:07Z"
     },
     "nvd": [],
     "vulnerability": {
@@ -450,53 +48,6 @@
   {
     "artifact": {
       "cpe": null,
-      "cpes": [
-        "cpe:2.3:a:*:guava:23.0:*:*:*:*:*:*:*",
-        "cpe:2.3:a:google:guava:23.0:*:*:*:*:*:*:*"
-      ],
-      "location": "/sandbox/target/original-my-app-1.jar:guava",
-      "name": "guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-06-08T20:16:01Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 2.1,
-          "exploitability_score": 3.9,
-          "impact_score": 2.9,
-          "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
-          "version": "2.0"
-        },
-        {
-          "base_score": 3.3,
-          "exploitability_score": 1.8,
-          "impact_score": 1.4,
-          "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
-          "version": "3.1"
-        }
-      ],
-      "description": "A temp directory creation vulnerability exists in all versions of Guava, allowing an attacker with access to the machine to potentially access data in a temporary directory created by the Guava API com.google.common.io.Files.createTempDir(). By default, on unix-like systems, the created directory is world-readable (readable by an attacker with access to the system). The method in question has been marked @Deprecated in versions 30.0 and later and should not be used. For Android developers, we recommend choosing a temporary directory API provided by Android, such as context.getCacheDir(). For other Java developers, we recommend migrating to the Java 7 API java.nio.file.Files.createTempDirectory() which explicitly configures permissions of 700, or configuring the Java runtime's java.io.tmpdir system property to point to a location whose permissions are appropriately configured.",
-      "feed": "vulnerabilities",
-      "feed_group": "nvd",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2020-8908"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
       "cpes": [],
       "location": "pkgdb",
       "name": "busybox",
@@ -505,14 +56,14 @@
     },
     "fix": {
       "advisories": [],
-      "observed_at": "2021-06-08T20:16:01Z",
+      "observed_at": "2021-09-28T17:53:07Z",
       "versions": [
         "1.31.1-r20"
       ],
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-06-08T20:16:01Z"
+      "detected_at": "2021-09-28T17:53:07Z"
     },
     "nvd": [
       {
@@ -551,9 +102,362 @@
   {
     "artifact": {
       "cpe": null,
-      "cpes": [
-        "cpe:2.3:a:*:aiohttp:3.7.3:*:*:*:*:*:*:*"
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "ssl_client",
+      "pkg_type": "APKG",
+      "version": "1.31.1-r19"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-09-28T17:53:07Z",
+      "versions": [
+        "1.31.1-r20"
       ],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-28T17:53:07Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.0,
+            "exploitability_score": 10.0,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 7.5,
+            "exploitability_score": 3.9,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-28831",
+        "severity": "High",
+        "vulnerability_id": "CVE-2021-28831"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "alpine:3.12",
+      "link": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-28831",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2021-28831"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "pkgdb",
+      "name": "apk-tools",
+      "pkg_type": "APKG",
+      "version": "2.10.5-r1"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-09-28T17:53:07Z",
+      "versions": [
+        "2.10.6-r0"
+      ],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-28T17:53:07Z"
+    },
+    "nvd": [],
+    "vulnerability": {
+      "cvss": [],
+      "description": null,
+      "feed": "vulnerabilities",
+      "feed_group": "alpine:3.12",
+      "link": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-30139",
+      "severity": "Medium",
+      "vulnerability_id": "CVE-2021-30139"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/sandbox/target/my-app-1.jar:guava",
+      "name": "guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-09-28T17:53:07Z",
+      "versions": [
+        "30.0-jre"
+      ],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-28T17:53:07Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 3.3,
+            "exploitability_score": 1.8,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2020-8908"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": "Information Disclosure in Guava",
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/sandbox/target/original-my-app-1.jar:guava",
+      "name": "guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-09-28T17:53:07Z",
+      "versions": [
+        "30.0-jre"
+      ],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-28T17:53:07Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 3.3,
+            "exploitability_score": 1.8,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2020-8908"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": "Information Disclosure in Guava",
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/sandbox/node_modules/xmldom/package.json",
+      "name": "xmldom",
+      "pkg_type": "npm",
+      "version": "0.4.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-09-28T17:53:07Z",
+      "versions": [
+        "0.5.0"
+      ],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-28T17:53:07Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 4.3,
+            "exploitability_score": 2.8,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21366",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2021-21366"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": "Misinterpretation of malicious XML input",
+      "feed": "vulnerabilities",
+      "feed_group": "github:npm",
+      "link": "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv",
+      "severity": "Low",
+      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/sandbox/target/my-app-1.jar:guava",
+      "name": "guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-09-28T17:53:07Z",
+      "versions": [
+        "24.1.1-jre"
+      ],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-28T17:53:07Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 5.9,
+            "exploitability_score": 2.2,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2018-10237"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": "Denial of Service in Google Guava",
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/sandbox/target/original-my-app-1.jar:guava",
+      "name": "guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-09-28T17:53:07Z",
+      "versions": [
+        "24.1.1-jre"
+      ],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-28T17:53:07Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 5.9,
+            "exploitability_score": 2.2,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2018-10237"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": "Denial of Service in Google Guava",
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
       "location": "/usr/lib/python3.8/site-packages/aiohttp",
       "name": "aiohttp",
       "pkg_type": "python",
@@ -561,37 +465,47 @@
     },
     "fix": {
       "advisories": [],
-      "observed_at": null,
-      "versions": [],
+      "observed_at": "2021-09-28T17:53:07Z",
+      "versions": [
+        "3.7.4"
+      ],
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-06-08T20:16:01Z"
+      "detected_at": "2021-09-28T17:53:07Z"
     },
-    "nvd": [],
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.8,
+            "exploitability_score": 8.6,
+            "impact_score": 4.9,
+            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 6.1,
+            "exploitability_score": 2.8,
+            "impact_score": 2.7,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21330",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2021-21330"
+      }
+    ],
     "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 4.3,
-          "exploitability_score": 8.6,
-          "impact_score": 2.9,
-          "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-          "version": "2.0"
-        },
-        {
-          "base_score": 6.5,
-          "exploitability_score": 2.8,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:N",
-          "version": "3.0"
-        }
-      ],
-      "description": "aio-libs aiohttp-session contains a Session Fixation vulnerability in load_session function for RedisStorage (see: https://github.com/aio-libs/aiohttp-session/blob/master/aiohttp_session/redis_storage.py#L42) that can result in Session Hijacking. This attack appear to be exploitable via Any method that allows setting session cookies (?session=<>, or meta tags or script tags with Set-Cookie).",
+      "cvss": [],
+      "description": "Open redirect vulnerability in `aiohttp` (`normalize_path_middleware` middleware)",
       "feed": "vulnerabilities",
-      "feed_group": "nvd",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-1000519",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2018-1000519"
+      "feed_group": "github:python",
+      "link": "https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
+      "severity": "Low",
+      "vulnerability_id": "GHSA-v6wp-4m6f-gcjg"
     }
   }
 ]

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/grype/sha256:fe3ca35038008b0eac0fa4e686bd072c9430000ab7d7853001bde5f5b8ccf60c.json
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/expected_output/test_vulnerability_scanner/grype/sha256:fe3ca35038008b0eac0fa4e686bd072c9430000ab7d7853001bde5f5b8ccf60c.json
@@ -2,53 +2,6 @@
   {
     "artifact": {
       "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-34.el7_0.3"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.0,
-            "exploitability_score": 4.9,
-            "impact_score": 4.9,
-            "vector": "AV:N/AC:H/Au:N/C:N/I:P/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2010-5298",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2010-5298"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "Race condition in the ssl3_read_bytes function in s3_pkt.c in OpenSSL through 1.0.1g, when SSL_MODE_RELEASE_BUFFERS is enabled, allows remote attackers to inject data across sessions or cause a denial of service (use-after-free and parsing error) via an SSL connection in a multithreaded environment.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2010-5298",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2010-5298"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
       "cpes": [
         "cpe:2.3:a:*:ftpd:0.2.1:*:*:*:*:*:*:*"
       ],
@@ -64,7 +17,7 @@
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
+      "detected_at": "2021-09-28T17:55:01Z"
     },
     "nvd": [],
     "vulnerability": {
@@ -97,827 +50,6 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-34.el7_0.3"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 6.8,
-            "exploitability_score": 8.6,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-0195",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2014-0195"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "The dtls1_reassemble_fragment function in d1_both.c in OpenSSL before 0.9.8za, 1.0.0 before 1.0.0m, and 1.0.1 before 1.0.1h does not properly validate fragment lengths in DTLS ClientHello messages, which allows remote attackers to execute arbitrary code or cause a denial of service (buffer overflow and application crash) via a long non-initial fragment.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2014-0195",
-      "severity": "High",
-      "vulnerability_id": "CVE-2014-0195"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-34.el7_0.3"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-0198",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2014-0198"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "The do_ssl3_write function in s3_pkt.c in OpenSSL 1.x through 1.0.1g, when SSL_MODE_RELEASE_BUFFERS is enabled, does not properly manage a buffer pointer during certain recursive calls, which allows remote attackers to cause a denial of service (NULL pointer dereference and application crash) via vectors that trigger an alert condition.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2014-0198",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2014-0198"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-34.el7_0.3"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-0221",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2014-0221"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "A denial of service flaw was found in the way OpenSSL handled certain DTLS ServerHello requests. A specially crafted DTLS handshake packet could cause a DTLS client using OpenSSL to crash.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2014-0221",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2014-0221"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-34.el7_0.3"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.8,
-            "exploitability_score": 8.6,
-            "impact_score": 4.9,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.4,
-            "exploitability_score": 2.2,
-            "impact_score": 5.2,
-            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-0224",
-        "severity": "High",
-        "vulnerability_id": "CVE-2014-0224"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "It was found that OpenSSL clients and servers could be forced, via a specially crafted handshake packet, to use weak keying material for communication. A man-in-the-middle attacker could use this flaw to decrypt and modify traffic between a client and a server.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2014-0224",
-      "severity": "High",
-      "vulnerability_id": "CVE-2014-0224"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-34.el7_0.3"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-3470",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2014-3470"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "The ssl3_send_client_key_exchange function in s3_clnt.c in OpenSSL before 0.9.8za, 1.0.0 before 1.0.0m, and 1.0.1 before 1.0.1h, when an anonymous ECDH cipher suite is used, allows remote attackers to cause a denial of service (NULL pointer dereference and client crash) by triggering a NULL certificate value.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2014-3470",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2014-3470"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-34.el7_0.4"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-3505",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2014-3505"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "A flaw was discovered in the way OpenSSL handled DTLS packets. A remote attacker could use this flaw to cause a DTLS server or client using OpenSSL to crash or use excessive amounts of memory.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2014-3505",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2014-3505"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-34.el7_0.4"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-3506",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2014-3506"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "A flaw was discovered in the way OpenSSL handled DTLS packets. A remote attacker could use this flaw to cause a DTLS server or client using OpenSSL to crash or use excessive amounts of memory.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2014-3506",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2014-3506"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-34.el7_0.4"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-3507",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2014-3507"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "A flaw was discovered in the way OpenSSL handled DTLS packets. A remote attacker could use this flaw to cause a DTLS server or client using OpenSSL to crash or use excessive amounts of memory.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2014-3507",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2014-3507"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-34.el7_0.4"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-3508",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2014-3508"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "It was discovered that the OBJ_obj2txt() function could fail to properly NUL-terminate its output. This could possibly cause an application using OpenSSL functions to format fields of X.509 certificates to disclose portions of its memory.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2014-3508",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2014-3508"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-34.el7_0.4"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 6.8,
-            "exploitability_score": 8.6,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-3509",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2014-3509"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "A race condition was found in the way OpenSSL handled ServerHello messages with an included Supported EC Point Format extension. A malicious server could possibly use this flaw to cause a multi-threaded TLS/SSL client using OpenSSL to write into freed memory, causing the client to crash or execute arbitrary code.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2014-3509",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2014-3509"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-34.el7_0.4"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-3510",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2014-3510"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "A NULL pointer dereference flaw was found in the way OpenSSL performed a handshake when using the anonymous Diffie-Hellman (DH) key exchange. A malicious server could cause a DTLS client using OpenSSL to crash if that client had anonymous DH cipher suites enabled.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2014-3510",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2014-3510"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-34.el7_0.4"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-3511",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2014-3511"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "A flaw was found in the way OpenSSL handled fragmented handshake packets. A man-in-the-middle attacker could use this flaw to force a TLS/SSL server using OpenSSL to use TLS 1.0, even if both the client and the server supported newer protocol versions.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2014-3511",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2014-3511"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-34.el7_0.6"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.1,
-            "exploitability_score": 8.6,
-            "impact_score": 6.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:C",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-3513",
-        "severity": "High",
-        "vulnerability_id": "CVE-2014-3513"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "A memory leak flaw was found in the way OpenSSL parsed the DTLS Secure Real-time Transport Protocol (SRTP) extension data. A remote attacker could send multiple specially crafted handshake messages to exhaust all available memory of an SSL/TLS or DTLS server.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2014-3513",
-      "severity": "High",
-      "vulnerability_id": "CVE-2014-3513"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-34.el7_0.6"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.1,
-            "exploitability_score": 8.6,
-            "impact_score": 6.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:C",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-3567",
-        "severity": "High",
-        "vulnerability_id": "CVE-2014-3567"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "A memory leak flaw was found in the way an OpenSSL handled failed session ticket integrity checks. A remote attacker could exhaust all available memory of an SSL/TLS or DTLS server by sending a large number of invalid session tickets to that server.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2014-3567",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2014-3567"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-34.el7_0.7"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-3570",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2014-3570"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 3.7,
-          "exploitability_score": 2.2,
-          "impact_score": 1.4,
-          "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N",
-          "version": "3.0"
-        },
-        {
-          "base_score": 3.7,
-          "exploitability_score": 2.2,
-          "impact_score": 1.4,
-          "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N",
-          "version": "3.0"
-        }
-      ],
-      "description": "It was found that OpenSSL's BigNumber Squaring implementation could produce incorrect results under certain special conditions. This flaw could possibly affect certain OpenSSL library functionality, such as RSA blinding. Note that this issue occurred rarely and with a low probability, and there is currently no known way of exploiting it.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2014-3570",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2014-3570"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-34.el7_0.7"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-3571",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2014-3571"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "A NULL pointer dereference flaw was found in the DTLS implementation of OpenSSL. A remote attacker could send a specially crafted DTLS message, which would cause an OpenSSL server to crash.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2014-3571",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2014-3571"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-34.el7_0.7"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-3572",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2014-3572"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "It was discovered that OpenSSL would perform an ECDH key exchange with a non-ephemeral key even when the ephemeral ECDH cipher suite was selected. A malicious server could make a TLS/SSL client using OpenSSL use a weaker key exchange method than the one requested by the user.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2014-3572",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2014-3572"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
       "name": "gnupg2",
       "pkg_type": "rpm",
       "version": "2.0.22-5.el7_5"
@@ -929,7 +61,7 @@
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
+      "detected_at": "2021-09-28T17:55:01Z"
     },
     "nvd": [
       {
@@ -981,7 +113,7 @@
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
+      "detected_at": "2021-09-28T17:55:01Z"
     },
     "nvd": [
       {
@@ -1033,7 +165,7 @@
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
+      "detected_at": "2021-09-28T17:55:01Z"
     },
     "nvd": [
       {
@@ -1078,7 +210,7 @@
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
+      "detected_at": "2021-09-28T17:55:01Z"
     },
     "nvd": [
       {
@@ -1123,7 +255,7 @@
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
+      "detected_at": "2021-09-28T17:55:01Z"
     },
     "nvd": [
       {
@@ -1168,7 +300,7 @@
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
+      "detected_at": "2021-09-28T17:55:01Z"
     },
     "nvd": [
       {
@@ -1202,318 +334,6 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-42.el7_1.8"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.5,
-            "exploitability_score": 10.0,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-8176",
-        "severity": "High",
-        "vulnerability_id": "CVE-2014-8176"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 7.5,
-          "exploitability_score": 3.9,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-          "version": "3.0"
-        },
-        {
-          "base_score": 7.5,
-          "exploitability_score": 3.9,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-          "version": "3.0"
-        }
-      ],
-      "description": "An invalid-free flaw was found in the way OpenSSL handled certain DTLS handshake messages. A malicious DTLS client or server could send a specially crafted message to the peer, which could cause the application to crash or potentially result in arbitrary code execution.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2014-8176",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2014-8176"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-34.el7_0.7"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2014-8275",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2014-8275"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "Multiple flaws were found in the way OpenSSL parsed X.509 certificates. An attacker could use these flaws to modify an X.509 certificate to produce a certificate with a different fingerprint without invalidating its signature, and possibly bypass fingerprint-based blacklisting in applications.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2014-8275",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2014-8275"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-34.el7_0.7"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-0204",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2015-0204"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 5.3,
-          "exploitability_score": 3.9,
-          "impact_score": 1.4,
-          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
-          "version": "3.0"
-        },
-        {
-          "base_score": 5.3,
-          "exploitability_score": 3.9,
-          "impact_score": 1.4,
-          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
-          "version": "3.0"
-        }
-      ],
-      "description": "It was discovered that OpenSSL would accept ephemeral RSA keys when using non-export RSA cipher suites. A malicious server could make a TLS/SSL client using OpenSSL use a weaker key exchange method.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2015-0204",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2015-0204"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-34.el7_0.7"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-0205",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2015-0205"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "It was found that an OpenSSL server would, under certain conditions, accept Diffie-Hellman client certificates without the use of a private key. An attacker could use a user's client certificate to authenticate as that user, without needing the private key.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2015-0205",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2015-0205"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-34.el7_0.7"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-0206",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2015-0206"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "A memory leak flaw was found in the way the dtls1_buffer_record() function of OpenSSL parsed certain DTLS messages. A remote attacker could send multiple specially crafted DTLS messages to exhaust all available memory of a DTLS server.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2015-0206",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2015-0206"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-42.el7_1.4"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 6.8,
-            "exploitability_score": 8.6,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-0209",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2015-0209"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "A use-after-free flaw was found in the way OpenSSL imported malformed Elliptic Curve private keys. A specially crafted key file could cause an application using OpenSSL to crash when imported.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2015-0209",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2015-0209"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
       "name": "libcom_err",
       "pkg_type": "rpm",
       "version": "1.42.9-19.el7"
@@ -1525,7 +345,7 @@
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
+      "detected_at": "2021-09-28T17:55:01Z"
     },
     "nvd": [
       {
@@ -1559,483 +379,6 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-42.el7_1.4"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-0286",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2015-0286"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "An invalid pointer use flaw was found in OpenSSL's ASN1_TYPE_cmp() function. A remote attacker could crash a TLS/SSL client or server using OpenSSL via a specially crafted X.509 certificate when the attacker-supplied certificate was verified by the application.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2015-0286",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2015-0286"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-42.el7_1.4"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-0287",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2015-0287"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "An out-of-bounds write flaw was found in the way OpenSSL reused certain ASN.1 structures. A remote attacker could possibly use a specially crafted ASN.1 structure that, when parsed by an application, would cause that application to crash.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2015-0287",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2015-0287"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-42.el7_1.4"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-0288",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2015-0288"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "A NULL pointer dereference flaw was found in OpenSSL's X.509 certificate handling implementation. A specially crafted X.509 certificate could cause an application using OpenSSL to crash if the application attempted to convert the certificate to a certificate request.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2015-0288",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2015-0288"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-42.el7_1.4"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-0289",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2015-0289"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "A NULL pointer dereference was found in the way OpenSSL handled certain PKCS#7 inputs. An attacker able to make an application using OpenSSL verify, decrypt, or parse a specially crafted PKCS#7 input could cause that application to crash. TLS/SSL clients and servers using OpenSSL were not affected by this flaw.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2015-0289",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2015-0289"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-42.el7_1.4"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.5,
-            "exploitability_score": 10.0,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-0292",
-        "severity": "High",
-        "vulnerability_id": "CVE-2015-0292"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "An integer underflow flaw, leading to a buffer overflow, was found in the way OpenSSL decoded malformed Base64-encoded inputs. An attacker able to make an application using OpenSSL decode a specially crafted Base64-encoded input (such as a PEM file) could use this flaw to cause the application to crash. Note: this flaw is not exploitable via the TLS/SSL protocol because the data being transferred is not Base64-encoded.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2015-0292",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2015-0292"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-42.el7_1.4"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-0293",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2015-0293"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "A denial of service flaw was found in the way OpenSSL handled SSLv2 handshake messages. A remote attacker could use this flaw to cause a TLS/SSL server using OpenSSL to exit on a failed assertion if it had both the SSLv2 protocol and EXPORT-grade cipher suites enabled.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2015-0293",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2015-0293"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-42.el7_1.8"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-1789",
-        "severity": "High",
-        "vulnerability_id": "CVE-2015-1789"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "An out-of-bounds read flaw was found in the X509_cmp_time() function of OpenSSL, which is used to test the expiry dates of SSL/TLS certificates. An attacker could possibly use a specially crafted SSL/TLS certificate or CRL (Certificate Revocation List), which when parsed by an application would cause that application to crash.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2015-1789",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2015-1789"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-42.el7_1.8"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-1790",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2015-1790"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "A NULL pointer dereference was found in the way OpenSSL handled certain PKCS#7 inputs. An attacker able to make an application using OpenSSL verify, decrypt, or parse a specially crafted PKCS#7 input could cause that application to crash. TLS/SSL clients and servers using OpenSSL were not affected by this flaw.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2015-1790",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2015-1790"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-42.el7_1.8"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 6.8,
-            "exploitability_score": 8.6,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-1791",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2015-1791"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "A race condition was found in the session handling code of OpenSSL. This issue could possibly cause a multi-threaded TLS/SSL client using OpenSSL to double free session ticket data and crash.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2015-1791",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2015-1791"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-42.el7_1.8"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-1792",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2015-1792"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "A denial of service flaw was found in the way OpenSSL verified certain signed messages using CMS (Cryptographic Message Syntax). A remote attacker could cause an application using OpenSSL to use excessive amounts of memory by sending a specially crafted message for verification.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2015-1792",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2015-1792"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
       "name": "libidn",
       "pkg_type": "rpm",
       "version": "1.28-4.el7"
@@ -2047,7 +390,7 @@
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
+      "detected_at": "2021-09-28T17:55:01Z"
     },
     "nvd": [
       {
@@ -2081,3368 +424,20 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-51.el7_2.1"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-3194",
-        "severity": "High",
-        "vulnerability_id": "CVE-2015-3194"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "A NULL pointer dereference flaw was found in the way OpenSSL verified signatures using the RSA PSS algorithm. A remote attacker could possibly use this flaw to crash a TLS/SSL client using OpenSSL, or a TLS/SSL server using OpenSSL if it enabled client authentication.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2015-3194",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2015-3194"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-51.el7_2.1"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.3,
-            "exploitability_score": 3.9,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-3195",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2015-3195"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 5.3,
-          "exploitability_score": 3.9,
-          "impact_score": 1.4,
-          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
-          "version": "3.0"
-        },
-        {
-          "base_score": 5.3,
-          "exploitability_score": 3.9,
-          "impact_score": 1.4,
-          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
-          "version": "3.0"
-        }
-      ],
-      "description": "A memory leak vulnerability was found in the way OpenSSL parsed PKCS#7 and CMS data. A remote attacker could use this flaw to cause an application that parses PKCS#7 or CMS data from untrusted sources to use an excessive amount of memory and possibly crash.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2015-3195",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2015-3195"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-51.el7_2.1"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-3196",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2015-3196"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "A race condition flaw, leading to a double free, was found in the way OpenSSL handled pre-shared key (PSK) identify hints. A remote attacker could use this flaw to crash a multi-threaded SSL/TLS client using OpenSSL.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2015-3196",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2015-3196"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-51.el7_2.4"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-3197",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2015-3197"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "A flaw was found in the way malicious SSLv2 clients could negotiate SSLv2 ciphers that were disabled on the server. This could result in weak SSLv2 ciphers being used for SSLv2 connections, making them vulnerable to man-in-the-middle attacks.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2015-3197",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2015-3197"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-42.el7_1.8"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-3216",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2015-3216"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "A regression was found in the ssleay_rand_bytes() function in the versions of OpenSSL shipped with Red Hat Enterprise Linux 6 and 7. This regression could cause a multi-threaded application to crash.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2015-3216",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2015-3216"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-42.el7_1.6"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 3.7,
-            "exploitability_score": 2.2,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-4000",
-        "severity": "Low",
-        "vulnerability_id": "CVE-2015-4000"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 3.7,
-          "exploitability_score": 2.2,
-          "impact_score": 1.4,
-          "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
-          "version": "3.0"
-        },
-        {
-          "base_score": 3.7,
-          "exploitability_score": 2.2,
-          "impact_score": 1.4,
-          "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
-          "version": "3.0"
-        },
-        {
-          "base_score": 3.7,
-          "exploitability_score": 2.2,
-          "impact_score": 1.4,
-          "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
-          "version": "3.0"
-        },
-        {
-          "base_score": 3.7,
-          "exploitability_score": 2.2,
-          "impact_score": 1.4,
-          "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
-          "version": "3.0"
-        },
-        {
-          "base_score": 3.7,
-          "exploitability_score": 2.2,
-          "impact_score": 1.4,
-          "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
-          "version": "3.0"
-        },
-        {
-          "base_score": 3.7,
-          "exploitability_score": 2.2,
-          "impact_score": 1.4,
-          "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
-          "version": "3.0"
-        }
-      ],
-      "description": "A flaw was found in the way the TLS protocol composes the Diffie-Hellman exchange (for both export and non-export grade cipher suites). An attacker could use this flaw to downgrade a DHE connection to use export-grade key sizes, which could then be broken by sufficient pre-computation. This can lead to a passive man-in-the-middle attack in which the attacker is able to decrypt all traffic.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2015-4000",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2015-4000"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-51.el7_2.2"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2015-7575",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2015-7575"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "A flaw was found in the way TLS 1.2 could use the MD5 hash function for signing ServerKeyExchange and Client Authentication packets during a TLS handshake. A man-in-the-middle attacker able to force a TLS connection to use the MD5 hash function could use this flaw to conduct collision attacks to impersonate a TLS server or an authenticated TLS client.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2015-7575",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2015-7575"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-51.el7_2.4"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 1.9,
-            "exploitability_score": 3.4,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:M/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.1,
-            "exploitability_score": 1.4,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2016-0702",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2016-0702"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "A side-channel attack was found that makes use of cache-bank conflicts on the Intel Sandy-Bridge microarchitecture. An attacker who has the ability to control code in a thread running on the same hyper-threaded core as the victim's thread that is performing decryption, could use this flaw to recover RSA private keys.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2016-0702",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2016-0702"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-42.el7_1.4"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2016-0703",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2016-0703"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "It was discovered that the SSLv2 servers using OpenSSL accepted SSLv2 connection handshakes that indicated non-zero clear key length for non-export cipher suites. An attacker could use this flaw to decrypt recorded SSLv2 sessions with the server by using it as a decryption oracle.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2016-0703",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2016-0703"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-42.el7_1.4"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2016-0704",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2016-0704"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "It was discovered that the SSLv2 protocol implementation in OpenSSL did not properly implement the Bleichenbacher protection for export cipher suites. An attacker could use a SSLv2 server using OpenSSL as a Bleichenbacher oracle.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2016-0704",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2016-0704"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-51.el7_2.4"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 10.0,
-            "exploitability_score": 10.0,
-            "impact_score": 10.0,
-            "vector": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
-            "version": "2.0"
-          },
-          {
-            "base_score": 9.8,
-            "exploitability_score": 3.9,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2016-0705",
-        "severity": "Critical",
-        "vulnerability_id": "CVE-2016-0705"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "A double-free flaw was found in the way OpenSSL parsed certain malformed DSA (Digital Signature Algorithm) private keys. An attacker could create specially crafted DSA private keys that, when processed by an application compiled against OpenSSL, could cause the application to crash.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2016-0705",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2016-0705"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-51.el7_2.4"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2016-0797",
-        "severity": "High",
-        "vulnerability_id": "CVE-2016-0797"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "An integer overflow flaw, leading to a NULL pointer dereference or a heap-based memory corruption, was found in the way some BIGNUM functions of OpenSSL were implemented. Applications that use these functions with large untrusted input could crash or, potentially, execute arbitrary code.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2016-0797",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2016-0797"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-51.el7_2.5"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 10.0,
-            "exploitability_score": 10.0,
-            "impact_score": 10.0,
-            "vector": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
-            "version": "2.0"
-          },
-          {
-            "base_score": 9.8,
-            "exploitability_score": 3.9,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2016-0799",
-        "severity": "Critical",
-        "vulnerability_id": "CVE-2016-0799"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "Several flaws were found in the way BIO_*printf functions were implemented in OpenSSL. Applications which passed large amounts of untrusted data through these functions could crash or potentially execute code with the permissions of the user running such an application.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2016-0799",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2016-0799"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-51.el7_2.4"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2016-0800",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2016-0800"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "A padding oracle flaw was found in the Secure Sockets Layer version 2.0 (SSLv2) protocol. An attacker could potentially use this flaw to decrypt RSA-encrypted cipher text from a connection using a newer SSL/TLS protocol version, allowing them to decrypt such connections. This cross-protocol attack is publicly referred to as DROWN.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2016-0800",
-      "severity": "High",
-      "vulnerability_id": "CVE-2016-0800"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "vim-minimal",
-      "pkg_type": "rpm",
-      "version": "7.4.629-7.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "2:7.4.160-1.el7_3.1"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 6.8,
-            "exploitability_score": 8.6,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.8,
-            "exploitability_score": 1.8,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2016-1248",
-        "severity": "High",
-        "vulnerability_id": "CVE-2016-1248"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 7.5,
-          "exploitability_score": 1.6,
-          "impact_score": 5.9,
-          "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H",
-          "version": "3.0"
-        }
-      ],
-      "description": "A vulnerability was found in vim in how certain modeline options were treated. An attacker could craft a file that, when opened in vim with modelines enabled, could execute arbitrary commands with privileges of the user running vim.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2016-1248",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2016-1248"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-51.el7_2.5"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2016-2105",
-        "severity": "High",
-        "vulnerability_id": "CVE-2016-2105"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 5.6,
-          "exploitability_score": 2.2,
-          "impact_score": 3.4,
-          "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L",
-          "version": "3.0"
-        },
-        {
-          "base_score": 5.6,
-          "exploitability_score": 2.2,
-          "impact_score": 3.4,
-          "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L",
-          "version": "3.0"
-        }
-      ],
-      "description": "An integer overflow flaw, leading to a buffer overflow, was found in the way the EVP_EncodeUpdate() function of OpenSSL parsed very large amounts of input data. A remote attacker could use this flaw to crash an application using OpenSSL or, possibly, execute arbitrary code with the permissions of the user running that application.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2016-2105",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2016-2105"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-51.el7_2.5"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2016-2106",
-        "severity": "High",
-        "vulnerability_id": "CVE-2016-2106"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 5.6,
-          "exploitability_score": 2.2,
-          "impact_score": 3.4,
-          "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L",
-          "version": "3.0"
-        },
-        {
-          "base_score": 5.6,
-          "exploitability_score": 2.2,
-          "impact_score": 3.4,
-          "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L",
-          "version": "3.0"
-        }
-      ],
-      "description": "An integer overflow flaw, leading to a buffer overflow, was found in the way the EVP_EncryptUpdate() function of OpenSSL parsed very large amounts of input data. A remote attacker could use this flaw to crash an application using OpenSSL or, possibly, execute arbitrary code with the permissions of the user running that application.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2016-2106",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2016-2106"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-51.el7_2.5"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 2.6,
-            "exploitability_score": 4.9,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:H/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2016-2107",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2016-2107"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "It was discovered that OpenSSL leaked timing information when decrypting TLS/SSL and DTLS protocol encrypted records when the connection used the AES CBC cipher suite and the server supported AES-NI. A remote attacker could possibly use this flaw to retrieve plain text from encrypted packets by using a TLS/SSL or DTLS server as a padding oracle.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2016-2107",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2016-2107"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-51.el7_2.5"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 10.0,
-            "exploitability_score": 10.0,
-            "impact_score": 10.0,
-            "vector": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
-            "version": "2.0"
-          },
-          {
-            "base_score": 9.8,
-            "exploitability_score": 3.9,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2016-2108",
-        "severity": "Critical",
-        "vulnerability_id": "CVE-2016-2108"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 5.6,
-          "exploitability_score": 2.2,
-          "impact_score": 3.4,
-          "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L",
-          "version": "3.0"
-        },
-        {
-          "base_score": 5.6,
-          "exploitability_score": 2.2,
-          "impact_score": 3.4,
-          "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L",
-          "version": "3.0"
-        }
-      ],
-      "description": "A flaw was found in the way OpenSSL encoded certain ASN.1 data structures. An attacker could use this flaw to create a specially crafted certificate which, when verified or re-encoded by OpenSSL, could cause it to crash, or execute arbitrary code using the permissions of the user running an application compiled against the OpenSSL library.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2016-2108",
-      "severity": "High",
-      "vulnerability_id": "CVE-2016-2108"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-51.el7_2.5"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.8,
-            "exploitability_score": 10.0,
-            "impact_score": 6.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:C",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2016-2109",
-        "severity": "High",
-        "vulnerability_id": "CVE-2016-2109"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 4.0,
-          "exploitability_score": 2.5,
-          "impact_score": 1.4,
-          "vector": "CVSS:3.0/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
-          "version": "3.0"
-        },
-        {
-          "base_score": 4.0,
-          "exploitability_score": 2.5,
-          "impact_score": 1.4,
-          "vector": "CVSS:3.0/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
-          "version": "3.0"
-        }
-      ],
-      "description": "A denial of service flaw was found in the way OpenSSL parsed certain ASN.1-encoded data from BIO (OpenSSL's I/O abstraction) inputs. An application using OpenSSL that accepts untrusted ASN.1 BIO input could be forced to allocate an excessive amount of data.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2016-2109",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2016-2109"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-51.el7_2.7"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.5,
-            "exploitability_score": 10.0,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 9.8,
-            "exploitability_score": 3.9,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2016-2177",
-        "severity": "Critical",
-        "vulnerability_id": "CVE-2016-2177"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 5.9,
-          "exploitability_score": 2.2,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
-          "version": "3.0"
-        },
-        {
-          "base_score": 5.9,
-          "exploitability_score": 2.2,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
-          "version": "3.0"
-        }
-      ],
-      "description": "Multiple integer overflow flaws were found in the way OpenSSL performed pointer arithmetic. A remote attacker could possibly use these flaws to cause a TLS/SSL server or client using OpenSSL to crash.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2016-2177",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2016-2177"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-51.el7_2.7"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.5,
-            "exploitability_score": 1.8,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2016-2178",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2016-2178"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 5.1,
-          "exploitability_score": 1.4,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
-          "version": "3.0"
-        },
-        {
-          "base_score": 5.1,
-          "exploitability_score": 1.4,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
-          "version": "3.0"
-        }
-      ],
-      "description": "It was discovered that OpenSSL did not always use constant time operations when computing Digital Signature Algorithm (DSA) signatures. A local attacker could possibly use this flaw to obtain a private DSA key belonging to another user or service running on the same system.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2016-2178",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2016-2178"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-51.el7_2.7"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2016-2179",
-        "severity": "High",
-        "vulnerability_id": "CVE-2016-2179"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 5.3,
-          "exploitability_score": 3.9,
-          "impact_score": 1.4,
-          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
-          "version": "3.0"
-        },
-        {
-          "base_score": 5.3,
-          "exploitability_score": 3.9,
-          "impact_score": 1.4,
-          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
-          "version": "3.0"
-        }
-      ],
-      "description": "It was discovered that the Datagram TLS (DTLS) implementation could fail to release memory in certain cases. A malicious DTLS client could cause a DTLS server using OpenSSL to consume an excessive amount of memory and, possibly, exit unexpectedly after exhausting all available memory.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2016-2179",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2016-2179"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-51.el7_2.7"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2016-2180",
-        "severity": "High",
-        "vulnerability_id": "CVE-2016-2180"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 5.1,
-          "exploitability_score": 1.4,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:L/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
-          "version": "3.0"
-        }
-      ],
-      "description": "An out of bounds read flaw was found in the way OpenSSL formatted Public Key Infrastructure Time-Stamp Protocol data for printing. An attacker could possibly cause an application using OpenSSL to crash if it printed time stamp data from the attacker.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2016-2180",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2016-2180"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-51.el7_2.7"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2016-2181",
-        "severity": "High",
-        "vulnerability_id": "CVE-2016-2181"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 5.9,
-          "exploitability_score": 2.2,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
-          "version": "3.0"
-        },
-        {
-          "base_score": 5.9,
-          "exploitability_score": 2.2,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
-          "version": "3.0"
-        }
-      ],
-      "description": "A flaw was found in the Datagram TLS (DTLS) replay protection implementation in OpenSSL. A remote attacker could possibly use this flaw to make a DTLS server using OpenSSL to reject further packets sent from a DTLS client over an established DTLS connection.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2016-2181",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2016-2181"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-51.el7_2.7"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.5,
-            "exploitability_score": 10.0,
-            "impact_score": 6.4,
-            "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 9.8,
-            "exploitability_score": 3.9,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2016-2182",
-        "severity": "Critical",
-        "vulnerability_id": "CVE-2016-2182"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 6.2,
-          "exploitability_score": 2.5,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-          "version": "3.0"
-        },
-        {
-          "base_score": 6.2,
-          "exploitability_score": 2.5,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-          "version": "3.0"
-        }
-      ],
-      "description": "An out of bounds write flaw was discovered in the OpenSSL BN_bn2dec() function. An attacker able to make an application using OpenSSL to process a large BIGNUM could cause the application to crash or, possibly, execute arbitrary code.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2016-2182",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2016-2182"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-51.el7_2.5"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 10.0,
-            "exploitability_score": 10.0,
-            "impact_score": 10.0,
-            "vector": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
-            "version": "2.0"
-          },
-          {
-            "base_score": 9.8,
-            "exploitability_score": 3.9,
-            "impact_score": 5.9,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2016-2842",
-        "severity": "Critical",
-        "vulnerability_id": "CVE-2016-2842"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [],
-      "description": "Several flaws were found in the way BIO_*printf functions were implemented in OpenSSL. Applications which passed large amounts of untrusted data through these functions could crash or potentially execute code with the permissions of the user running such an application.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2016-2842",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2016-2842"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-51.el7_2.7"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2016-6302",
-        "severity": "High",
-        "vulnerability_id": "CVE-2016-6302"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 5.9,
-          "exploitability_score": 2.2,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
-          "version": "3.0"
-        }
-      ],
-      "description": "An integer underflow flaw leading to a buffer over-read was found in the way OpenSSL parsed TLS session tickets. A remote attacker could use this flaw to crash a TLS server using OpenSSL if it used SHA-512 as HMAC for session tickets.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2016-6302",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2016-6302"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-51.el7_2.7"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 7.8,
-            "exploitability_score": 10.0,
-            "impact_score": 6.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:C",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2016-6304",
-        "severity": "High",
-        "vulnerability_id": "CVE-2016-6304"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 7.5,
-          "exploitability_score": 3.9,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-          "version": "3.0"
-        }
-      ],
-      "description": "A memory leak flaw was found in the way OpenSSL handled TLS status request extension data during session renegotiation. A remote attacker could cause a TLS server using OpenSSL to consume an excessive amount of memory and, possibly, exit unexpectedly after exhausting all available memory, if it enabled OCSP stapling support.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2016-6304",
-      "severity": "High",
-      "vulnerability_id": "CVE-2016-6304"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-51.el7_2.7"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2016-6306",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2016-6306"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 5.9,
-          "exploitability_score": 2.2,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
-          "version": "3.0"
-        },
-        {
-          "base_score": 5.9,
-          "exploitability_score": 2.2,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
-          "version": "3.0"
-        }
-      ],
-      "description": "Multiple out of bounds read flaws were found in the way OpenSSL handled certain TLS/SSL protocol handshake messages. A remote attacker could possibly use these flaws to crash a TLS/SSL server or client using OpenSSL.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2016-6306",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2016-6306"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.2k-8.el7"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 2.1,
-            "exploitability_score": 3.9,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.5,
-            "exploitability_score": 1.8,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2016-7056",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2016-7056"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 5.5,
-          "exploitability_score": 1.8,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
-          "version": "3.0"
-        }
-      ],
-      "description": "A timing attack flaw was found in OpenSSL that could allow a malicious user with local access to recover ECDSA P-256 private keys.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2016-7056",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2016-7056"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-60.el7_3.1"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2016-8610",
-        "severity": "High",
-        "vulnerability_id": "CVE-2016-8610"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 7.5,
-          "exploitability_score": 3.9,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-          "version": "3.0"
-        },
-        {
-          "base_score": 7.5,
-          "exploitability_score": 3.9,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-          "version": "3.0"
-        },
-        {
-          "base_score": 7.5,
-          "exploitability_score": 3.9,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-          "version": "3.0"
-        }
-      ],
-      "description": "A denial of service flaw was found in the way the TLS/SSL protocol defined processing of ALERT packets during a connection handshake. A remote attacker could use this flaw to make a TLS/SSL server consume an excessive amount of CPU and fail to accept connections from other clients.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2016-8610",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2016-8610"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.1e-60.el7_3.1"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-3731",
-        "severity": "High",
-        "vulnerability_id": "CVE-2017-3731"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 5.9,
-          "exploitability_score": 2.2,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
-          "version": "3.0"
-        },
-        {
-          "base_score": 5.9,
-          "exploitability_score": 2.2,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
-          "version": "3.0"
-        }
-      ],
-      "description": "An integer underflow leading to an out of bounds read flaw was found in OpenSSL. A remote attacker could possibly use this flaw to crash a 32-bit TLS/SSL server or client using OpenSSL if it used the RC4-MD5 cipher suite.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2017-3731",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2017-3731"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.2k-16.el7"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.3,
-            "exploitability_score": 3.9,
-            "impact_score": 1.4,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-3735",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2017-3735"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 5.3,
-          "exploitability_score": 3.9,
-          "impact_score": 1.4,
-          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
-          "version": "3.0"
-        },
-        {
-          "base_score": 5.3,
-          "exploitability_score": 3.9,
-          "impact_score": 1.4,
-          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
-          "version": "3.0"
-        },
-        {
-          "base_score": 5.3,
-          "exploitability_score": 3.9,
-          "impact_score": 1.4,
-          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
-          "version": "3.0"
-        }
-      ],
-      "description": "While parsing an IPAddressFamily extension in an X.509 certificate, it is possible to do a one-byte overread. This would result in an incorrect text display of the certificate. This bug has been present since 2006 and is present in all versions of OpenSSL before 1.0.2m and 1.1.0g.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2017-3735",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2017-3735"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.2k-12.el7"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.0,
-            "exploitability_score": 8.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:S/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 6.5,
-            "exploitability_score": 2.8,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-3736",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2017-3736"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 5.9,
-          "exploitability_score": 2.2,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
-          "version": "3.0"
-        },
-        {
-          "base_score": 5.9,
-          "exploitability_score": 2.2,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
-          "version": "3.0"
-        }
-      ],
-      "description": "There is a carry propagating bug in the x86_64 Montgomery squaring procedure in OpenSSL before 1.0.2m and 1.1.0 before 1.1.0g. No EC algorithms are affected. Analysis suggests that attacks against RSA and DSA as a result of this defect would be very difficult to perform and are not believed likely. Attacks against DH are considered just feasible (although very difficult) because most of the work necessary to deduce information about a private key may be performed offline. The amount of resources required for such an attack would be very significant and likely only accessible to a limited number of attackers. An attacker would additionally need online access to an unpatched system using the target private key in a scenario with persistent DH parameters and a private key that is shared between multiple clients. This only affects processors that support the BMI1, BMI2 and ADX extensions like Intel Broadwell (5th generation) and later or AMD Ryzen.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2017-3736",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2017-3736"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.2k-12.el7"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-3737",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2017-3737"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 5.9,
-          "exploitability_score": 2.2,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
-          "version": "3.0"
-        }
-      ],
-      "description": "OpenSSL 1.0.2 (starting from version 1.0.2b) introduced an \"error state\" mechanism. The intent was that if a fatal error occurred during a handshake then OpenSSL would move into the error state and would immediately fail if you attempted to continue the handshake. This works as designed for the explicit handshake functions (SSL_do_handshake(), SSL_accept() and SSL_connect()), however due to a bug it does not work correctly if SSL_read() or SSL_write() is called directly. In that scenario, if the handshake fails then a fatal error will be returned in the initial function call. If SSL_read()/SSL_write() is subsequently called by the application for the same SSL object then it will succeed and the data is passed without being decrypted/encrypted directly from the SSL/TLS record layer. In order to exploit this issue an application bug would have to be present that resulted in a call to SSL_read()/SSL_write() being issued after having already received a fatal error. OpenSSL version 1.0.2b-1.0.2m are affected. Fixed in OpenSSL 1.0.2n. OpenSSL 1.1.0 is not affected.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2017-3737",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2017-3737"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.2k-12.el7"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2017-3738",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2017-3738"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 5.9,
-          "exploitability_score": 2.2,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
-          "version": "3.0"
-        }
-      ],
-      "description": "There is an overflow bug in the AVX2 Montgomery multiplication procedure used in exponentiation with 1024-bit moduli. No EC algorithms are affected. Analysis suggests that attacks against RSA and DSA as a result of this defect would be very difficult to perform and are not believed likely. Attacks against DH1024 are considered just feasible, because most of the work necessary to deduce information about a private key may be performed offline. The amount of resources required for such an attack would be significant. However, for an attack on TLS to be meaningful, the server would have to share the DH1024 private key among multiple clients, which is no longer an option since CVE-2016-0701. This only affects processors that support the AVX2 but not ADX extensions like Intel Haswell (4th generation). Note: The impact from this issue is similar to CVE-2017-3736, CVE-2017-3732 and CVE-2015-3193. OpenSSL version 1.0.2-1.0.2m and 1.1.0-1.1.0g are affected. Fixed in OpenSSL 1.0.2n. Due to the low severity of this issue we are not issuing a new release of OpenSSL 1.1.0 at this time. The fix will be included in OpenSSL 1.1.0h when it becomes available. The fix is also available in commit e502cc86d in the OpenSSL git repository.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2017-3738",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2017-3738"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.2k-16.el7"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 1.9,
-            "exploitability_score": 3.4,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:M/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 4.7,
-            "exploitability_score": 1.0,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:N/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-0495",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2018-0495"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 5.1,
-          "exploitability_score": 1.4,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
-          "version": "3.0"
-        },
-        {
-          "base_score": 5.1,
-          "exploitability_score": 1.4,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
-          "version": "3.0"
-        },
-        {
-          "base_score": 5.1,
-          "exploitability_score": 1.4,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
-          "version": "3.0"
-        },
-        {
-          "base_score": 5.1,
-          "exploitability_score": 1.4,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
-          "version": "3.0"
-        }
-      ],
-      "description": "Libgcrypt before 1.7.10 and 1.8.x before 1.8.3 allows a memory-cache side-channel attack on ECDSA signatures that can be mitigated through the use of blinding during the signing process in the _gcry_ecc_ecdsa_sign function in cipher/ecc-ecdsa.c, aka the Return Of the Hidden Number Problem or ROHNP. To discover an ECDSA key, the attacker needs access to either the local machine or a different virtual machine on the same physical host.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2018-0495",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2018-0495"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.2k-16.el7"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 5.0,
-            "exploitability_score": 10.0,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.5,
-            "exploitability_score": 3.9,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-0732",
-        "severity": "High",
-        "vulnerability_id": "CVE-2018-0732"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 4.3,
-          "exploitability_score": 2.8,
-          "impact_score": 1.4,
-          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:L",
-          "version": "3.0"
-        },
-        {
-          "base_score": 4.3,
-          "exploitability_score": 2.8,
-          "impact_score": 1.4,
-          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:L",
-          "version": "3.0"
-        },
-        {
-          "base_score": 4.3,
-          "exploitability_score": 2.8,
-          "impact_score": 1.4,
-          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:L",
-          "version": "3.0"
-        }
-      ],
-      "description": "During key agreement in a TLS handshake using a DH(E) based ciphersuite a malicious server can send a very large prime value to the client. This will cause the client to spend an unreasonably long period of time generating a key for this prime resulting in a hang until the client has finished. This could be exploited in a Denial Of Service attack. Fixed in OpenSSL 1.1.0i-dev (Affected 1.1.0-1.1.0h). Fixed in OpenSSL 1.0.2p-dev (Affected 1.0.2-1.0.2o).",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2018-0732",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2018-0732"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.2k-19.el7"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-0734",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2018-0734"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 5.1,
-          "exploitability_score": 1.4,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
-          "version": "3.0"
-        },
-        {
-          "base_score": 5.1,
-          "exploitability_score": 1.4,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
-          "version": "3.0"
-        },
-        {
-          "base_score": 5.1,
-          "exploitability_score": 1.4,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
-          "version": "3.0"
-        }
-      ],
-      "description": "The OpenSSL DSA signature algorithm has been shown to be vulnerable to a timing side channel attack. An attacker could use variations in the signing algorithm to recover the private key. Fixed in OpenSSL 1.1.1a (Affected 1.1.1). Fixed in OpenSSL 1.1.0j (Affected 1.1.0-1.1.0i). Fixed in OpenSSL 1.0.2q (Affected 1.0.2-1.0.2p).",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2018-0734",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2018-0734"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.2k-16.el7_6.1"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-0735",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2018-0735"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 5.1,
-          "exploitability_score": 1.4,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
-          "version": "3.0"
-        },
-        {
-          "base_score": 5.1,
-          "exploitability_score": 1.4,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
-          "version": "3.0"
-        }
-      ],
-      "description": "The OpenSSL ECDSA signature algorithm has been shown to be vulnerable to a timing side channel attack. An attacker could use variations in the signing algorithm to recover the private key. Fixed in OpenSSL 1.1.0j (Affected 1.1.0-1.1.0i). Fixed in OpenSSL 1.1.1a (Affected 1.1.1).",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2018-0735",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2018-0735"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.2k-16.el7"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-0737",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2018-0737"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 3.3,
-          "exploitability_score": 0.8,
-          "impact_score": 2.5,
-          "vector": "CVSS:3.0/AV:L/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:N",
-          "version": "3.0"
-        },
-        {
-          "base_score": 3.3,
-          "exploitability_score": 0.8,
-          "impact_score": 2.5,
-          "vector": "CVSS:3.0/AV:L/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:N",
-          "version": "3.0"
-        }
-      ],
-      "description": "OpenSSL RSA key generation was found to be vulnerable to cache side-channel attacks. An attacker with sufficient access to mount cache timing attacks during the RSA key generation process could recover parts of the private key.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2018-0737",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2018-0737"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.2k-16.el7"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
-            "version": "2.0"
-          },
-          {
-            "base_score": 6.5,
-            "exploitability_score": 2.8,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-0739",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2018-0739"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 6.5,
-          "exploitability_score": 2.8,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
-          "version": "3.0"
-        },
-        {
-          "base_score": 6.5,
-          "exploitability_score": 2.8,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
-          "version": "3.0"
-        },
-        {
-          "base_score": 6.5,
-          "exploitability_score": 2.8,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
-          "version": "3.0"
-        },
-        {
-          "base_score": 6.5,
-          "exploitability_score": 2.8,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
-          "version": "3.0"
-        }
-      ],
-      "description": "Constructed ASN.1 types with a recursive definition (such as can be found in PKCS7) could eventually exceed the stack given malicious input with excessive recursion. This could result in a Denial Of Service attack. There are no such structures used within SSL/TLS that come from untrusted sources so this is considered safe. Fixed in OpenSSL 1.1.0h (Affected 1.1.0-1.1.0g). Fixed in OpenSSL 1.0.2o (Affected 1.0.2b-1.0.2n).",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2018-0739",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2018-0739"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [
-        "cpe:2.3:a:*:aiohttp:3.7.3:*:*:*:*:*:*:*"
-      ],
-      "location": "/usr/local/lib64/python3.6/site-packages/aiohttp",
-      "name": "aiohttp",
-      "pkg_type": "python",
-      "version": "3.7.3"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 4.3,
-          "exploitability_score": 8.6,
-          "impact_score": 2.9,
-          "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-          "version": "2.0"
-        },
-        {
-          "base_score": 6.5,
-          "exploitability_score": 2.8,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:N",
-          "version": "3.0"
-        }
-      ],
-      "description": "aio-libs aiohttp-session contains a Session Fixation vulnerability in load_session function for RedisStorage (see: https://github.com/aio-libs/aiohttp-session/blob/master/aiohttp_session/redis_storage.py#L42) that can result in Session Hijacking. This attack appear to be exploitable via Any method that allows setting session cookies (?session=<>, or meta tags or script tags with Set-Cookie).",
-      "feed": "vulnerabilities",
-      "feed_group": "nvd",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-1000519",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2018-1000519"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [
-        "cpe:2.3:a:google:guava:23.0:*:*:*:*:*:*:*",
-        "cpe:2.3:a:*:guava:23.0:*:*:*:*:*:*:*"
-      ],
-      "location": "/sandbox/target/my-app-1.jar:guava",
-      "name": "guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 4.3,
-          "exploitability_score": 8.6,
-          "impact_score": 2.9,
-          "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
-          "version": "2.0"
-        },
-        {
-          "base_score": 5.9,
-          "exploitability_score": 2.2,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
-          "version": "3.1"
-        }
-      ],
-      "description": "Unbounded memory allocation in Google Guava 11.0 through 24.x before 24.1.1 allows remote attackers to conduct denial of service attacks against servers that depend on this library and deserialize attacker-provided data, because the AtomicDoubleArray class (when serialized with Java serialization) and the CompoundOrdering class (when serialized with GWT serialization) perform eager allocation without appropriate checks on what a client has sent and whether the data size is reasonable.",
-      "feed": "vulnerabilities",
-      "feed_group": "nvd",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2018-10237"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [
-        "cpe:2.3:a:google:guava:23.0:*:*:*:*:*:*:*",
-        "cpe:2.3:a:*:guava:23.0:*:*:*:*:*:*:*"
-      ],
-      "location": "/sandbox/target/original-my-app-1.jar:guava",
-      "name": "guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 4.3,
-          "exploitability_score": 8.6,
-          "impact_score": 2.9,
-          "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
-          "version": "2.0"
-        },
-        {
-          "base_score": 5.9,
-          "exploitability_score": 2.2,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
-          "version": "3.1"
-        }
-      ],
-      "description": "Unbounded memory allocation in Google Guava 11.0 through 24.x before 24.1.1 allows remote attackers to conduct denial of service attacks against servers that depend on this library and deserialize attacker-provided data, because the AtomicDoubleArray class (when serialized with Java serialization) and the CompoundOrdering class (when serialized with GWT serialization) perform eager allocation without appropriate checks on what a client has sent and whether the data size is reasonable.",
-      "feed": "vulnerabilities",
-      "feed_group": "nvd",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2018-10237"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [
-        "cpe:2.3:a:*:app:1:*:*:*:*:*:*:*"
-      ],
-      "location": "/sandbox/target/my-app-1.jar",
-      "name": "my-app",
-      "pkg_type": "java",
-      "version": "1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 5.0,
-          "exploitability_score": 10.0,
-          "impact_score": 2.9,
-          "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
-          "version": "2.0"
-        },
-        {
-          "base_score": 7.5,
-          "exploitability_score": 3.9,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
-          "version": "3.0"
-        }
-      ],
-      "description": "The mintToken function of a smart contract implementation for APP, an Ethereum token, has an integer overflow that allows the owner of the contract to set the balance of an arbitrary user to any value.",
-      "feed": "vulnerabilities",
-      "feed_group": "nvd",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-13661",
-      "severity": "High",
-      "vulnerability_id": "CVE-2018-13661"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [
-        "cpe:2.3:a:*:app:1:*:*:*:*:*:*:*"
-      ],
-      "location": "/sandbox/target/original-my-app-1.jar",
-      "name": "my-app",
-      "pkg_type": "java",
-      "version": "1"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 5.0,
-          "exploitability_score": 10.0,
-          "impact_score": 2.9,
-          "vector": "AV:N/AC:L/Au:N/C:N/I:P/A:N",
-          "version": "2.0"
-        },
-        {
-          "base_score": 7.5,
-          "exploitability_score": 3.9,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
-          "version": "3.0"
-        }
-      ],
-      "description": "The mintToken function of a smart contract implementation for APP, an Ethereum token, has an integer overflow that allows the owner of the contract to set the balance of an arbitrary user to any value.",
-      "feed": "vulnerabilities",
-      "feed_group": "nvd",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-13661",
-      "severity": "High",
-      "vulnerability_id": "CVE-2018-13661"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.2k-16.el7_6.1"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 1.9,
-            "exploitability_score": 3.4,
-            "impact_score": 2.9,
-            "vector": "AV:L/AC:M/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 4.7,
-            "exploitability_score": 1.0,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:N/A:N",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-5407",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2018-5407"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 4.8,
-          "exploitability_score": 0.4,
-          "impact_score": 4.0,
-          "vector": "CVSS:3.0/AV:P/AC:H/PR:L/UI:N/S:C/C:H/I:N/A:N",
-          "version": "3.0"
-        },
-        {
-          "base_score": 4.8,
-          "exploitability_score": 0.4,
-          "impact_score": 4.0,
-          "vector": "CVSS:3.0/AV:P/AC:H/PR:L/UI:N/S:C/C:H/I:N/A:N",
-          "version": "3.0"
-        },
-        {
-          "base_score": 4.8,
-          "exploitability_score": 0.4,
-          "impact_score": 4.0,
-          "vector": "CVSS:3.0/AV:P/AC:H/PR:L/UI:N/S:C/C:H/I:N/A:N",
-          "version": "3.0"
-        }
-      ],
-      "description": "A microprocessor side-channel vulnerability was found on SMT (e.g, Hyper-Threading) architectures. An attacker running a malicious process on the same core of the processor as the victim process can extract certain secret information.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2018-5407",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2018-5407"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "vim-minimal",
-      "pkg_type": "rpm",
-      "version": "7.4.629-7.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "2:7.4.160-6.el7_6"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 9.3,
-            "exploitability_score": 8.6,
-            "impact_score": 10.0,
-            "vector": "AV:N/AC:M/Au:N/C:C/I:C/A:C",
-            "version": "2.0"
-          },
-          {
-            "base_score": 8.6,
-            "exploitability_score": 1.8,
-            "impact_score": 6.0,
-            "vector": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-12735",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-12735"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 6.3,
-          "exploitability_score": 2.8,
-          "impact_score": 3.4,
-          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:L",
-          "version": "3.0"
-        }
-      ],
-      "description": "It was found that the `:source!` command was not restricted by the sandbox mode. If modeline was explicitly enabled, opening a specially crafted text file in vim could result in arbitrary command execution.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2019-12735",
-      "severity": "High",
-      "vulnerability_id": "CVE-2019-12735"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "dbus",
-      "pkg_type": "rpm",
-      "version": "1.10.24-15.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.10.24-15.el7"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 3.6,
-            "exploitability_score": 3.9,
-            "impact_score": 4.9,
-            "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.1,
-            "exploitability_score": 1.8,
-            "impact_score": 5.2,
-            "vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-12749",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-12749"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 7.0,
-          "exploitability_score": 1.0,
-          "impact_score": 5.9,
-          "vector": "CVSS:3.0/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H",
-          "version": "3.0"
-        }
-      ],
-      "description": "A flaw was found in dbus. The implementation of DBUS_COOKIE_SHA1 is susceptible to a symbolic link attack. A malicious client with write access to its own home directory could manipulate a ~/.dbus-keyrings symlink to cause the DBusServer to read and write in unintended locations resulting in an authentication bypass. The highest threat from this vulnerability is to data confidentiality and integrity as well as system availability.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2019-12749",
-      "severity": "High",
-      "vulnerability_id": "CVE-2019-12749"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "dbus-libs",
-      "pkg_type": "rpm",
-      "version": "1.10.24-15.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.10.24-15.el7"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 3.6,
-            "exploitability_score": 3.9,
-            "impact_score": 4.9,
-            "vector": "AV:L/AC:L/Au:N/C:P/I:P/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 7.1,
-            "exploitability_score": 1.8,
-            "impact_score": 5.2,
-            "vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-12749",
-        "severity": "High",
-        "vulnerability_id": "CVE-2019-12749"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 7.0,
-          "exploitability_score": 1.0,
-          "impact_score": 5.9,
-          "vector": "CVSS:3.0/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H",
-          "version": "3.0"
-        }
-      ],
-      "description": "A flaw was found in dbus. The implementation of DBUS_COOKIE_SHA1 is susceptible to a symbolic link attack. A malicious client with write access to its own home directory could manipulate a ~/.dbus-keyrings symlink to cause the DBusServer to read and write in unintended locations resulting in an authentication bypass. The highest threat from this vulnerability is to data confidentiality and integrity as well as system availability.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2019-12749",
-      "severity": "High",
-      "vulnerability_id": "CVE-2019-12749"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "openssl-libs",
-      "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.0.2k-19.el7"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.3,
-            "exploitability_score": 8.6,
-            "impact_score": 2.9,
-            "vector": "AV:N/AC:M/Au:N/C:P/I:N/A:N",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.9,
-            "exploitability_score": 2.2,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
-            "version": "3.0"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-1559",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2019-1559"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 5.9,
-          "exploitability_score": 2.2,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
-          "version": "3.1"
-        },
-        {
-          "base_score": 5.9,
-          "exploitability_score": 2.2,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
-          "version": "3.1"
-        },
-        {
-          "base_score": 5.9,
-          "exploitability_score": 2.2,
-          "impact_score": 3.6,
-          "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
-          "version": "3.1"
-        }
-      ],
-      "description": "If an application encounters a fatal protocol error and then calls SSL_shutdown() twice (once to send a close_notify, and once to receive one) then OpenSSL can respond differently to the calling application if a 0 byte record is received with invalid padding compared to if a 0 byte record is received with an invalid MAC. If the application then behaves differently based on that in a way that is detectable to the remote peer, then this amounts to a padding oracle that could be used to decrypt data. In order for this to be exploitable \"non-stitched\" ciphersuites must be in use. Stitched ciphersuites are optimised implementations of certain commonly used ciphersuites. Also the application must call SSL_shutdown() twice even if a protocol error has occurred (applications should not do this but some do anyway). Fixed in OpenSSL 1.0.2r (Affected 1.0.2-1.0.2q).",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2019-1559",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2019-1559"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
       "name": "python",
       "pkg_type": "rpm",
       "version": "2.7.5-89.el7"
     },
     "fix": {
       "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
+      "observed_at": "2021-09-28T17:55:01Z",
       "versions": [
         "0:2.7.5-90.el7"
       ],
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
+      "detected_at": "2021-09-28T17:55:01Z"
     },
     "nvd": [
       {
@@ -5504,14 +499,14 @@
     },
     "fix": {
       "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
+      "observed_at": "2021-09-28T17:55:01Z",
       "versions": [
         "0:2.7.5-90.el7"
       ],
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
+      "detected_at": "2021-09-28T17:55:01Z"
     },
     "nvd": [
       {
@@ -5567,144 +562,20 @@
       "cpe": null,
       "cpes": [],
       "location": "pkgdb",
-      "name": "dbus",
-      "pkg_type": "rpm",
-      "version": "1.10.24-15.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.10.24-14.el7_8"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.9,
-            "exploitability_score": 3.9,
-            "impact_score": 6.9,
-            "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:C",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.5,
-            "exploitability_score": 1.8,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-12049",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2020-12049"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 6.5,
-          "exploitability_score": 2.0,
-          "impact_score": 4.0,
-          "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:N/I:N/A:H",
-          "version": "3.1"
-        }
-      ],
-      "description": "An uncontrolled resource consumption vulnerability was discovered in D-Bus. The DBusServer leaks file descriptors when a message exceeds the per-message file descriptor limit. This flaw allows a local attacker with access to the D-Bus system bus or another system service's private AF_UNIX socket, to make the system service reach its file descriptor limit, denying service to subsequent D-Bus clients. As a result, the system may become unusable for other users, and some services may stop working. The highest threat from this vulnerability is to system availability.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2020-12049",
-      "severity": "High",
-      "vulnerability_id": "CVE-2020-12049"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
-      "name": "dbus-libs",
-      "pkg_type": "rpm",
-      "version": "1.10.24-15.el7"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
-      "versions": [
-        "1:1.10.24-14.el7_8"
-      ],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [
-      {
-        "cvss": [
-          {
-            "base_score": 4.9,
-            "exploitability_score": 3.9,
-            "impact_score": 6.9,
-            "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:C",
-            "version": "2.0"
-          },
-          {
-            "base_score": 5.5,
-            "exploitability_score": 1.8,
-            "impact_score": 3.6,
-            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
-            "version": "3.1"
-          }
-        ],
-        "description": null,
-        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-12049",
-        "severity": "Medium",
-        "vulnerability_id": "CVE-2020-12049"
-      }
-    ],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 6.5,
-          "exploitability_score": 2.0,
-          "impact_score": 4.0,
-          "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:N/I:N/A:H",
-          "version": "3.1"
-        }
-      ],
-      "description": "An uncontrolled resource consumption vulnerability was discovered in D-Bus. The DBusServer leaks file descriptors when a message exceeds the per-message file descriptor limit. This flaw allows a local attacker with access to the D-Bus system bus or another system service's private AF_UNIX socket, to make the system service reach its file descriptor limit, denying service to subsequent D-Bus clients. As a result, the system may become unusable for other users, and some services may stop working. The highest threat from this vulnerability is to system availability.",
-      "feed": "vulnerabilities",
-      "feed_group": "rhel:7",
-      "link": "https://access.redhat.com/security/cve/CVE-2020-12049",
-      "severity": "High",
-      "vulnerability_id": "CVE-2020-12049"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [],
-      "location": "pkgdb",
       "name": "openssl-libs",
       "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
+      "version": "1:1.0.2k-19.el7"
     },
     "fix": {
       "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
+      "observed_at": "2021-09-28T17:55:01Z",
       "versions": [
         "1:1.0.2k-21.el7_9"
       ],
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
+      "detected_at": "2021-09-28T17:55:01Z"
     },
     "nvd": [
       {
@@ -5759,14 +630,14 @@
     },
     "fix": {
       "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
+      "observed_at": "2021-09-28T17:55:01Z",
       "versions": [
         "0:3.53.1-7.el7_9"
       ],
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
+      "detected_at": "2021-09-28T17:55:01Z"
     },
     "nvd": [
       {
@@ -5821,14 +692,14 @@
     },
     "fix": {
       "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
+      "observed_at": "2021-09-28T17:55:01Z",
       "versions": [
         "0:3.53.1-7.el7_9"
       ],
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
+      "detected_at": "2021-09-28T17:55:01Z"
     },
     "nvd": [
       {
@@ -5883,14 +754,14 @@
     },
     "fix": {
       "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
+      "observed_at": "2021-09-28T17:55:01Z",
       "versions": [
         "0:3.53.1-7.el7_9"
       ],
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
+      "detected_at": "2021-09-28T17:55:01Z"
     },
     "nvd": [
       {
@@ -5945,14 +816,14 @@
     },
     "fix": {
       "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
+      "observed_at": "2021-09-28T17:55:01Z",
       "versions": [
         "0:2.4.44-23.el7_9"
       ],
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
+      "detected_at": "2021-09-28T17:55:01Z"
     },
     "nvd": [
       {
@@ -6007,14 +878,14 @@
     },
     "fix": {
       "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
+      "observed_at": "2021-09-28T17:55:01Z",
       "versions": [
         "0:7.29.0-59.el7_9.1"
       ],
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
+      "detected_at": "2021-09-28T17:55:01Z"
     },
     "nvd": [
       {
@@ -6069,14 +940,14 @@
     },
     "fix": {
       "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
+      "observed_at": "2021-09-28T17:55:01Z",
       "versions": [
         "0:7.29.0-59.el7_9.1"
       ],
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
+      "detected_at": "2021-09-28T17:55:01Z"
     },
     "nvd": [
       {
@@ -6123,243 +994,11 @@
   {
     "artifact": {
       "cpe": null,
-      "cpes": [
-        "cpe:2.3:a:google:guava:23.0:*:*:*:*:*:*:*",
-        "cpe:2.3:a:*:guava:23.0:*:*:*:*:*:*:*"
-      ],
-      "location": "/sandbox/target/my-app-1.jar:guava",
-      "name": "guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 2.1,
-          "exploitability_score": 3.9,
-          "impact_score": 2.9,
-          "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
-          "version": "2.0"
-        },
-        {
-          "base_score": 3.3,
-          "exploitability_score": 1.8,
-          "impact_score": 1.4,
-          "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
-          "version": "3.1"
-        }
-      ],
-      "description": "A temp directory creation vulnerability exists in all versions of Guava, allowing an attacker with access to the machine to potentially access data in a temporary directory created by the Guava API com.google.common.io.Files.createTempDir(). By default, on unix-like systems, the created directory is world-readable (readable by an attacker with access to the system). The method in question has been marked @Deprecated in versions 30.0 and later and should not be used. For Android developers, we recommend choosing a temporary directory API provided by Android, such as context.getCacheDir(). For other Java developers, we recommend migrating to the Java 7 API java.nio.file.Files.createTempDirectory() which explicitly configures permissions of 700, or configuring the Java runtime's java.io.tmpdir system property to point to a location whose permissions are appropriately configured.",
-      "feed": "vulnerabilities",
-      "feed_group": "nvd",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2020-8908"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [
-        "cpe:2.3:a:google:guava:23.0:*:*:*:*:*:*:*",
-        "cpe:2.3:a:*:guava:23.0:*:*:*:*:*:*:*"
-      ],
-      "location": "/sandbox/target/original-my-app-1.jar:guava",
-      "name": "guava",
-      "pkg_type": "java",
-      "version": "23.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 2.1,
-          "exploitability_score": 3.9,
-          "impact_score": 2.9,
-          "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
-          "version": "2.0"
-        },
-        {
-          "base_score": 3.3,
-          "exploitability_score": 1.8,
-          "impact_score": 1.4,
-          "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
-          "version": "3.1"
-        }
-      ],
-      "description": "A temp directory creation vulnerability exists in all versions of Guava, allowing an attacker with access to the machine to potentially access data in a temporary directory created by the Guava API com.google.common.io.Files.createTempDir(). By default, on unix-like systems, the created directory is world-readable (readable by an attacker with access to the system). The method in question has been marked @Deprecated in versions 30.0 and later and should not be used. For Android developers, we recommend choosing a temporary directory API provided by Android, such as context.getCacheDir(). For other Java developers, we recommend migrating to the Java 7 API java.nio.file.Files.createTempDirectory() which explicitly configures permissions of 700, or configuring the Java runtime's java.io.tmpdir system property to point to a location whose permissions are appropriately configured.",
-      "feed": "vulnerabilities",
-      "feed_group": "nvd",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
-      "severity": "Low",
-      "vulnerability_id": "CVE-2020-8908"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [
-        "cpe:2.3:a:*:aiohttp:3.7.3:*:*:*:*:*:*:*"
-      ],
-      "location": "/usr/local/lib64/python3.6/site-packages/aiohttp",
-      "name": "aiohttp",
-      "pkg_type": "python",
-      "version": "3.7.3"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 5.8,
-          "exploitability_score": 8.6,
-          "impact_score": 4.9,
-          "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:N",
-          "version": "2.0"
-        },
-        {
-          "base_score": 6.1,
-          "exploitability_score": 2.8,
-          "impact_score": 2.7,
-          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
-          "version": "3.1"
-        }
-      ],
-      "description": "aiohttp is an asynchronous HTTP client/server framework for asyncio and Python. In aiohttp before version 3.7.4 there is an open redirect vulnerability. A maliciously crafted link to an aiohttp-based web-server could redirect the browser to a different website. It is caused by a bug in the `aiohttp.web_middlewares.normalize_path_middleware` middleware. This security problem has been fixed in 3.7.4. Upgrade your dependency using pip as follows \"pip install aiohttp >= 3.7.4\". If upgrading is not an option for you, a workaround can be to avoid using `aiohttp.web_middlewares.normalize_path_middleware` in your applications.",
-      "feed": "vulnerabilities",
-      "feed_group": "nvd",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21330",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2021-21330"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [
-        "cpe:2.3:a:*:xmldom:0.4.0:*:*:*:*:*:*:*"
-      ],
-      "location": "/root/.npm/xmldom/0.4.0/package/package.json",
-      "name": "xmldom",
-      "pkg_type": "npm",
-      "version": "0.4.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 4.3,
-          "exploitability_score": 8.6,
-          "impact_score": 2.9,
-          "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-          "version": "2.0"
-        },
-        {
-          "base_score": 4.3,
-          "exploitability_score": 2.8,
-          "impact_score": 1.4,
-          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
-          "version": "3.1"
-        }
-      ],
-      "description": "xmldom is a pure JavaScript W3C standard-based (XML DOM Level 2 Core) DOMParser and XMLSerializer module. xmldom versions 0.4.0 and older do not correctly preserve system identifiers, FPIs or namespaces when repeatedly parsing and serializing maliciously crafted documents. This may lead to unexpected syntactic changes during XML processing in some downstream applications. This is fixed in version 0.5.0. As a workaround downstream applications can validate the input and reject the maliciously crafted documents.",
-      "feed": "vulnerabilities",
-      "feed_group": "nvd",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21366",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2021-21366"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
-      "cpes": [
-        "cpe:2.3:a:*:xmldom:0.4.0:*:*:*:*:*:*:*"
-      ],
-      "location": "/sandbox/node_modules/xmldom/package.json",
-      "name": "xmldom",
-      "pkg_type": "npm",
-      "version": "0.4.0"
-    },
-    "fix": {
-      "advisories": [],
-      "observed_at": null,
-      "versions": [],
-      "will_not_fix": false
-    },
-    "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
-    },
-    "nvd": [],
-    "vulnerability": {
-      "cvss": [
-        {
-          "base_score": 4.3,
-          "exploitability_score": 8.6,
-          "impact_score": 2.9,
-          "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
-          "version": "2.0"
-        },
-        {
-          "base_score": 4.3,
-          "exploitability_score": 2.8,
-          "impact_score": 1.4,
-          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
-          "version": "3.1"
-        }
-      ],
-      "description": "xmldom is a pure JavaScript W3C standard-based (XML DOM Level 2 Core) DOMParser and XMLSerializer module. xmldom versions 0.4.0 and older do not correctly preserve system identifiers, FPIs or namespaces when repeatedly parsing and serializing maliciously crafted documents. This may lead to unexpected syntactic changes during XML processing in some downstream applications. This is fixed in version 0.5.0. As a workaround downstream applications can validate the input and reject the maliciously crafted documents.",
-      "feed": "vulnerabilities",
-      "feed_group": "nvd",
-      "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21366",
-      "severity": "Medium",
-      "vulnerability_id": "CVE-2021-21366"
-    }
-  },
-  {
-    "artifact": {
-      "cpe": null,
       "cpes": [],
       "location": "pkgdb",
       "name": "openssl-libs",
       "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
+      "version": "1:1.0.2k-19.el7"
     },
     "fix": {
       "advisories": [],
@@ -6368,7 +1007,7 @@
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
+      "detected_at": "2021-09-28T17:55:01Z"
     },
     "nvd": [
       {
@@ -6426,7 +1065,7 @@
       "location": "pkgdb",
       "name": "openssl-libs",
       "pkg_type": "rpm",
-      "version": "1.0.2k-19.el7"
+      "version": "1:1.0.2k-19.el7"
     },
     "fix": {
       "advisories": [],
@@ -6435,7 +1074,7 @@
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
+      "detected_at": "2021-09-28T17:55:01Z"
     },
     "nvd": [
       {
@@ -6504,14 +1143,14 @@
     },
     "fix": {
       "advisories": [],
-      "observed_at": "2021-09-10T20:52:59Z",
+      "observed_at": "2021-09-28T17:55:01Z",
       "versions": [
         "0:2.56.1-9.el7_9"
       ],
       "will_not_fix": false
     },
     "match": {
-      "detected_at": "2021-09-10T20:52:59Z"
+      "detected_at": "2021-09-28T17:55:01Z"
     },
     "nvd": [
       {
@@ -6553,6 +1192,384 @@
       "link": "https://access.redhat.com/security/cve/CVE-2021-27219",
       "severity": "High",
       "vulnerability_id": "CVE-2021-27219"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/sandbox/target/my-app-1.jar:guava",
+      "name": "guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-09-28T17:55:01Z",
+      "versions": [
+        "30.0-jre"
+      ],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-28T17:55:01Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 3.3,
+            "exploitability_score": 1.8,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2020-8908"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": "Information Disclosure in Guava",
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/sandbox/target/original-my-app-1.jar:guava",
+      "name": "guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-09-28T17:55:01Z",
+      "versions": [
+        "30.0-jre"
+      ],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-28T17:55:01Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 2.1,
+            "exploitability_score": 3.9,
+            "impact_score": 2.9,
+            "vector": "AV:L/AC:L/Au:N/C:P/I:N/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 3.3,
+            "exploitability_score": 1.8,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908",
+        "severity": "Low",
+        "vulnerability_id": "CVE-2020-8908"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": "Information Disclosure in Guava",
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "link": "https://github.com/advisories/GHSA-5mg8-w23w-74h3",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-5mg8-w23w-74h3"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/root/.npm/xmldom/0.4.0/package/package.json",
+      "name": "xmldom",
+      "pkg_type": "npm",
+      "version": "0.4.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-09-28T17:55:01Z",
+      "versions": [
+        "0.5.0"
+      ],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-28T17:55:01Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 4.3,
+            "exploitability_score": 2.8,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21366",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2021-21366"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": "Misinterpretation of malicious XML input",
+      "feed": "vulnerabilities",
+      "feed_group": "github:npm",
+      "link": "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv",
+      "severity": "Low",
+      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/sandbox/node_modules/xmldom/package.json",
+      "name": "xmldom",
+      "pkg_type": "npm",
+      "version": "0.4.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-09-28T17:55:01Z",
+      "versions": [
+        "0.5.0"
+      ],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-28T17:55:01Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 4.3,
+            "exploitability_score": 2.8,
+            "impact_score": 1.4,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21366",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2021-21366"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": "Misinterpretation of malicious XML input",
+      "feed": "vulnerabilities",
+      "feed_group": "github:npm",
+      "link": "https://github.com/advisories/GHSA-h6q6-9hqw-rwfv",
+      "severity": "Low",
+      "vulnerability_id": "GHSA-h6q6-9hqw-rwfv"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/sandbox/target/my-app-1.jar:guava",
+      "name": "guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-09-28T17:55:01Z",
+      "versions": [
+        "24.1.1-jre"
+      ],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-28T17:55:01Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 5.9,
+            "exploitability_score": 2.2,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2018-10237"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": "Denial of Service in Google Guava",
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/sandbox/target/original-my-app-1.jar:guava",
+      "name": "guava",
+      "pkg_type": "java",
+      "version": "23.0"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-09-28T17:55:01Z",
+      "versions": [
+        "24.1.1-jre"
+      ],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-28T17:55:01Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 4.3,
+            "exploitability_score": 8.6,
+            "impact_score": 2.9,
+            "vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
+            "version": "2.0"
+          },
+          {
+            "base_score": 5.9,
+            "exploitability_score": 2.2,
+            "impact_score": 3.6,
+            "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2018-10237",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2018-10237"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": "Denial of Service in Google Guava",
+      "feed": "vulnerabilities",
+      "feed_group": "github:java",
+      "link": "https://github.com/advisories/GHSA-mvr2-9pj6-7w5j",
+      "severity": "Medium",
+      "vulnerability_id": "GHSA-mvr2-9pj6-7w5j"
+    }
+  },
+  {
+    "artifact": {
+      "cpe": null,
+      "cpes": [],
+      "location": "/usr/local/lib64/python3.6/site-packages/aiohttp",
+      "name": "aiohttp",
+      "pkg_type": "python",
+      "version": "3.7.3"
+    },
+    "fix": {
+      "advisories": [],
+      "observed_at": "2021-09-28T17:55:01Z",
+      "versions": [
+        "3.7.4"
+      ],
+      "will_not_fix": false
+    },
+    "match": {
+      "detected_at": "2021-09-28T17:55:01Z"
+    },
+    "nvd": [
+      {
+        "cvss": [
+          {
+            "base_score": 5.8,
+            "exploitability_score": 8.6,
+            "impact_score": 4.9,
+            "vector": "AV:N/AC:M/Au:N/C:P/I:P/A:N",
+            "version": "2.0"
+          },
+          {
+            "base_score": 6.1,
+            "exploitability_score": 2.8,
+            "impact_score": 2.7,
+            "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+            "version": "3.1"
+          }
+        ],
+        "description": null,
+        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-21330",
+        "severity": "Medium",
+        "vulnerability_id": "CVE-2021-21330"
+      }
+    ],
+    "vulnerability": {
+      "cvss": [],
+      "description": "Open redirect vulnerability in `aiohttp` (`normalize_path_middleware` middleware)",
+      "feed": "vulnerabilities",
+      "feed_group": "github:python",
+      "link": "https://github.com/advisories/GHSA-v6wp-4m6f-gcjg",
+      "severity": "Low",
+      "vulnerability_id": "GHSA-v6wp-4m6f-gcjg"
     }
   }
 ]

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/test_query_by_vulnerability.py
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/test_query_by_vulnerability.py
@@ -25,33 +25,16 @@ arg_combination_tests = [
         ["sha256:fe3ca35038008b0eac0fa4e686bd072c9430000ab7d7853001bde5f5b8ccf60c"],
         ImagesByVulnerabilityQueryOptions("Medium", "rhel:7", "curl", False),
     ),
+    ImagesByVulnerabilityQuery(
+        "GHSA-5mg8-w23w-74h3",
+        [
+            "sha256:80a31c3ce2e99c3691c27ac3b1753163214494e9b2ca07bfdccf29a5cca2bfbe",
+            "sha256:406413437f26223183d133ccc7186f24c827729e1b21adc7330dd43fcdc030b3",
+            "sha256:fe3ca35038008b0eac0fa4e686bd072c9430000ab7d7853001bde5f5b8ccf60c",
+        ],
+        ImagesByVulnerabilityQueryOptions("Medium", "github:java", "guava", False),
+    ),
 ]
-
-# conditionally add test based upon whether grype or legacy vuln provider
-if is_legacy_provider():
-    arg_combination_tests.append(
-        ImagesByVulnerabilityQuery(
-            "GHSA-5mg8-w23w-74h3",
-            [
-                "sha256:80a31c3ce2e99c3691c27ac3b1753163214494e9b2ca07bfdccf29a5cca2bfbe",
-                "sha256:406413437f26223183d133ccc7186f24c827729e1b21adc7330dd43fcdc030b3",
-                "sha256:fe3ca35038008b0eac0fa4e686bd072c9430000ab7d7853001bde5f5b8ccf60c",
-            ],
-            ImagesByVulnerabilityQueryOptions("Medium", "github:java", "guava", False),
-        )
-    )
-else:
-    arg_combination_tests.append(
-        ImagesByVulnerabilityQuery(
-            "CVE-2020-8908",
-            [
-                "sha256:80a31c3ce2e99c3691c27ac3b1753163214494e9b2ca07bfdccf29a5cca2bfbe",
-                "sha256:406413437f26223183d133ccc7186f24c827729e1b21adc7330dd43fcdc030b3",
-                "sha256:fe3ca35038008b0eac0fa4e686bd072c9430000ab7d7853001bde5f5b8ccf60c",
-            ],
-            ImagesByVulnerabilityQueryOptions("Low", "nvd", "guava", False),
-        )
-    )
 
 
 class TestQueryByVulnerability:
@@ -86,10 +69,6 @@ class TestQueryByVulnerability:
         )
         assert results == set(query.affected_images)
 
-    @pytest.mark.skipif(
-        not is_legacy_provider(),
-        reason="Temporarily skipping test with changed output from grype",
-    )
     @pytest.mark.parametrize(
         "query",
         [
@@ -102,7 +81,7 @@ class TestQueryByVulnerability:
                 ],
             ),
             ImagesByVulnerabilityQuery(
-                "GHSA-h6q6-9hqw-rwfv" if is_legacy_provider() else "CVE-2021-21366",
+                "GHSA-h6q6-9hqw-rwfv",
                 [
                     "sha256:80a31c3ce2e99c3691c27ac3b1753163214494e9b2ca07bfdccf29a5cca2bfbe",
                     "sha256:406413437f26223183d133ccc7186f24c827729e1b21adc7330dd43fcdc030b3",
@@ -110,7 +89,7 @@ class TestQueryByVulnerability:
                 ],
             ),
             ImagesByVulnerabilityQuery(
-                "CVE-2021-21330",
+                "CVE-2021-21330" if is_legacy_provider() else "GHSA-v6wp-4m6f-gcjg",
                 [
                     "sha256:80a31c3ce2e99c3691c27ac3b1753163214494e9b2ca07bfdccf29a5cca2bfbe",
                     "sha256:406413437f26223183d133ccc7186f24c827729e1b21adc7330dd43fcdc030b3",
@@ -118,7 +97,7 @@ class TestQueryByVulnerability:
                 ],
             ),
             ImagesByVulnerabilityQuery(
-                "CVE-2020-8908",
+                "CVE-2020-8908" if is_legacy_provider() else "GHSA-5mg8-w23w-74h3",
                 [
                     "sha256:80a31c3ce2e99c3691c27ac3b1753163214494e9b2ca07bfdccf29a5cca2bfbe",
                     "sha256:406413437f26223183d133ccc7186f24c827729e1b21adc7330dd43fcdc030b3",
@@ -149,18 +128,14 @@ class TestQueryByVulnerability:
             ImagesByVulnerabilityQuery("CVE-2020-0000", []),
         ],
     )
-    def test_query_by_vulnerability(self, schema_validator, ingress_all_images, query):
+    def test_query_by_vulnerability(self, schema_validator, setup_all_images, query):
         self._test_query_by_vulnerability(query, schema_validator)
 
-    @pytest.mark.skipif(
-        not is_legacy_provider(),
-        reason="Temporarily skipping test with changed output from grype",
-    )
     @pytest.mark.parametrize("query", arg_combination_tests)
     def test_query_by_vulnerability_arg_combinations(
         self,
         schema_validator,
-        ingress_all_images,
+        setup_all_images,
         query,
     ):
         # Where n is the number of args that can be passed to the endpoint

--- a/tests/functional/services/policy_engine/vulnerability_data_tests/test_vulnerability_scanner.py
+++ b/tests/functional/services/policy_engine/vulnerability_data_tests/test_vulnerability_scanner.py
@@ -2,6 +2,9 @@ import pytest
 
 import tests.functional.services.policy_engine.utils.api as policy_engine_api
 from tests.functional.services.policy_engine.conftest import is_legacy_provider
+from tests.functional.services.policy_engine.vulnerability_data_tests.conftest import (
+    IMAGE_DIGEST_MAP,
+)
 from tests.functional.services.utils import http_utils
 
 
@@ -14,6 +17,10 @@ from tests.functional.services.utils import http_utils
     ],
 )
 class TestVulnerabilityScanner:
+    @pytest.mark.skipif(
+        not is_legacy_provider(),
+        reason="Grype workflow no longer testing policy engine in isolation",
+    )
     def test_image_load_schema(self, image_digest, ingress_image, schema_validator):
         # ingress image and check that response is 200
         image_load_resp: http_utils.APIResponse = ingress_image(image_digest)
@@ -30,56 +37,27 @@ class TestVulnerabilityScanner:
         ]
 
     def test_get_vulnerabilities_schema(
-        self, image_digest, image_digest_id_map, ingress_image, schema_validator
+        self, image_digest, setup_image, schema_validator
     ):
         # ingress image
-        ingress_image(image_digest)
+        setup_image(image_digest)
         # now that image is ingressed, can query vulnerabilities and assert response is 200
-        image_id = image_digest_id_map[image_digest]
+        image_id = IMAGE_DIGEST_MAP[image_digest]["image_id"]
         images_vuln_resp: http_utils.APIResponse = (
             policy_engine_api.users.get_image_vulnerabilities(image_id)
         )
         assert images_vuln_resp == http_utils.APIResponse(200)
 
-        # check that response schema matches expected format
-        vulnerability_schema_validator = schema_validator(
-            "vulnerability_report.schema.json"
-        )
-        is_valid: bool = vulnerability_schema_validator.is_valid(images_vuln_resp.body)
-        assert is_valid, "\n".join(
-            [
-                str(e)
-                for e in vulnerability_schema_validator.iter_errors(
-                    images_vuln_resp.body
-                )
-            ]
-        )
-
-    def test_image_load_content(self, image_digest, ingress_image, expected_content):
-        # ingress image and check that response is 200
-        image_load_resp: http_utils.APIResponse = ingress_image(image_digest)
-        assert image_load_resp == http_utils.APIResponse(200)
-        # check that there are no errors in response
-        assert len(image_load_resp.body["problems"]) == 0, image_load_resp.body[
-            "problems"
-        ]
-        assert image_load_resp.body["status"] == "loaded"
-
-    @pytest.mark.skipif(
-        not is_legacy_provider(),
-        reason="Temporarily skipping test with changed output from grype",
-    )
     def test_get_vulnerabilities_content(
         self,
         image_digest,
-        image_digest_id_map,
-        ingress_image,
+        setup_image,
         expected_content,
         is_legacy_test,
     ):
         # ingress the image and get the image id
-        ingress_image(image_digest)
-        image_id = image_digest_id_map[image_digest]
+        setup_image(image_digest)
+        image_id = IMAGE_DIGEST_MAP[image_digest]["image_id"]
         # get the vulnerabilities for the image
         images_vuln_resp: http_utils.APIResponse = (
             policy_engine_api.users.get_image_vulnerabilities(image_id)


### PR DESCRIPTION
Fixes broken vulnerability tests for grype provider by adding the test images via the api instead of adding data to catalog and ingressing into the policy engine directly. Since the images need to analyze as opposed to having the content already available for vulnerability scanner, this changes does add some overhead to the workflow.