### PR TITLE
Add `coveragerc` to Anchore Engine

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[report]
+omit = */tests/*
+precision = 2
+
+[run]
+branch = true


### PR DESCRIPTION
Currently there is no `coveragerc` file for Anchore Engine so coverage
is generating statistics with the default set of parameters.

This patch adds a new `.coveragerc` file to Anchore Engine to ensure
that we are generating coverage with a good amount of precision (two
places past the decimal), are ensuring that we have branch coverage, and
to omit the tests from coverage statistics.

Signed-off-by: Dustin Schoenbrun <dustin.schoenbrun@anchore.com>
