### PR TITLE
Changed sbom alpine metadata type to ApkMetadata

### DIFF
--- a/anchore_engine/services/policy_engine/engine/vulns/mappers.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/mappers.py
@@ -266,7 +266,7 @@ class ApkgMapper(LinuxDistroPackageMapper):
 
         artifact = super().image_content_to_grype_sbom(record)
         if record.get("sourcepkg") not in [None, "N/A", "n/a"]:
-            artifact["metadataType"] = "ApkgMetadata"
+            artifact["metadataType"] = "ApkMetadata"
             artifact["metadata"] = {"originPackage": record.get("sourcepkg")}
         return artifact
 

--- a/tests/unit/anchore_engine/services/policy_engine/engine/vulns/test_mappers.py
+++ b/tests/unit/anchore_engine/services/policy_engine/engine/vulns/test_mappers.py
@@ -350,7 +350,7 @@ class TestImageContentAPIToGrypeSbom:
                         "cpe:2.3:a:ssl:ssl-client:1.32.1-r5:*:*:*:*:*:*:*",
                     ],
                     "locations": [{"path": "pkgdb"}],
-                    "metadataType": "ApkgMetadata",
+                    "metadataType": "ApkMetadata",
                     "metadata": {"originPackage": "busybox"},
                 },
                 id="apkg-with-source",


### PR DESCRIPTION
Changes sbom metadata type to `ApkMetadata` instead of `ApkgMetadata` because that is what grype uses to build the metadata information