### PR TITLE
Add unit test for taskstate methods

### DIFF
--- a/anchore_engine/subsys/taskstate.py
+++ b/anchore_engine/subsys/taskstate.py
@@ -95,7 +95,7 @@ def working_state(state_type):
 
 def next_state(state_type, current_state):
     if not current_state:
-        return state_graphs[state_type]["transisitions"]["init"]
+        return state_graphs[state_type]["transitions"]["init"]
 
     return state_graphs[state_type]["transitions"][current_state]
 

--- a/tests/unit/anchore_engine/subsys/test_taskstate.py
+++ b/tests/unit/anchore_engine/subsys/test_taskstate.py
@@ -1,0 +1,182 @@
+import pytest
+
+from anchore_engine.subsys.taskstate import (
+    state_graphs,
+    init_state,
+    reset_state,
+    base_state,
+    fault_state,
+    queued_state,
+    working_state,
+    next_state,
+    complete_state,
+    orphaned_state,
+)
+
+
+@pytest.mark.parametrize(
+    "param",
+    [
+        pytest.param(
+            {
+                "state_type": "analyze",
+                "current_state": None,
+                "reset": False,
+                "expected": state_graphs["analyze"]["base_state"],
+            },
+            id="basic-no-current-state",
+        ),
+        pytest.param(
+            {
+                "state_type": "analyze",
+                "current_state": "somerandomstate",
+                "reset": False,
+                "expected": "somerandomstate",
+            },
+            id="basic-with-current-state",
+        ),
+        pytest.param(
+            {
+                "state_type": "analyze",
+                "current_state": "somerandomstate",
+                "reset": True,
+                "expected": state_graphs["analyze"]["base_state"],
+            },
+            id="basic-reset",
+        ),
+    ],
+)
+def test_init_state(param):
+    actual_state = init_state(
+        param["state_type"], param["current_state"], param["reset"]
+    )
+    assert actual_state == param["expected"]
+
+
+@pytest.mark.parametrize(
+    "state_type",
+    [
+        "analyze",
+        "policy_evaluate",
+        "image_status",
+        "service_status",
+        "policy_engine_state",
+    ],
+)
+def test_reset_state(state_type):
+    assert reset_state(state_type) == state_graphs[state_type]["base_state"]
+
+
+@pytest.mark.parametrize(
+    "state_type",
+    [
+        "analyze",
+        "policy_evaluate",
+        "image_status",
+        "service_status",
+        "policy_engine_state",
+    ],
+)
+def test_base_state(state_type):
+    assert base_state(state_type) == state_graphs[state_type]["base_state"]
+
+
+@pytest.mark.parametrize(
+    "state_type",
+    [
+        "analyze",
+        "policy_evaluate",
+        "image_status",
+        "service_status",
+        "policy_engine_state",
+    ],
+)
+def test_fault_state(state_type):
+    assert fault_state(state_type) == state_graphs[state_type]["fault_state"]
+
+
+@pytest.mark.parametrize(
+    "state_type",
+    [
+        "analyze",
+        "policy_evaluate",
+        "image_status",
+        "service_status",
+        "policy_engine_state",
+    ],
+)
+def test_queued_state(state_type):
+    assert queued_state(state_type) == state_graphs[state_type]["queued_state"]
+
+
+@pytest.mark.parametrize(
+    "state_type",
+    [
+        "analyze",
+        "policy_evaluate",
+        "image_status",
+        "service_status",
+        "policy_engine_state",
+    ],
+)
+def test_working_state(state_type):
+    assert working_state(state_type) == state_graphs[state_type]["working_state"]
+
+
+@pytest.mark.parametrize(
+    "state_type,current",
+    [
+        ("analyze", ""),
+        ("analyze", "not_analyzed"),
+        ("policy_evaluate", ""),
+        ("policy_evaluate", "evaluation_queued"),
+        ("image_status", ""),
+        ("image_status", "deleting"),
+        ("service_status", ""),
+        ("service_status", "registered"),
+        ("policy_engine_state", ""),
+        ("policy_engine_state", "syncing"),
+    ],
+)
+def test_next_state(state_type, current):
+    if not current:
+        assert (
+            next_state(state_type, current)
+            == state_graphs[state_type]["transitions"]["init"]
+        )
+    else:
+        assert (
+            next_state(state_type, current)
+            == state_graphs[state_type]["transitions"][current]
+        )
+
+
+@pytest.mark.parametrize(
+    "state_type",
+    [
+        "analyze",
+        "policy_evaluate",
+        "image_status",
+        "service_status",
+        "policy_engine_state",
+    ],
+)
+def test_complete_state(state_type):
+    assert complete_state(state_type) == state_graphs[state_type]["complete_state"]
+
+
+@pytest.mark.parametrize(
+    "state_type",
+    [
+        "analyze",
+        "policy_evaluate",
+        "image_status",
+        "service_status",
+        "policy_engine_state",
+    ],
+)
+def test_orphaned_state(state_type):
+    if "orphaned_state" in state_graphs[state_type]:
+        assert orphaned_state(state_type) == state_graphs[state_type]["orphaned_state"]
+    else:
+        assert orphaned_state(state_type) == state_graphs[state_type]["fault_state"]


### PR DESCRIPTION
Signed-off-by: Samuel Dacanay <sam.dacanay@anchore.com>

<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**: Adds a unit test for a previously untested part of anchore engine that is called numerous times across the repo

**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #:

**Special notes**: There was actually a bug in the **next_state** method regarding a typo. This fix may have downstream consequences and may require further investigation

