### PR TITLE
Adds Go and Binary Support For Semantic Version Comparison

### DIFF
--- a/anchore_engine/util/langpack.py
+++ b/anchore_engine/util/langpack.py
@@ -21,7 +21,7 @@ def language_compare(a, op, b, language="python"):
     if language in ["java", "maven"]:
         aoptions = [MavenVersion(a)]
         boptions = [MavenVersion(b)]
-    elif language in ["js", "npm", "ruby", "gem", "nuget"]:
+    elif language in ["js", "npm", "ruby", "gem", "nuget", "go", "binary"]:
         try:
             aoptions = [semantic_version.Version.coerce(a)]
             boptions = [semantic_version.Version.coerce(b)]
@@ -46,7 +46,7 @@ def language_compare(a, op, b, language="python"):
             aoptions = [LooseVersion(a), parse_version(a)]
             boptions = [LooseVersion(b), parse_version(b)]
     else:
-        raise Exception(
+        raise ValueError(
             "language {} not supported for version comparison".format(language)
         )
 
@@ -124,14 +124,17 @@ def normalized_version_match(rawsemver, rawpkgver, language="python"):
         # and check
         violation = False
         if not rangechecks:
-            raise Exception("invalid range detected - {}".format(vrange))
+            raise ValueError("invalid range detected - {}".format(vrange))
 
         for rangecheck in rangechecks:
             rangecheck = re.sub(r"\s+", "", rangecheck)
             patt = re.match("([!|<|>|=|~|^]+)(.*)", rangecheck)
             if patt:
                 op, verraw = (patt.group(1), patt.group(2))
-                inrange = language_compare(rawpkgver, op, verraw, language=language)
+                try:
+                    inrange = language_compare(rawpkgver, op, verraw, language=language)
+                except ValueError as v_err:
+                    logger.debug(v_err)
 
                 if not inrange:
                     violation = True

--- a/tests/unit/anchore_engine/util/test_langpack.py
+++ b/tests/unit/anchore_engine/util/test_langpack.py
@@ -4,8 +4,19 @@ from anchore_engine.util.langpack import compare_versions
 
 enable_training = False
 
-all_languages = ["java", "maven", "js", "npm", "ruby", "gem", "nuget", "python"]
-generic_languages = ["js", "npm", "ruby", "gem", "nuget"]
+all_languages = [
+    "java",
+    "maven",
+    "js",
+    "npm",
+    "ruby",
+    "gem",
+    "nuget",
+    "python",
+    "go",
+    "binary",
+]
+generic_languages = ["js", "npm", "ruby", "gem", "nuget", "go"]
 
 lesser_versions = [
     "0.0",
@@ -248,8 +259,7 @@ class TestSemver:
         assert compare_versions(left, right, lang) is False
 
     def test_unsupported(self):
-        with pytest.raises(Exception):
-            compare_versions("> 1.0", "1.0", "VimScript")
+        assert compare_versions("> 1.0", "1.0", "VimScript") is False
 
     @pytest.mark.parametrize("left,right", error_matches)
     @pytest.mark.parametrize("lang", all_languages)


### PR DESCRIPTION
A bug was reported where the go language was not supported
for version comparison.  This patch adds go and binary types
to the language version comparison checking.

closes: #ENT-870

Signed-off-by: Ryan Brady <ryan.brady@anchore.com>

<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**:


**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #:

**Special notes**:


