### PR TITLE
Add unit test for make_response_error

### DIFF
--- a/tests/unit/anchore_engine/common/test_helpers.py
+++ b/tests/unit/anchore_engine/common/test_helpers.py
@@ -45,3 +45,164 @@ class TestExtractPythonContent:
         assert len(extracted_content[key]["licenses"]) == 1
         assert extracted_content[key]["licenses"][0] == "MIT"
         assert len(extracted_content[key]["cpes"]) > 0
+
+
+class TestMakeResponseError:
+    class TestException(Exception):
+        def __init__(self, msg, anchore_error_json=None):
+            super().__init__(msg)
+            if anchore_error_json is not None:
+                self.anchore_error_json = anchore_error_json
+
+    params = [
+        pytest.param(
+            {
+                "errmsg": "basic-test-case",
+                "in_httpcode": None,
+                "details": None,
+                "expected": {
+                    "message": "basic-test-case",
+                    "httpcode": 500,
+                    "detail": {"error_codes": []},
+                },
+            },
+            id="basic",
+        ),
+        pytest.param(
+            {
+                "errmsg": "basic-test-case",
+                "in_httpcode": 400,
+                "details": None,
+                "expected": {
+                    "message": "basic-test-case",
+                    "httpcode": 400,
+                    "detail": {"error_codes": []},
+                },
+            },
+            id="basic-with-httpcode",
+        ),
+        pytest.param(
+            {
+                "errmsg": "basic-test-case",
+                "in_httpcode": None,
+                "details": {"test": "value"},
+                "expected": {
+                    "message": "basic-test-case",
+                    "httpcode": 500,
+                    "detail": {
+                        "test": "value",
+                        "error_codes": [],
+                    },
+                },
+            },
+            id="basic-with-details",
+        ),
+        pytest.param(
+            {
+                "errmsg": "basic-test-case",
+                "in_httpcode": None,
+                "details": {"error_codes": [500, 404]},
+                "expected": {
+                    "message": "basic-test-case",
+                    "httpcode": 500,
+                    "detail": {"error_codes": [500, 404]},
+                },
+            },
+            id="basic-with-error-codes",
+        ),
+        pytest.param(
+            {
+                "errmsg": Exception("thisisatest"),
+                "in_httpcode": None,
+                "details": None,
+                "expected": {
+                    "message": "thisisatest",
+                    "httpcode": 500,
+                    "detail": {"error_codes": []},
+                },
+            },
+            id="basic-exception",
+        ),
+        pytest.param(
+            {
+                "errmsg": TestException(
+                    "testexception",
+                    anchore_error_json={
+                        "message": "test",
+                        "httpcode": 500,
+                        "detail": {"error_codes": [404]},
+                    },
+                ),
+                "in_httpcode": 400,
+                "details": None,
+                "expected": {
+                    "message": "test",
+                    "httpcode": 500,
+                    "detail": {"error_codes": [404]},
+                },
+            },
+            id="basic-exception-with-anchore-error-json",
+        ),
+        pytest.param(
+            {
+                "errmsg": TestException(
+                    "testexception",
+                    anchore_error_json={
+                        "message": "test",
+                        "httpcode": 500,
+                        "detail": {"error_codes": [404]},
+                        "error_code": 401,
+                    },
+                ),
+                "in_httpcode": 400,
+                "details": None,
+                "expected": {
+                    "message": "test",
+                    "httpcode": 500,
+                    "detail": {"error_codes": [404, 401]},
+                },
+            },
+            id="basic-exception-with-anchore-error-json-and-error-code",
+        ),
+        pytest.param(
+            {
+                "errmsg": TestException(
+                    "testexception",
+                    anchore_error_json='{"message": "test", "httpcode": 500, "detail": {"error_codes": [404]}}',
+                ),
+                "in_httpcode": 400,
+                "details": None,
+                "expected": {
+                    "message": "test",
+                    "httpcode": 500,
+                    "detail": {"error_codes": [404]},
+                },
+            },
+            id="basic-exception-with-json-string",
+        ),
+        pytest.param(
+            {
+                "errmsg": TestException(
+                    "testexception",
+                    anchore_error_json='{"message" "test", "httpcode": 500, "detail": {"error_codes": [404]}}',
+                ),
+                "in_httpcode": 400,
+                "details": None,
+                "expected": {
+                    "message": "testexception",
+                    "httpcode": 400,
+                    "detail": {"error_codes": []},
+                },
+            },
+            id="basic-exception-with-bad-json-string",
+        ),
+    ]
+
+    @pytest.mark.parametrize("param", params)
+    def test_make_response_error(self, param):
+        actual = helpers.make_response_error(
+            param["errmsg"], param["in_httpcode"], param["details"]
+        )
+        assert actual["message"] == param["expected"]["message"]
+        assert actual["httpcode"] == param["expected"]["httpcode"]
+        assert actual["detail"] == param["expected"]["detail"]


### PR DESCRIPTION
Signed-off-by: Samuel Dacanay <sam.dacanay@anchore.com>

<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**: Adds some unit test coverage for a highly used method in the engine project


**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #:

**Special notes**:


