### PR TITLE
Change msg to reason within the skip annotation

### DIFF
--- a/tests/unit/anchore_engine/test_simplequeue_leases.py
+++ b/tests/unit/anchore_engine/test_simplequeue_leases.py
@@ -100,7 +100,7 @@ def fail_target():
 
 
 @pytest.mark.skip(
-    msg="Disabled temporarily pending work to remove db requirement from internal client init"
+    reason="Disabled temporarily pending work to remove db requirement from internal client init"
 )
 def test_run_target_with_lease_ok():
     global SimpleQueueClient
@@ -119,7 +119,7 @@ def test_run_target_with_lease_ok():
 
 
 @pytest.mark.skip(
-    msg="Disabled temporarily pending work to remove db requirement from internal client init"
+    reason="Disabled temporarily pending work to remove db requirement from internal client init"
 )
 def test_run_target_with_lease_conn_error():
     global SimpleQueueClient


### PR DESCRIPTION
Noticed that some old unit tests were causing issues in pytest, due to the fact that the "msg" keyword was used instead of the "reason" keyword. Maybe this was a new update or something?