### PR TITLE
Add Almalinux OS support

### DIFF
--- a/anchore_engine/services/policy_engine/__init__.py
+++ b/anchore_engine/services/policy_engine/__init__.py
@@ -138,6 +138,7 @@ def _init_distro_mappings():
             from_distro="sles", to_distro="sles", flavor="RHEL"
         ),  # RHEL since it uses RPMs for version checks
         DistroMapping(from_distro="rocky", to_distro="rhel", flavor="RHEL"),
+        DistroMapping(from_distro="almalinux", to_distro="rhel", flavor="RHEL"),
     ]
 
     # set up any data necessary at system init

--- a/anchore_engine/services/policy_engine/engine/vulns/mappers.py
+++ b/anchore_engine/services/policy_engine/engine/vulns/mappers.py
@@ -698,6 +698,9 @@ ENGINE_DISTRO_MAPPERS = {
     "rocky": DistroMapper(
         engine_distro="rocky", grype_os="rockylinux", grype_like_os="fedora"
     ),
+    "almalinux": DistroMapper(
+        engine_distro="almalinux", grype_os="almalinux", grype_like_os="fedora"
+    ),
 }
 
 

--- a/tests/integration/services/policy_engine/db/test_distro_mapping.py
+++ b/tests/integration/services/policy_engine/db/test_distro_mapping.py
@@ -80,5 +80,10 @@ def test_distro_from(anchore_db):
         logger.info("Distros for rocky 8 (rhel) = {}".format(distros))
         assert distros is not None
         assert len(distros) == 1
+        
+        distros = DistroMapping.distros_for("almalinux", "8", "rhel")
+        logger.info("Distros for almalinux 8 (rhel) = {}".format(distros))
+        assert distros is not None
+        assert len(distros) == 1
     finally:
         session.commit()

--- a/tests/integration/services/policy_engine/test_namespaces.py
+++ b/tests/integration/services/policy_engine/test_namespaces.py
@@ -231,13 +231,17 @@ def test_distromappings(initialized_mappings):
     assert c7.like_namespace_names == ["rhel:7"]
 
     r7 = DistroNamespace(name="rhel", version="7", like_distro="rhel")
-    assert set(r7.mapped_names()) == {"centos", "fedora", "rhel", "redhat", "rocky"}
+    assert set(r7.mapped_names()) == {"centos", "fedora", "rhel", "redhat", "rocky", "almalinux"}
     assert r7.like_namespace_names == ["rhel:7"]
 
     rocky7 = DistroNamespace(name="rocky", version="7", like_distro="rhel")
     assert rocky7.mapped_names() == []
     assert rocky7.like_namespace_names == ["rhel:7"]
 
+    almalinux7 = DistroNamespace(name="almalinux", version="7", like_distro="rhel")
+    assert almalinux7.mapped_names() == []
+    assert almalinux7.like_namespace_names == ["rhel:7"]
+    
     assert sorted(DistroMapping.distros_mapped_to("rhel", "7")) == sorted(
         [
             DistroTuple("redhat", "7", "RHEL"),
@@ -245,6 +249,7 @@ def test_distromappings(initialized_mappings):
             DistroTuple("centos", "7", "RHEL"),
             DistroTuple("fedora", "7", "RHEL"),
             DistroTuple("rocky", "7", "RHEL"),
+            DistroTuple("almalinux", "7", "RHEL"),
         ]
     )
 
@@ -259,3 +264,6 @@ def test_mapped_distros(initialized_mappings):
     assert DistroMapping.distros_for("rocky", "8", "rhel") == [
         DistroTuple("rhel", "8", "RHEL")
     ]
+    assert DistroMapping.distros_for("almalinux", "8", "rhel") == [
+        DistroTuple("rhel", "8", "RHEL")
+    ]    

--- a/tests/integration/services/policy_engine/utils.py
+++ b/tests/integration/services/policy_engine/utils.py
@@ -42,6 +42,7 @@ def init_distro_mappings():
         DistroMapping(from_distro="rhel", to_distro="centos", flavor="RHEL"),
         DistroMapping(from_distro="ubuntu", to_distro="ubuntu", flavor="DEB"),
         DistroMapping(from_distro="rocky", to_distro="rhel", flavor="RHEL"),
+        DistroMapping(from_distro="almalinux", to_distro="rhel", flavor="RHEL"),
     ]
 
     # set up any data necessary at system init

--- a/tests/unit/anchore_engine/services/policy_engine/engine/vulns/test_mappers.py
+++ b/tests/unit/anchore_engine/services/policy_engine/engine/vulns/test_mappers.py
@@ -24,6 +24,7 @@ from anchore_engine.services.policy_engine.engine.vulns.mappers import (
         pytest.param("sles", "sles", "sles", id="sles"),
         pytest.param("windows", "windows", "", id="windows"),
         pytest.param("rocky", "rockylinux", "fedora", id="rocky"),
+        pytest.param("almalinux", "almalinux", "fedora", id="almalinux"),
     ],
 )
 def test_engine_distro_mappers(test_distro, expected_os, expected_like_os):


### PR DESCRIPTION
Followed the changes of https://github.com/anchore/anchore-engine/pull/1315 to provide support for AlmaLinux, resolves #412, in reference to #1299

* Update __init__.py
* Update mappers.py
* Update test_namespaces.py
* Update utils.py
* Update test_distro_mapping.py
* Update test_mappers.py

This PR has dependent PRs in other repos to fulfill 
https://github.com/anchore/syft/pull/652
https://github.com/anchore/grype/pull/514
https://github.com/anchore/grype-db/pull/40