### PR TITLE
Fix unused imports

### DIFF
--- a/anchore_engine/db/entities/upgrade.py
+++ b/anchore_engine/db/entities/upgrade.py
@@ -754,8 +754,6 @@ def db_upgrade_007_008():
 
 
 def catalog_upgrade_007_008():
-    from anchore_engine.db import session_scope
-
     log.err("performing catalog table upgrades")
     engine = anchore_engine.db.entities.common.get_engine()
     new_columns = [
@@ -1112,8 +1110,6 @@ def db_upgrade_008_009():
     :return:
     """
 
-    from anchore_engine.db import session_scope
-
     if True:
         engine = anchore_engine.db.entities.common.get_engine()
 
@@ -1149,7 +1145,6 @@ def cpe_vulnerability_upgrade_009_010():
 
     :return:
     """
-    from anchore_engine.db import session_scope
 
     engine = anchore_engine.db.entities.common.get_engine()
 
@@ -1179,8 +1174,6 @@ def archive_document_upgrade_009_010():
     :return:
     """
 
-    from anchore_engine.db import session_scope
-
     engine = anchore_engine.db.entities.common.get_engine()
 
     exec_commands = [
@@ -1209,8 +1202,6 @@ def registry_name_upgrade_010_011():
 
     :return:
     """
-
-    from anchore_engine.db import session_scope
 
     engine = anchore_engine.db.entities.common.get_engine()
 
@@ -1262,8 +1253,6 @@ def fixed_artifacts_upgrade_010_011():
 
     :return:
     """
-
-    from anchore_engine.db import session_scope
 
     engine = anchore_engine.db.entities.common.get_engine()
 
@@ -1408,8 +1397,6 @@ def db_upgrade_package_size_011_012():
     Update the column type for image package size from int to bigint
     :return:
     """
-    from anchore_engine.db import session_scope
-
     engine = anchore_engine.db.entities.common.get_engine()
 
     # Add constraints and index
@@ -1423,8 +1410,6 @@ def event_type_index_upgrade_011_012():
 
     :return:
     """
-
-    from anchore_engine.db import session_scope
 
     engine = anchore_engine.db.entities.common.get_engine()
 
@@ -1590,8 +1575,6 @@ def db_upgrade_012_013():
 
 
 def upgrade_014_archive_rules():
-    from anchore_engine.db import session_scope
-
     engine = anchore_engine.db.entities.common.get_engine()
 
     new_columns = [

--- a/anchore_engine/db/entities/upgrade.py
+++ b/anchore_engine/db/entities/upgrade.py
@@ -14,11 +14,50 @@ from sqlalchemy import (
     Text,
 )
 
+import anchore_engine.common
 import anchore_engine.common.helpers
 import anchore_engine.db.entities.common
 import anchore_engine.subsys.object_store.manager
-from anchore_engine.db.entities.common import StringJSON
+from anchore_engine import version
+from anchore_engine.configuration import localconfig
+from anchore_engine.configuration.localconfig import (
+    ADMIN_ACCOUNT_NAME,
+    SYSTEM_ACCOUNT_NAME,
+)
+from anchore_engine.db import (
+    Image,
+    ImageGem,
+    ImageNpm,
+    ImagePackage,
+    LegacyArchiveDocument,
+    ObjectStorageMetadata,
+    db_anchore,
+    db_archivedocument,
+    db_catalog_image,
+    db_policybundle,
+    db_registries,
+    legacy_db_users,
+    session_scope,
+)
+from anchore_engine.db.db_locks import application_lock_ids, db_application_lock
+from anchore_engine.db.entities.common import Base, StringJSON, do_create
 from anchore_engine.db.entities.exceptions import is_table_not_found
+from anchore_engine.db.entities.identity import UserTypes, anchore_uuid
+from anchore_engine.services.policy_engine import process_preflight
+from anchore_engine.services.policy_engine.engine.feeds import sync
+from anchore_engine.services.policy_engine.engine.feeds.feeds import (
+    have_vulnerabilities_for,
+)
+from anchore_engine.services.policy_engine.engine.vulnerabilities import (
+    DistroNamespace,
+    rescan_namespace,
+)
+from anchore_engine.subsys import object_store
+from anchore_engine.subsys.identities import AccountStates, manager_factory
+from anchore_engine.subsys.object_store.config import (
+    ALT_OBJECT_STORE_CONFIG_KEY,
+    DEFAULT_OBJECT_STORE_MANAGER_ID,
+)
 
 try:
     # Separate logger for use during bootstrap when logging may not be fully configured
@@ -64,14 +103,10 @@ def get_versions():
     code_versions = {}
     db_versions = {}
 
-    from anchore_engine import version
-
     code_versions["service_version"] = version.version
     code_versions["db_version"] = version.db_version
 
     try:
-        from anchore_engine.db import db_anchore, session_scope
-
         with session_scope() as dbsession:
             db_versions = db_anchore.get(session=dbsession)
     except Exception as err:
@@ -88,8 +123,6 @@ def get_versions():
 
 
 def do_version_update(db_versions, code_versions):
-    from anchore_engine.db import db_anchore, session_scope
-
     with session_scope() as dbsession:
         db_anchore.add(
             code_versions["service_version"],
@@ -112,8 +145,6 @@ def upgrade_context(lock_id):
     """
     engine = anchore_engine.db.entities.common.get_engine()
 
-    from anchore_engine.db.db_locks import application_lock_ids, db_application_lock
-
     with db_application_lock(
         engine, (application_lock_ids["upgrade"]["namespace"], lock_id)
     ):
@@ -123,7 +154,6 @@ def upgrade_context(lock_id):
 
 def do_create_tables(specific_tables=None):
     print("Creating DB Tables")
-    from anchore_engine.db.entities.common import Base, do_create
 
     try:
         with upgrade_context(my_module_upgrade_id) as ctx:
@@ -135,7 +165,6 @@ def do_create_tables(specific_tables=None):
 
 
 def do_db_bootstrap(localconfig=None, db_versions=None, code_versions=None):
-    from anchore_engine.db import session_scope
 
     with upgrade_context(my_module_upgrade_id) as ctx:
         with session_scope() as session:
@@ -291,8 +320,6 @@ def do_upgrade(inplace, incode):
 def db_upgrade_001_002():
     engine = anchore_engine.db.entities.common.get_engine()
 
-    from anchore_engine.db import db_policybundle, db_registries, session_scope
-
     try:
         table_name = "registries"
         column = Column("registry_type", String, primary_key=False)
@@ -377,9 +404,6 @@ def db_upgrade_002_003():
 
 def db_upgrade_003_004():
     engine = anchore_engine.db.entities.common.get_engine()
-
-    import anchore_engine.common
-    from anchore_engine.db import db_archivedocument, db_catalog_image, session_scope
 
     newcolumns = [
         Column("arch", String, primary_key=False),
@@ -529,18 +553,6 @@ def archive_data_upgrade_005_006():
 
     :return:
     """
-
-    from anchore_engine.configuration import localconfig
-    from anchore_engine.db import (
-        LegacyArchiveDocument,
-        ObjectStorageMetadata,
-        session_scope,
-    )
-    from anchore_engine.subsys import object_store
-    from anchore_engine.subsys.object_store.config import (
-        ALT_OBJECT_STORE_CONFIG_KEY,
-        DEFAULT_OBJECT_STORE_MANAGER_ID,
-    )
 
     config = localconfig.get_config()
     object_store.initialize(
@@ -695,13 +707,6 @@ def catalog_image_upgrades_006_007():
 def user_account_upgrades_007_008():
     logger.info("Upgrading user accounts for multi-user support")
 
-    from anchore_engine.configuration.localconfig import (
-        ADMIN_ACCOUNT_NAME,
-        SYSTEM_ACCOUNT_NAME,
-    )
-    from anchore_engine.db import legacy_db_users, session_scope
-    from anchore_engine.subsys.identities import AccountStates, manager_factory
-
     with session_scope() as session:
         mgr = manager_factory.for_session(session)
         for user in legacy_db_users.get_all():
@@ -794,7 +799,6 @@ def catalog_upgrade_007_008():
 
 
 def policy_engine_packages_upgrade_007_008():
-    from anchore_engine.db import Image, ImageGem, ImageNpm, ImagePackage, session_scope
 
     if True:
         engine = anchore_engine.db.entities.common.get_engine()
@@ -1303,8 +1307,6 @@ def update_users_010_011():
     Upgrade to add column to users table
     :return:
     """
-    from anchore_engine.configuration import localconfig
-    from anchore_engine.db.entities.identity import UserTypes, anchore_uuid
 
     engine = anchore_engine.db.entities.common.get_engine()
 
@@ -1425,8 +1427,6 @@ def db_upgrade_011_012():
 def upgrade_feed_groups_013():
     log.err("Upgrading feed and feed group schemas to add enabled flags")
 
-    from anchore_engine.services.policy_engine.engine.feeds import sync
-
     engine = anchore_engine.db.entities.common.get_engine()
 
     log.err("Updating feeds table to have enabled flag")
@@ -1479,13 +1479,6 @@ def upgrade_flush_centos_vulns_013():
 
     :return:
     """
-    from anchore_engine.services.policy_engine.engine.feeds import sync
-    from anchore_engine.services.policy_engine.engine.feeds.feeds import (
-        have_vulnerabilities_for,
-    )
-    from anchore_engine.services.policy_engine.engine.vulnerabilities import (
-        DistroNamespace,
-    )
 
     engine = anchore_engine.db.entities.common.get_engine()
 
@@ -1530,10 +1523,6 @@ def upgrade_centos_rhel_synced_013():
 
     :return:
     """
-    from anchore_engine.db import session_scope
-    from anchore_engine.services.policy_engine.engine.vulnerabilities import (
-        rescan_namespace,
-    )
 
     log.err(
         "Scanning all images applicable for the rhel data feed to create matches based on new CVE data in rhel:* groups in addition to RHSA-based data from old centos:* groups. This may take a while"
@@ -1565,7 +1554,6 @@ def db_upgrade_012_013():
     :return:
     """
     # Setup some policy engine stuff to support feed ops
-    from anchore_engine.services.policy_engine import process_preflight
 
     process_preflight()
 

--- a/anchore_engine/services/policy_engine/__init__.py
+++ b/anchore_engine/services/policy_engine/__init__.py
@@ -343,9 +343,6 @@ def handle_grypedb_sync(*args, **kwargs):
     # import code in function so that it is not imported to all contexts that import policy engine
     # this is an issue caused by these handlers being declared within the __init__.py file
     # See https://github.com/anchore/anchore-engine/issues/991
-    from anchore_engine.services.policy_engine.engine.feeds.grypedb_sync import (
-        GrypeDBSyncError,
-    )
     from anchore_engine.services.policy_engine.engine.tasks import GrypeDBSyncTask
 
     logger.info("init args: {}".format(kwargs))


### PR DESCRIPTION
This PR removes some unused imports in the policy engine and the db upgrade script. It's possible that the unused imports in the upgrade script were doing something, but I can't tell what. Would appreciate a sanity check.