### PR TITLE
add libpq-devel to Dockerfile.functional so that psycopg2 can be compiled on ARM

### DIFF
--- a/scripts/ci/Dockerfile.functional
+++ b/scripts/ci/Dockerfile.functional
@@ -5,7 +5,7 @@ USER root
 
 RUN set -ex && \
     echo "installing OS dependencies" && \
-    yum install -y gcc make git python38-wheel python38-devel python38-psycopg2
+    yum install -y gcc make git python38-wheel python38-devel python38-psycopg2 libpq-devel
 
 # Install Docker-in-Docker into the image for testing
 ENV DOCKERVERSION=18.03.1-ce


### PR DESCRIPTION
There is no precompiled binary for psycopg2-binary on ARM. When running the functional tests on an ARM machine, psycopg2 fails to compile because pg_config is not available. This PR adds libpq-devel to the Dockerfile for the job runner so that psycopg2 may be compiled from source.