### PR TITLE
Support for Rocky Linux distro

### DIFF
--- a/anchore_engine/services/policy_engine/__init__.py
+++ b/anchore_engine/services/policy_engine/__init__.py
@@ -137,6 +137,7 @@ def _init_distro_mappings():
         DistroMapping(
             from_distro="sles", to_distro="sles", flavor="RHEL"
         ),  # RHEL since it uses RPMs for version checks
+        DistroMapping(from_distro="rocky", to_distro="rhel", flavor="RHEL"),
     ]
 
     # set up any data necessary at system init

--- a/anchore_engine/services/policy_engine/engine/vulns/mappers.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/mappers.py
@@ -694,6 +694,9 @@ ENGINE_DISTRO_MAPPERS = {
     "windows": DistroMapper(
         engine_distro="windows", grype_os="windows", grype_like_os=""
     ),
+    "rocky": DistroMapper(
+        engine_distro="rocky", grype_os="rockylinux", grype_like_os="fedora"
+    ),
 }
 
 

--- a/tests/integration/services/policy_engine/db/test_distro_mapping.py
+++ b/tests/integration/services/policy_engine/db/test_distro_mapping.py
@@ -75,5 +75,10 @@ def test_distro_from(anchore_db):
         logger.info("Distros for magaiea 5 (fedora, mandriva) = {}".format(distros))
         assert distros is not None
         assert len(distros) == 1
+
+        distros = DistroMapping.distros_for("rocky", "8", "rhel")
+        logger.info("Distros for rocky 8 (rhel) = {}".format(distros))
+        assert distros is not None
+        assert len(distros) == 1
     finally:
         session.commit()

--- a/tests/integration/services/policy_engine/test_namespaces.py
+++ b/tests/integration/services/policy_engine/test_namespaces.py
@@ -231,8 +231,12 @@ def test_distromappings(initialized_mappings):
     assert c7.like_namespace_names == ["rhel:7"]
 
     r7 = DistroNamespace(name="rhel", version="7", like_distro="rhel")
-    assert set(r7.mapped_names()) == {"centos", "fedora", "rhel", "redhat"}
+    assert set(r7.mapped_names()) == {"centos", "fedora", "rhel", "redhat", "rocky"}
     assert r7.like_namespace_names == ["rhel:7"]
+
+    rocky7 = DistroNamespace(name="rocky", version="7", like_distro="rhel")
+    assert rocky7.mapped_names() == []
+    assert rocky7.like_namespace_names == ["rhel:7"]
 
     assert sorted(DistroMapping.distros_mapped_to("rhel", "7")) == sorted(
         [
@@ -240,6 +244,7 @@ def test_distromappings(initialized_mappings):
             DistroTuple("rhel", "7", "RHEL"),
             DistroTuple("centos", "7", "RHEL"),
             DistroTuple("fedora", "7", "RHEL"),
+            DistroTuple("rocky", "7", "RHEL"),
         ]
     )
 
@@ -250,4 +255,7 @@ def test_mapped_distros(initialized_mappings):
     ]
     assert DistroMapping.distros_for("centos", "6", "centos") == [
         DistroTuple("rhel", "6", "RHEL")
+    ]
+    assert DistroMapping.distros_for("rocky", "8", "rhel") == [
+        DistroTuple("rhel", "8", "RHEL")
     ]

--- a/tests/integration/services/policy_engine/utils.py
+++ b/tests/integration/services/policy_engine/utils.py
@@ -41,6 +41,7 @@ def init_distro_mappings():
         DistroMapping(from_distro="ol", to_distro="ol", flavor="RHEL"),
         DistroMapping(from_distro="rhel", to_distro="centos", flavor="RHEL"),
         DistroMapping(from_distro="ubuntu", to_distro="ubuntu", flavor="DEB"),
+        DistroMapping(from_distro="rocky", to_distro="rhel", flavor="RHEL"),
     ]
 
     # set up any data necessary at system init

--- a/tests/unit/anchore_engine/services/policy_engine/engine/vulns/test_mappers.py
+++ b/tests/unit/anchore_engine/services/policy_engine/engine/vulns/test_mappers.py
@@ -23,6 +23,7 @@ from anchore_engine.services.policy_engine.engine.vulns.mappers import (
         pytest.param("alpine", "alpine", "alpine", id="alpine"),
         pytest.param("sles", "sles", "sles", id="sles"),
         pytest.param("windows", "windows", "", id="windows"),
+        pytest.param("rocky", "rockylinux", "fedora", id="rocky"),
     ],
 )
 def test_engine_distro_mappers(test_distro, expected_os, expected_like_os):


### PR DESCRIPTION
This PR adds mappings to recognize Rocky Linux distro for both grype and legacy vulnerabilities provider