### PR TITLE
Cleanup dockerfile for p1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,10 @@ RUN set -ex && \
     echo "installing Grype" && \
     curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /build_output/deps "$GRYPE_VERSION"
 
-RUN tar -z -c -v -C /build_output -f /anchore-buildblob.tgz .
+# create p1 buildblob & checksum
+RUN set -ex && \
+    tar -z -c -v -C /build_output -f /anchore-buildblob.tgz . && \
+    sha256sum /anchore-buildblob.tgz > /buildblob.tgz.sha256sum
 
 # Build setup section
 


### PR DESCRIPTION
<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**:
Installs pip3 using a wheel in /build_output for p1 compatibility. Add sha256sum of buildblob directly to first stage.

