### PR TITLE
Adds save and retrieve image sboms

### DIFF
--- a/anchore_engine/analyzers/syft/__init__.py
+++ b/anchore_engine/analyzers/syft/__init__.py
@@ -1,90 +1,25 @@
-import collections
+import typing
 
 from anchore_engine.analyzers.syft.handlers import (
     modules_by_artifact_type,
     modules_by_engine_type,
 )
-from anchore_engine.analyzers.utils import defaultdict_to_dict, dig
 from anchore_engine.clients.syft_wrapper import run_syft
-from anchore_engine.subsys import logger
+
+from .adapters import FilteringEngineAdapter
 
 
-def filter_relationships(relationships, **kwargs):
-    def filter_fn(relationship):
-        for key, expected in kwargs.items():
-            if relationship[key] != expected:
-                return False
-        return True
-
-    return [r for r in relationships if filter_fn(r)]
-
-
-def filter_artifacts(artifacts, relationships):
-    def filter_fn(artifact):
-        # some packages are owned by other packages (e.g. a python package that was installed
-        # from an RPM instead of with pip), filter out any packages that are not "root" packages.
-        if filter_relationships(
-            relationships, child=dig(artifact, "id"), type="ownership-by-file-overlap"
-        ):
-            return False
-
-        return True
-
-    return [a for a in artifacts if filter_fn(a)]
-
-
-def catalog_image(unpackdir, imagedir, package_filtering_enabled=True):
+def catalog_image(
+    tmp_dir: str, image_oci_dir: str, package_filtering_enabled=True
+) -> typing.Tuple[dict, dict]:
     """
-    Catalog the given image with syft, keeping only select artifacts in the returned results.
+    Catalog the given image with syft, keeping only select artifacts in the returned results
+
+    :param tmp_dir: path to directory where the image data resides
+    :param image_oci_dir: path to the directory for temp file construction
+    :return: tuple of engine formatted result and raw syft output to allow it to be used downstream if needed
     """
-    all_results = run_syft(unpackdir, imagedir)
-    return convert_syft_to_engine(all_results, package_filtering_enabled)
-
-
-def convert_syft_to_engine(all_results, enable_package_filtering=True):
-    """
-    Do the conversion from syft format to engine format
-
-    :param all_results:
-    :return:
-    """
-
-    # transform output into analyzer-module/service "raw" analyzer json document
-    nested_dict = lambda: collections.defaultdict(nested_dict)
-    findings = nested_dict()
-
-    # This is the only use case for consuming the top-level results from syft,
-    # capturing the information needed for BusyBox. No artifacts should be
-    # expected, and having outside of the artifacts loop ensure this will only
-    # get called once.
-    distro = all_results.get("distro")
-    if distro and distro.get("name", "").lower() == "busybox":
-        findings["package_list"]["pkgs.all"]["base"]["BusyBox"] = distro["version"]
-    elif not distro or not distro.get("name"):
-        findings["package_list"]["pkgs.all"]["base"]["Unknown"] = "0"
-
-    # take a sub-set of the syft findings and invoke the handler function to
-    # craft the artifact document and inject into the "raw" analyzer json
-    # document
-    if enable_package_filtering:
-        logger.info("filtering owned packages")
-        artifacts = filter_artifacts(
-            all_results["artifacts"],
-            dig(all_results, "artifactRelationships", force_default=[]),
-        )
-    else:
-        artifacts = all_results["artifacts"]
-    for artifact in artifacts:
-        # syft may do more work than what is supported in engine, ensure we only include artifacts
-        # of select package types.
-        if artifact["type"] not in modules_by_artifact_type:
-            logger.warn(
-                "Handler for artifact type {} not available. Skipping package {}.".format(
-                    artifact["type"], artifact["name"]
-                )
-            )
-            continue
-        handler = modules_by_artifact_type[artifact["type"]]
-        handler.translate_and_save_entry(findings, artifact)
-
-    return defaultdict_to_dict(findings)
+    syft_analysis = run_syft(tmp_dir_path=tmp_dir, oci_image_dir_path=image_oci_dir)
+    output_adapter = FilteringEngineAdapter(syft_analysis, package_filtering_enabled)
+    converted_output = output_adapter.convert()
+    return converted_output, syft_analysis

--- a/anchore_engine/analyzers/syft/__init__.py
+++ b/anchore_engine/analyzers/syft/__init__.py
@@ -1,12 +1,11 @@
 import typing
 
+from anchore_engine.analyzers.syft.adapters import FilteringEngineAdapter
 from anchore_engine.analyzers.syft.handlers import (
     modules_by_artifact_type,
     modules_by_engine_type,
 )
 from anchore_engine.clients.syft_wrapper import run_syft
-
-from .adapters import FilteringEngineAdapter
 
 
 def catalog_image(

--- a/anchore_engine/analyzers/syft/adapters.py
+++ b/anchore_engine/analyzers/syft/adapters.py
@@ -3,10 +3,9 @@ Module for adapters that convert syft to other formats
 """
 import collections
 
+from anchore_engine.analyzers.syft.handlers import modules_by_artifact_type
 from anchore_engine.analyzers.utils import defaultdict_to_dict, dig
 from anchore_engine.subsys import logger
-
-from .handlers import modules_by_artifact_type
 
 
 class IdentityAdapter:

--- a/anchore_engine/analyzers/syft/adapters.py
+++ b/anchore_engine/analyzers/syft/adapters.py
@@ -1,0 +1,122 @@
+"""
+Module for adapters that convert syft to other formats
+"""
+import collections
+
+from anchore_engine.analyzers.utils import defaultdict_to_dict, dig
+from anchore_engine.subsys import logger
+
+from .handlers import modules_by_artifact_type
+
+
+class IdentityAdapter:
+    """
+    Simple identity adapter for syft output that defines the interface.
+
+    This implementation maps syft output to itself.
+
+    """
+
+    def __init__(self, syft_output: dict):
+        self.syft_output = syft_output
+
+    def convert(self) -> dict:
+        return self.syft_output
+
+
+def _filter_relationships(relationships, **kwargs):
+    def filter_fn(relationship):
+        for key, expected in kwargs.items():
+            if relationship[key] != expected:
+                return False
+        return True
+
+    return [r for r in relationships if filter_fn(r)]
+
+
+def _filter_artifacts(artifacts, relationships):
+    """
+    Remove artifacts from the main list if they are a child package of another package.
+    Package A is a child of Package B if all of Package A's files are managed by Package B per its file manifest.
+
+    The most common examples are python packages that are installed via dpkg or rpms.
+
+    :param artifacts:
+    :param relationships:
+    :return:
+    """
+
+    def filter_fn(artifact):
+        # some packages are owned by other packages (e.g. a python package that was installed
+        # from an RPM instead of with pip), filter out any packages that are not "root" packages.
+        if _filter_relationships(
+            relationships, child=dig(artifact, "id"), type="ownership-by-file-overlap"
+        ):
+            return False
+
+        return True
+
+    return [a for a in artifacts if filter_fn(a)]
+
+
+def _convert_syft_to_engine(syft_output: dict, enable_package_filtering: bool) -> dict:
+    """
+    Do the conversion from syft format to engine format
+
+    :param syft_output: raw syft analysis output as a dict
+    :param enable_package_filtering: flag to indicate if packages in a child relationship with parent package should be filtered or not from final result
+    :return: dict in the engine internal analysis report format generated from the syft output
+    """
+
+    # transform output into analyzer-module/service "raw" analyzer json document
+    nested_dict = lambda: collections.defaultdict(nested_dict)
+    findings = nested_dict()
+
+    # This is the only use case for consuming the top-level results from syft,
+    # capturing the information needed for BusyBox. No artifacts should be
+    # expected, and having outside of the artifacts loop ensure this will only
+    # get called once.
+    distro = syft_output.get("distro")
+    if distro and distro.get("name", "").lower() == "busybox":
+        findings["package_list"]["pkgs.all"]["base"]["BusyBox"] = distro["version"]
+    elif not distro or not distro.get("name"):
+        findings["package_list"]["pkgs.all"]["base"]["Unknown"] = "0"
+
+    # take a sub-set of the syft findings and invoke the handler function to
+    # craft the artifact document and inject into the "raw" analyzer json
+    # document
+    if enable_package_filtering:
+        logger.info("filtering owned packages")
+        artifacts = _filter_artifacts(
+            syft_output["artifacts"],
+            dig(syft_output, "artifactRelationships", force_default=[]),
+        )
+    else:
+        artifacts = syft_output["artifacts"]
+    for artifact in artifacts:
+        # syft may do more work than what is supported in engine, ensure we only include artifacts
+        # of select package types.
+        if artifact["type"] not in modules_by_artifact_type:
+            logger.warn(
+                "Handler for artifact type {} not available. Skipping package {}.".format(
+                    artifact["type"], artifact["name"]
+                )
+            )
+            continue
+        handler = modules_by_artifact_type[artifact["type"]]
+        handler.translate_and_save_entry(findings, artifact)
+
+    return defaultdict_to_dict(findings)
+
+
+class FilteringEngineAdapter(IdentityAdapter):
+    """
+    Adapts syft output to Engine native analysis format
+    """
+
+    def __init__(self, syft_output: dict, enable_package_filtering: bool = True):
+        super().__init__(syft_output)
+        self.enable_package_filtering = enable_package_filtering
+
+    def convert(self):
+        return _convert_syft_to_engine(self.syft_output, self.enable_package_filtering)

--- a/anchore_engine/clients/syft_wrapper.py
+++ b/anchore_engine/clients/syft_wrapper.py
@@ -5,18 +5,25 @@ import shlex
 from anchore_engine.utils import run_check
 
 
-def run_syft(unpackdir, image):
+def run_syft(tmp_dir_path: str, oci_image_dir_path: str):
+    """
+    Execute syft on the specified image reference
+
+    :param tmp_dir_path: path for tmp usage
+    :param oci_image_dir_path: path to the local oci-dir holding the image data to analyze
+    :return: json result of syft execution on the referenced image
+    """
     proc_env = os.environ.copy()
 
     syft_env = {
         "SYFT_CHECK_FOR_APP_UPDATE": "0",
         "SYFT_LOG_STRUCTURED": "1",
-        "TMPDIR": unpackdir,
+        "TMPDIR": tmp_dir_path,
     }
 
     proc_env.update(syft_env)
 
-    cmd = "syft -vv -o json oci-dir:{image}".format(image=image)
+    cmd = "syft -vv -o json oci-dir:{image}".format(image=oci_image_dir_path)
 
     stdout, _ = run_check(shlex.split(cmd), env=proc_env, log_level="spew")
 

--- a/anchore_engine/services/analyzer/api/controllers/default_controller.py
+++ b/anchore_engine/services/analyzer/api/controllers/default_controller.py
@@ -1,14 +1,5 @@
-import connexion
-
-import anchore_engine.apis
-import anchore_engine.clients.services.catalog
-import anchore_engine.common
-import anchore_engine.common.images
-import anchore_engine.configuration.localconfig
-import anchore_engine.services.analyzer.analysis
-import anchore_engine.subsys.servicestatus
+from anchore_engine.subsys import servicestatus
 from anchore_engine.apis.authorization import INTERNAL_SERVICE_ALLOWED, get_authorizer
-from anchore_engine.subsys import logger
 
 authorizer = get_authorizer()
 
@@ -17,106 +8,10 @@ authorizer = get_authorizer()
 def status():
     httpcode = 500
     try:
-        service_record = anchore_engine.subsys.servicestatus.get_my_service_record()
-        return_object = anchore_engine.subsys.servicestatus.get_status(service_record)
+        service_record = servicestatus.get_my_service_record()
+        return_object = servicestatus.get_status(service_record)
         httpcode = 200
     except Exception as err:
         return_object = str(err)
 
     return return_object, httpcode
-
-
-@authorizer.requires_account(with_types=INTERNAL_SERVICE_ALLOWED)
-def interactive_analyze(bodycontent):
-
-    try:
-        return_object = {}
-        httpcode = 500
-
-        request_inputs = anchore_engine.apis.do_request_prep(
-            connexion.request, default_params={}
-        )
-
-        user_auth = request_inputs["auth"]
-        method = request_inputs["method"]
-        # bodycontent = request_inputs['bodycontent']
-        params = request_inputs["params"]
-        userId = request_inputs["userId"]
-
-        try:
-            # input prep
-            # jsondata = json.loads(bodycontent)
-            jsondata = bodycontent
-            tag = jsondata.pop("tag", None)
-            if not tag:
-                httpcode = 500
-                raise Exception("must supply a valid tag param in json body")
-
-            try:
-                # image prep
-                registry_creds = anchore_engine.clients.services.catalog.get_registry(
-                    user_auth
-                )
-                image_info = anchore_engine.common.images.get_image_info(
-                    userId,
-                    "docker",
-                    tag,
-                    registry_lookup=True,
-                    registry_creds=registry_creds,
-                )
-                pullstring = (
-                    image_info["registry"]
-                    + "/"
-                    + image_info["repo"]
-                    + "@"
-                    + image_info["digest"]
-                )
-                fulltag = (
-                    image_info["registry"]
-                    + "/"
-                    + image_info["repo"]
-                    + ":"
-                    + image_info["tag"]
-                )
-                new_image_record = anchore_engine.common.images.make_image_record(
-                    userId,
-                    "docker",
-                    fulltag,
-                    registry_lookup=False,
-                    registry_creds=(None, None),
-                )
-                image_detail = new_image_record["image_detail"][0]
-                if not image_detail:
-                    raise Exception("no image found matching input")
-
-            except Exception as err:
-                httpcode = 404
-                raise Exception(str(err))
-
-            (
-                image_data,
-                query_data,
-            ) = anchore_engine.services.analyzer.analysis.perform_analyze(
-                userId, pullstring, fulltag, image_detail, registry_creds
-            )
-            (
-                image_data,
-                query_data,
-            ) = anchore_engine.services.analyzer.analysis.perform_analyze(
-                userId, pullstring, fulltag, image_detail, registry_creds
-            )
-            if image_data:
-                return_object = image_data
-                httpcode = 200
-            else:
-                httpcode = 500
-                raise Exception("analyze resulted in empty analysis data")
-        except Exception as err:
-            logger.error(str(err))
-            raise err
-    except Exception as err:
-        logger.error(str(err))
-        return_object = str(err)
-
-    return return_object, httpcode
-    # return(json.dumps(return_object, indent=4)+"\n", httpcode)

--- a/anchore_engine/services/analyzer/api/controllers/default_controller.py
+++ b/anchore_engine/services/analyzer/api/controllers/default_controller.py
@@ -1,5 +1,5 @@
-from anchore_engine.subsys import servicestatus
 from anchore_engine.apis.authorization import INTERNAL_SERVICE_ALLOWED, get_authorizer
+from anchore_engine.subsys import servicestatus
 
 authorizer = get_authorizer()
 

--- a/anchore_engine/services/analyzer/swagger/swagger.yaml
+++ b/anchore_engine/services/analyzer/swagger/swagger.yaml
@@ -62,28 +62,6 @@ paths:
           schema:
             type: object
       x-swagger-router-controller: "anchore_engine.services.analyzer.api.controllers.default_controller"
-  /analyze:
-    get:
-      tags:
-      - "analyzer"
-      summary: "Perform DB side-effect free interactive analysis"
-      description: ""
-      operationId: "interactive_analyze"
-      parameters:
-      - name: 'bodycontent'
-        in: body
-        schema:
-          type: object
-        description: "object describing image to analyze"
-        required: true
-      produces:
-      - "application/json"
-      responses:
-        200:
-          description: "success"
-          schema:
-            type: object
-      x-swagger-router-controller: "anchore_engine.services.analyzer.api.controllers.default_controller"
 definitions:
   ServiceVersion:
     type: object

--- a/anchore_engine/services/apiext/api/controllers/images.py
+++ b/anchore_engine/services/apiext/api/controllers/images.py
@@ -1,9 +1,11 @@
 import datetime
+import gzip
 import io
 import json
 import re
 import tarfile
 
+import flask
 from connexion import request
 
 import anchore_engine.apis
@@ -33,6 +35,7 @@ from anchore_engine.services.apiext.api.controllers.utils import (  # make_respo
 from anchore_engine.subsys import logger, taskstate
 from anchore_engine.subsys.metrics import flask_metrics
 from anchore_engine.util.docker import parse_dockerimage_string
+from anchore_engine.utils import ensure_bytes
 
 authorizer = get_authorizer()
 
@@ -1570,3 +1573,42 @@ def list_secret_search_results(imageDigest):
         raise
     except Exception as err:
         raise api_exceptions.InternalError(str(err), detail={})
+
+
+@authorizer.requires([ActionBoundPermission(domain=RequestingAccountValue())])
+def get_image_sbom_native(imageDigest: str):
+    """
+    GET /images/{digest}/sboms/native
+
+    :param imageDigest:
+    :return: A native anchore (syft) formatted sbom for the image
+    """
+
+    account = ApiRequestContextProxy.namespace()
+    try:
+        _get_image_ok(account, imageDigest)
+
+        client = internal_client_for(CatalogClient, account)
+        resp = client.get_document("syft_sbom", imageDigest)
+
+        # Do
+        compressed_bytes = json_content_gzipper(resp)
+        resp = flask.Response(
+            content_type="application/gzip", status=200, response=compressed_bytes
+        )
+        return resp
+    except api_exceptions.AnchoreApiError:
+        raise
+    except Exception as err:
+        raise api_exceptions.InternalError(str(err), detail={})
+
+
+def json_content_gzipper(content_json):
+    """
+    Returns gzipped bytes of content json
+
+    :param content_json:
+    :return:
+    """
+    compressed_json = gzip.compress(ensure_bytes(json.dumps(content_json, indent=0)))
+    return compressed_json

--- a/anchore_engine/services/apiext/api/controllers/images.py
+++ b/anchore_engine/services/apiext/api/controllers/images.py
@@ -1596,6 +1596,11 @@ def get_image_sbom_native(imageDigest: str):
         resp = flask.Response(
             content_type="application/gzip", status=200, response=compressed_bytes
         )
+        resp.headers.set(
+            "Content-Disposition",
+            "attachment",
+            filename="%s_%s.json.gzip" % (imageDigest, "native"),
+        )
         return resp
     except api_exceptions.AnchoreApiError:
         raise

--- a/anchore_engine/services/apiext/swagger/swagger.yaml
+++ b/anchore_engine/services/apiext/swagger/swagger.yaml
@@ -1135,6 +1135,8 @@ paths:
       responses:
         200:
           description: Image lookup success
+          schema:
+            type: file
         500:
           description: Internal error
           schema:

--- a/anchore_engine/services/apiext/swagger/swagger.yaml
+++ b/anchore_engine/services/apiext/swagger/swagger.yaml
@@ -1116,6 +1116,30 @@ paths:
           description: Internal Error
           schema:
             $ref: "#/definitions/ApiErrorResponse"
+  /images/{imageDigest}/sboms/native:
+    get:
+      tags:
+        - Images
+      x-swagger-router-controller: anchore_engine.services.apiext.api.controllers.images
+      operationId: get_image_sbom_native
+      x-anchore-authz-action: getImage
+      summary: Get image sbom in the native Anchore format
+      produces:
+        - application/gzip
+      parameters:
+        - name: imageDigest
+          in: path
+          type: string
+          required: true
+        - $ref: "#/parameters/AsAccountParameter"
+      responses:
+        200:
+          description: Image lookup success
+        500:
+          description: Internal error
+          schema:
+            $ref: "#/definitions/ApiErrorResponse"
+
   /images/{imageDigest}/metadata/{mtype}:
     get:
       tags:
@@ -3551,6 +3575,9 @@ definitions:
           - analyzing
           - analyzed
           - analysis_failed
+      record_version:
+        type: string
+        description: The version of the record, used for internal schema updates and data migrations.
   AnchoreImageList:
     description: A list of Anchore Images
     type: array
@@ -5137,4 +5164,6 @@ definitions:
         additionalProperties: true
         type: object
     additionalProperties: true
+    type: object
+  NativeSbom:
     type: object

--- a/anchore_engine/services/apiext/swagger/swagger.yaml
+++ b/anchore_engine/services/apiext/swagger/swagger.yaml
@@ -4937,6 +4937,11 @@ definitions:
   ImageImportManifest:
     x-nullable: True
     type: object
+    required:
+      - tags
+      - contents
+      - digest
+      - operation_uuid
     properties:
       contents:
         $ref: "#/definitions/ImportContentDigests"

--- a/anchore_engine/services/catalog/archiver.py
+++ b/anchore_engine/services/catalog/archiver.py
@@ -9,6 +9,7 @@ import os
 import tarfile
 import tempfile
 import time
+import typing
 import uuid
 from threading import RLock
 
@@ -52,6 +53,18 @@ DRY_RUN_MODE = os.getenv(DRY_RUN_ENV_VAR, "false").lower() == "true"
 _add_event_fn = None
 
 event_init_lock = RLock()
+
+
+class ArchiveError(Exception):
+    ...
+
+
+class ArchiveRestorationError(Exception):
+    ...
+
+
+class RequiredArchiveArtifactNotFoundError(Exception):
+    ...
 
 
 def init_events(handler_fn=None):
@@ -1182,6 +1195,20 @@ class RestoreArchivedImageTaskFromArchiveTarfile(RestoreArchivedImageTask):
             )
 
 
+class ArtifactRequirement:
+    """ "
+    Describes the required status of the referenced artifact
+    """
+
+    def __init__(self, artifact: Artifact, required=True):
+        self.artifact = artifact
+        self._required = required
+
+    @property
+    def required(self):
+        return self._required
+
+
 class ArchiveImageTask(object):
     """
     An archive task that moves an image and artifacts from archiving state to archived state.
@@ -1206,30 +1233,50 @@ class ArchiveImageTask(object):
 
         self.manifest = None  # Manifest to be saved and accessible outside of the tarball/backing-store lifecycle
 
-        self.required_artifacts = [
-            Artifact(
-                name="analysis",
-                source=ObjectStoreLocation(
-                    bucket="analysis_data", key=self.image_digest
+        self.artifacts = [
+            ArtifactRequirement(
+                Artifact(
+                    name="analysis",
+                    source=ObjectStoreLocation(
+                        bucket="analysis_data", key=self.image_digest
+                    ),
+                    dest=None,
+                    metadata={},
                 ),
-                dest=None,
-                metadata={},
+                True,
             ),
-            Artifact(
-                name="image_content",
-                source=ObjectStoreLocation(
-                    bucket="image_content_data", key=self.image_digest
+            ArtifactRequirement(
+                Artifact(
+                    name="image_content",
+                    source=ObjectStoreLocation(
+                        bucket="image_content_data", key=self.image_digest
+                    ),
+                    dest=None,
+                    metadata={},
                 ),
-                dest=None,
-                metadata={},
+                True,
             ),
-            Artifact(
-                name="image_manifest",
-                source=ObjectStoreLocation(
-                    bucket="manifest_data", key=self.image_digest
+            ArtifactRequirement(
+                Artifact(
+                    name="image_manifest",
+                    source=ObjectStoreLocation(
+                        bucket="manifest_data", key=self.image_digest
+                    ),
+                    dest=None,
+                    metadata={},
                 ),
-                dest=None,
-                metadata={},
+                True,
+            ),
+            ArtifactRequirement(
+                Artifact(
+                    name="syft_sbom",
+                    source=ObjectStoreLocation(
+                        bucket="syft_sbom", key=self.image_digest
+                    ),
+                    dest=None,
+                    metadata={},
+                ),
+                False,
             ),
         ]
 
@@ -1342,9 +1389,7 @@ class ArchiveImageTask(object):
                             ),
                         }
 
-                        self.archive_required(
-                            src_obj_mgr, self.required_artifacts, img_archive
-                        )
+                        self.archive_objects(src_obj_mgr, self.artifacts, img_archive)
 
                         try:
                             vuln_artifacts = self.archive_vuln_history(img_archive)
@@ -1416,20 +1461,30 @@ class ArchiveImageTask(object):
                 )
                 return "error", str(ex)
 
-    def archive_required(
-        self, src_mgr: ObjectStorageManager, artifacts: list, img_archive: ImageArchive
+    def archive_objects(
+        self,
+        src_mgr: ObjectStorageManager,
+        artifact_requirements: typing.List[ArtifactRequirement],
+        img_archive: ImageArchive,
     ) -> list:
         """
 
         :return: tuple of (manifest (dict), bucket (str), key (str))
         """
-        for artifact in artifacts:
+        for requirement in artifact_requirements:
+            artifact = requirement.artifact
+
+            if not requirement.required and not src_mgr.exists(
+                self.account, artifact.source.bucket, artifact.source.key
+            ):
+                continue
+
             data = src_mgr.get(
                 self.account, artifact.source.bucket, artifact.source.key
             )
 
             if not data:
-                raise Exception(
+                raise RequiredArchiveArtifactNotFoundError(
                     "Required artifact not found for migration: {}".format(
                         artifact.name
                     )
@@ -1461,8 +1516,9 @@ class ArchiveImageTask(object):
 
         Policy evaluation histories are only moved, not generated, so online previously generated evaluations are migrated.
 
-        :param dest_archive_mgr:
-        :param dest_bucket:
+        :param session: active database session to use for db queries
+        :param img_archive: archive to write to
+        :param src_obj_mgr: object manager for object reads
         :return: dict mapping tags (full pull tags) to policy eval histories for the migrating image
         """
 

--- a/anchore_engine/services/catalog/archiver.py
+++ b/anchore_engine/services/catalog/archiver.py
@@ -1022,7 +1022,7 @@ class RestoreArchivedImageTask(object):
                 os.remove(tf.name)
 
         else:
-            raise Exception(
+            raise ArchiveRestorationError(
                 "No archive manifest found in archive record. Cannot restore"
             )
 
@@ -1035,7 +1035,7 @@ class RestoreArchivedImageTask(object):
         with session_scope() as session:
             img_record_str = manifest.metadata.get("image_record")
             if not img_record_str:
-                raise Exception("Cannot restore missing image record")
+                raise ArchiveRestorationError("Cannot restore missing image record")
             else:
                 img_record = json.loads(img_record_str)
 
@@ -1088,7 +1088,7 @@ class RestoreArchivedImageTask(object):
 
                 if not data:
                     logger.error("Could not get data for {}".format(artifact.name))
-                    raise Exception(
+                    raise ArchiveRestorationError(
                         "Archive data unavailable for {}".format(artifact.name)
                     )
 
@@ -1177,7 +1177,7 @@ class RestoreArchivedImageTaskFromArchiveTarfile(RestoreArchivedImageTask):
                 os.remove(tf.name)
 
         else:
-            raise Exception(
+            raise ArchiveRestorationError(
                 "No archive manifest found in archive record. Cannot restore"
             )
 
@@ -1259,7 +1259,7 @@ class ArchiveImageTask(object):
                 )
 
                 if not catalog_img_dict:
-                    raise Exception(
+                    raise ArchiveError(
                         "Could not locate an image with digest {} in account {}".format(
                             self.image_digest, self.account
                         )
@@ -1271,7 +1271,7 @@ class ArchiveImageTask(object):
                     catalog_img_dict.get("image_status") != "active"
                     or catalog_img_dict.get("analysis_status") != "analyzed"
                 ):
-                    raise Exception(
+                    raise ArchiveError(
                         'Invalid image record state. Image must have "analysis_status"="analyzed" and "image_status"="active". Found {} and {}'.format(
                             catalog_img_dict.get("analysis_status"),
                             catalog_img_dict.get("image_status"),
@@ -1315,7 +1315,7 @@ class ArchiveImageTask(object):
             record = db_archived_images.get(session, self.account, self.image_digest)
 
             if not record:
-                raise Exception("No analysis archive record found to track state")
+                raise ArchiveError("No analysis archive record found to track state")
 
             try:
                 with tempfile.TemporaryDirectory(
@@ -1380,7 +1380,7 @@ class ArchiveImageTask(object):
                         archiveId=archive_key,
                         data=tarball_data,
                     ):
-                        raise Exception("Could not write archive manifest")
+                        raise ArchiveError("Could not write archive manifest")
 
                     data_written = True
                     record.archive_size_bytes = size

--- a/anchore_engine/services/catalog/catalog_impl.py
+++ b/anchore_engine/services/catalog/catalog_impl.py
@@ -2310,6 +2310,7 @@ def _delete_image_artifacts(account_id, image_digest, image_ids, full_tags, db_s
         "image_summary_data",
         "manifest_data",
         "parent_manifest_data",
+        "syft_sbom",
     ]:
         # try-except block ensures an attempt to delete every artifact despite errors
         try:

--- a/anchore_engine/services/catalog/importer.py
+++ b/anchore_engine/services/catalog/importer.py
@@ -27,7 +27,9 @@ IMPORT_OPERATION_ANNOTATION_KEY = (
 
 class RequiredFieldError(Exception):
     def __init__(self, required_field):
-        super().__init__("Field %s is required in imports but not found", required_field)
+        super().__init__(
+            "Field %s is required in imports but not found", required_field
+        )
 
 
 class ImportTypes(enum.Enum):

--- a/anchore_engine/services/catalog/importer.py
+++ b/anchore_engine/services/catalog/importer.py
@@ -352,7 +352,7 @@ def import_image(
             account,
             operation_id,
             import_manifest,
-            final_state=ImportState.complete,
+            final_state=ImportState.processing,
         )
 
         # raise BadRequest(

--- a/anchore_engine/services/catalog/importer.py
+++ b/anchore_engine/services/catalog/importer.py
@@ -25,6 +25,11 @@ IMPORT_OPERATION_ANNOTATION_KEY = (
 )
 
 
+class RequiredFieldError(Exception):
+    def __init__(self, required_field):
+        super().__init__("Field %s is required in imports but not found", required_field)
+
+
 class ImportTypes(enum.Enum):
     """
     The types of content supported for upload
@@ -298,6 +303,10 @@ def import_image(
     # Import analysis for a new digest, or re-load analysis for existing image
     logger.debug("Loading image info using import operation id %s", operation_id)
     image_references = []
+    if not import_manifest.tags:
+        # Handle missing tags
+        raise RequiredFieldError("tags")
+
     for t in import_manifest.tags:
         r = DockerImageReference.from_string(t)
         r.digest = import_manifest.digest

--- a/tests/functional/clients/scripts/standalone.py
+++ b/tests/functional/clients/scripts/standalone.py
@@ -137,7 +137,7 @@ def analyze(registry, manifest, repo, digest, tag, work_dir, localconfig):
 
     click.echo("Starting the analyze process...")
 
-    image_report, manifest = analyze_image(
+    result = analyze_image(
         userId,
         manifest,
         image_record,
@@ -149,7 +149,7 @@ def analyze(registry, manifest, repo, digest, tag, work_dir, localconfig):
     result_python = join(work_dir, "result.py")
     with open(result_python, "w") as python_file:
         python_file.write("result = ")
-        python_file.write(pprint.pformat(image_report))
+        python_file.write(pprint.pformat(result.image_export))
     click.echo("Saved the results of the analyzer to %s" % result_python)
 
 

--- a/tests/unit/anchore_engine/analyzers/syft/test_syft.py
+++ b/tests/unit/anchore_engine/analyzers/syft/test_syft.py
@@ -3,7 +3,10 @@ import os
 
 import pytest
 
-from anchore_engine.analyzers.syft import convert_syft_to_engine, filter_artifacts
+from anchore_engine.analyzers.syft.adapters import (
+    _convert_syft_to_engine,
+    _filter_artifacts,
+)
 
 
 class TestFilterArtifacts:
@@ -41,7 +44,7 @@ class TestFilterArtifacts:
             },
         ]
 
-        actual = filter_artifacts(artifacts, relationships)
+        actual = _filter_artifacts(artifacts, relationships)
         assert actual == artifacts
 
     @pytest.mark.parametrize(
@@ -89,7 +92,7 @@ class TestFilterArtifacts:
             },
         ]
 
-        actual = filter_artifacts(artifacts, relationships)
+        actual = _filter_artifacts(artifacts, relationships)
         assert [a["name"] for a in actual] == ["parent-pkg"]
 
     def test_filter_artifact_missing_id(self):
@@ -105,7 +108,7 @@ class TestFilterArtifacts:
             },
         ]
 
-        actual = filter_artifacts(initial_artifacts, [])
+        actual = _filter_artifacts(initial_artifacts, [])
         assert actual == initial_artifacts
 
     @pytest.mark.parametrize(
@@ -127,7 +130,7 @@ class TestFilterArtifacts:
             },
         ]
 
-        actual = filter_artifacts(artifacts, [])
+        actual = _filter_artifacts(artifacts, [])
         assert [a["name"] for a in actual] == ["pkg-name"]
 
 
@@ -149,7 +152,7 @@ class TestConvertSyftToEngine:
         [False, True],
     )
     def test_filter_artifact_by_type(self, test_sbom, enable_package_filtering):
-        findings = convert_syft_to_engine(test_sbom, enable_package_filtering)
+        findings = _convert_syft_to_engine(test_sbom, enable_package_filtering)
         for pkg_list in findings["package_list"]:
             if pkg_list == "pkgfiles.all":
                 continue


### PR DESCRIPTION
Saves raw syft analysis output and makes it available from GET /images/<digest>/sboms/native.

Still needs to add analysis archive/restore logic to include this data.