### PR TITLE
Add Fix for `get_input_string` when a Regsitry is Specified with a Port

### DIFF
--- a/anchore_engine/services/catalog/catalog_impl.py
+++ b/anchore_engine/services/catalog/catalog_impl.py
@@ -1870,7 +1870,9 @@ def get_input_string(image_key: ImageKey) -> str:
         if image_key.digest == "unknown":
             return image_key.tag
         else:
-            return "{}@{}".format(image_key.tag.split(":")[0], image_key.digest)
+            return "{}@{}".format(
+                image_key.tag.rsplit(":", maxsplit=1)[0], image_key.digest
+            )
     else:
         return image_key.tag
 

--- a/tests/unit/anchore_engine/services/catalog/test_catalog_impl.py
+++ b/tests/unit/anchore_engine/services/catalog/test_catalog_impl.py
@@ -392,10 +392,10 @@ class TestImageAddWorkflow:
             pytest.param(
                 {
                     "image_key": catalog_impl.ImageKey(
-                        tag="my.private.registry:5000/anchore/python:3.9.8",
-                        digest="sha256:deadbeef8675309e9"
+                        tag="nexus.aveng.me:5000/beats/filebeat:3.9.8",
+                        digest="sha256:1b5677e1cc3ad16dd700a1d61e488ffdc5",
                     ),
-                    "expected": "nexus.aveng.me:5000/beats/filebeat@sha256:1b5677e1cc3ad16dd700a1d61e488ffdc5"
+                    "expected": "nexus.aveng.me:5000/beats/filebeat@sha256:1b5677e1cc3ad16dd700a1d61e488ffdc5",
                 },
                 id="registry-with-port-number",
             ),

--- a/tests/unit/anchore_engine/services/catalog/test_catalog_impl.py
+++ b/tests/unit/anchore_engine/services/catalog/test_catalog_impl.py
@@ -389,6 +389,16 @@ class TestImageAddWorkflow:
                 },
                 id="valid-digest-valid-tag",
             ),
+            pytest.param(
+                {
+                    "image_key": catalog_impl.ImageKey(
+                        tag="my.private.registry:5000/anchore/python:3.9.8",
+                        digest="sha256:deadbeef8675309e9"
+                    ),
+                    "expected": "nexus.aveng.me:5000/beats/filebeat@sha256:1b5677e1cc3ad16dd700a1d61e488ffdc5"
+                },
+                id="registry-with-port-number",
+            ),
         ],
     )
     def test_get_input_string(self, param):


### PR DESCRIPTION
Previously, we would make the improper assumption in the `get_input_string` function within `catalog_impl.py` that the `split()` function on the image_key's tag field would always return two items: the registry and image name and then the tag for the image. However when a port number was explicitly used in the registry, this caused the
`split()` function to return three things: the registry name, port number and image name, and then the image tag.

This fix changes the `split()` function to `rsplit()` and will only split the string once, ensuring that the first item is always the registry (with port if specified) and image name, and the second is the tag for the image.

New unit test parameters were added to `test_get_input_string` to ensure that the updated function still works as intended and that the observed bad behavior has been fixed.

Signed-off-by: Dustin Schoenbrun <dustin.schoenbrun@anchore.com>

