### PR TITLE
use threadpoolexecutor in image archival

### DIFF
--- a/conf/default_config.yaml
+++ b/conf/default_config.yaml
@@ -125,6 +125,8 @@ services:
       image_gc: 60
     image_gc:
       max_worker_threads: 1
+    archive_tasks:
+      max_worker_threads: 1
     event_log:
       notification:
         enabled: ${ANCHORE_EVENTS_NOTIFICATIONS_ENABLED}


### PR DESCRIPTION
Related to: https://github.com/anchore/anchore-engine/pull/1273
This PR attempts to parallelize image archival with the use of a ThreadPoolExecutor. The hope that it may result in some performance improvements.

<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**:


**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #:

**Special notes**:


