### PR TITLE
Add nuget package mapping for Microsoft.NETCore.App. Add test case and fix existing test.

### DIFF
--- a/anchore_engine/util/cpe_generators.py
+++ b/anchore_engine/util/cpe_generators.py
@@ -7,6 +7,7 @@ duty, so this module is not expected to grow.
 
 import re
 from typing import List
+
 from anchore_engine.subsys import logger
 
 SIMPLIFIED_SEMVER_REGEX = r".*([0-9]+\.[0-9]+\.[0-9]+).*"
@@ -37,6 +38,9 @@ NOMATCH_INCLUSIONS = {
     },
     "python": {
         "python-rrdtool": ["rrdtool"],
+    },
+    "nuget": {
+        "Microsoft.NETCore.App": [".net_core"],
     },
 }
 

--- a/tests/unit/anchore_engine/util/test_cpe_generators.py
+++ b/tests/unit/anchore_engine/util/test_cpe_generators.py
@@ -49,7 +49,7 @@ def test_generate_product_functions(name, expected_list, generator_function):
         pytest.param(
             "cremefraiche",
             "gem",
-            ["creme_fraishe", "cremefraiche"],
+            ["creme_fraiche", "cremefraiche"],
             id="gem-matches-inclusion-list",
         ),
         pytest.param("npm1", "npm", ["npm1"], id="npm-simple"),
@@ -67,6 +67,12 @@ def test_generate_product_functions(name, expected_list, generator_function):
             id="python-matches-inclusion-list",
         ),
         pytest.param(
+            "Microsoft.NETCore.App",
+            "nuget",
+            ["Microsoft.NETCore.App", ".net_core"],
+            id="nuget-matches-inclusion-list",
+        ),
+        pytest.param(
             "foobar",
             "unknownpackagetype",
             ["foobar"],
@@ -75,7 +81,16 @@ def test_generate_product_functions(name, expected_list, generator_function):
     ],
 )
 def test_generate_products(name, package_type, expected_list):
-    assert generate_products(name, package_type).sort() == expected_list.sort()
+    # Function under test
+    products = generate_products(name, package_type)
+
+    # Sort the observed and expected lists
+    # sort() is an in-place operation and returns None, so don't store or compare the call results
+    products.sort()
+    expected_list.sort()
+
+    # Validate output
+    assert products == expected_list
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Signed-off-by: Dan Palmer <dan.palmer@anchore.com>

<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**: This PR adds a mapping for nuget CPEs where the package equals `Microsoft.NETCore.App` to line up with the nvd package name which is `.net_core`.

It also adds a unit test case, and fixes a minor test bug I found in the existing unit test case.