### PR TITLE
Add unit test for the write_kvfile_fomdict method

### DIFF
--- a/tests/unit/anchore_engine/analyzers/test_utils.py
+++ b/tests/unit/anchore_engine/analyzers/test_utils.py
@@ -81,11 +81,19 @@ class TestDig:
         ),
         pytest.param(
             {
-                "filename": "./nonstring-key-test.json",
-                "dict": {2: ""},
+                "filename": "./nonstring-value-test.json",
+                "dict": {"two": 2},
                 "expected": TypeError(
-                    "Expected value of key 2 to be a string, found int"
+                    "Expected value of key two to be a string, found int"
                 ),
+            },
+            id="nonstring-value",
+        ),
+        pytest.param(
+            {
+                "filename": "./nonstring-key-test.json",
+                "dict": {2: "two"},
+                "expected": TypeError("expected string or bytes-like object"),
             },
             id="nonstring-key",
         ),

--- a/tests/unit/anchore_engine/analyzers/test_utils.py
+++ b/tests/unit/anchore_engine/analyzers/test_utils.py
@@ -1,6 +1,8 @@
+import os
+
 import pytest
 
-from anchore_engine.analyzers.utils import dig
+from anchore_engine.analyzers.utils import dig, write_kvfile_fromdict
 
 
 class TestDig:
@@ -55,3 +57,84 @@ class TestDig:
 
     def test_none_empty_value_with_force_default(self):
         assert dig({"a": "b!"}, "a", force_default=12) == "b!"
+
+
+# This fixture runs to include the teardown of the file that is created as part of the
+# tested method's normal execution. It also provides the parameters to the unit test below
+@pytest.fixture(
+    params=[
+        pytest.param(
+            {
+                "filename": "./basic-file-test.json",
+                "dict": {"key": "value"},
+                "expected": "key value \n",
+            },
+            id="basic-file",
+        ),
+        pytest.param(
+            {
+                "filename": "./null-value-test.json",
+                "dict": {"key": ""},
+                "expected": "key none \n",
+            },
+            id="null-value",
+        ),
+        pytest.param(
+            {
+                "filename": "./nonstring-key-test.json",
+                "dict": {2: ""},
+                "expected": TypeError(
+                    "Expected value of key 2 to be a string, found int"
+                ),
+            },
+            id="nonstring-key",
+        ),
+        pytest.param(
+            {
+                "filename": "./key-with-spaces-test.json",
+                "dict": {"space key": "value"},
+                "expected": "space____key value \n",
+            },
+            id="key-with-spaces",
+        ),
+        pytest.param(
+            {
+                "filename": "./multiple-keys-test.json",
+                "dict": {
+                    "key1": "value1",
+                    "key2": "value2",
+                },
+                "expected": "key1 value1 \nkey2 value2 \n",
+            },
+            id="multiple-keys",
+        ),
+    ]
+)
+def kvfile_fixture(request):
+    filename = request.param.get("filename", None)
+    if filename is not None:
+
+        def delete_file():
+            os.remove(filename)
+
+        request.addfinalizer(delete_file)
+    else:
+        raise Exception("can't get filename")
+
+    return request.param
+
+
+def test_write_kvfile_fromdict(kvfile_fixture):
+    param = kvfile_fixture
+    if isinstance(param["expected"], TypeError):
+        with pytest.raises(TypeError) as actualerr:
+            write_kvfile_fromdict(param["filename"], param["dict"])
+            assert actualerr == param["expected"]
+            with open(param["filename"], "r") as f:
+                actual = f.read()
+                assert actual == ""
+    else:
+        write_kvfile_fromdict(param["filename"], param["dict"])
+        with open(param["filename"], "r") as f:
+            actual = f.read()
+            assert actual == param["expected"]


### PR DESCRIPTION
Signed-off-by: Samuel Dacanay <sam.dacanay@anchore.com>

<!--
Thank you for contributing to anchore-engine! We really appreciate your time and effort to help out the community.

Before submitting this PR, we'd like to make sure you are aware of our technical requirements and PR process.

* https://github.com/anchore/anchore-engine/tree/master/CONTRIBUTING.rst

When updates to your PR are requested, please add new commits and do not squash the history. This will make it easier to
identify new changes. The PR will be squashed when we merge it to ensure a clean history. Thanks.

-->

**What this PR does / why we need it**: Adds a unit test for the write_kvfile_fromdict method


**Which issue this PR fixes** *(optional, in `fixes #<issue number>)(, fixes #<issue_number, ...)` format, will close the issue when PR is merged*: fixes #:

**Special notes**:


